### PR TITLE
Add container mulled-v2-b3c6e81ffe4214facad8cac2879964324c7c4bc8:97b85be4266f8a67b2121310dd1e5055bb86e7bc.

### DIFF
--- a/combinations/mulled-v2-b3c6e81ffe4214facad8cac2879964324c7c4bc8:97b85be4266f8a67b2121310dd1e5055bb86e7bc-0.tsv
+++ b/combinations/mulled-v2-b3c6e81ffe4214facad8cac2879964324c7c4bc8:97b85be4266f8a67b2121310dd1e5055bb86e7bc-0.tsv
@@ -1,0 +1,1 @@
+bx-python=0.7.1,galaxy-ops=1.0.0


### PR DESCRIPTION
**Hash**: mulled-v2-b3c6e81ffe4214facad8cac2879964324c7c4bc8:97b85be4266f8a67b2121310dd1e5055bb86e7bc

**Packages**:
- bx-python=0.7.1
- galaxy-ops=1.0.0

**For** :
- basecoverage.xml
- cluster.xml
- complement.xml
- concat.xml
- coverage.xml
- flanking_features.xml
- get_flanks.xml
- intersect.xml
- join.xml
- merge.xml
- subtract.xml
- subtract_query.xml
- featureCounter.xml
- getIndelRates_3way.xml
- microsats_mutability.xml
- WeightedAverage.xml

Generated with Planemo.