### PR TITLE
Add container mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:2816033349d03791ccc70efb334ec5d827d81387.

### DIFF
--- a/combinations/mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:2816033349d03791ccc70efb334ec5d827d81387-0.tsv
+++ b/combinations/mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:2816033349d03791ccc70efb334ec5d827d81387-0.tsv
@@ -1,0 +1,1 @@
+bx-python=0.7.1,ucsc-fatotwobit=324,six=1.10.0


### PR DESCRIPTION
**Hash**: mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:2816033349d03791ccc70efb334ec5d827d81387

**Packages**:
- bx-python=0.7.1
- ucsc-fatotwobit=324
- six=1.10.0

**For** :
- extract_genomic_dna.xml

Generated with Planemo.