### PR TITLE
Add container mulled-v2-5b020019f77e9c1b4b7ae17a5ee5148afef0a19b:34b94c6c194643585af94dc12d98fc8393b99c54.

### DIFF
--- a/combinations/mulled-v2-5b020019f77e9c1b4b7ae17a5ee5148afef0a19b:34b94c6c194643585af94dc12d98fc8393b99c54-0.tsv
+++ b/combinations/mulled-v2-5b020019f77e9c1b4b7ae17a5ee5148afef0a19b:34b94c6c194643585af94dc12d98fc8393b99c54-0.tsv
@@ -1,0 +1,1 @@
+bx-python=0.7.1,ucsc-fatotwobit=324


### PR DESCRIPTION
**Hash**: mulled-v2-5b020019f77e9c1b4b7ae17a5ee5148afef0a19b:34b94c6c194643585af94dc12d98fc8393b99c54

**Packages**:
- bx-python=0.7.1
- ucsc-fatotwobit=324

**For** :
- extract_genomic_dna.xml

Generated with Planemo.