### PR TITLE
Add container mulled-v2-32d42ea3fa7a01225fa32bc2bf14c30f1a19c0c7:a363d7475c1d13b595a264cdfe404650ccdfa051.

### DIFF
--- a/combinations/mulled-v2-32d42ea3fa7a01225fa32bc2bf14c30f1a19c0c7:a363d7475c1d13b595a264cdfe404650ccdfa051-0.tsv
+++ b/combinations/mulled-v2-32d42ea3fa7a01225fa32bc2bf14c30f1a19c0c7:a363d7475c1d13b595a264cdfe404650ccdfa051-0.tsv
@@ -1,0 +1,1 @@
+blast-legacy=2.2.22,rdptools=2.0.2,qiime=1.9.1,vsearch=2.3.4,mothur=1.36.1


### PR DESCRIPTION
**Hash**: mulled-v2-32d42ea3fa7a01225fa32bc2bf14c30f1a19c0c7:a363d7475c1d13b595a264cdfe404650ccdfa051

**Packages**:
- blast-legacy=2.2.22
- rdptools=2.0.2
- qiime=1.9.1
- vsearch=2.3.4
- mothur=1.36.1

**For** :
- assign_taxonomy.xml

Generated with Planemo.