### PR TITLE
Add container mulled-v2-f28912445c51f6e1f3a8395b01424fb1a080370e:373e36f12b9ecc5ff0c4a9d4965c841ccff6b3cc.

### DIFF
--- a/combinations/mulled-v2-f28912445c51f6e1f3a8395b01424fb1a080370e:373e36f12b9ecc5ff0c4a9d4965c841ccff6b3cc-0.tsv
+++ b/combinations/mulled-v2-f28912445c51f6e1f3a8395b01424fb1a080370e:373e36f12b9ecc5ff0c4a9d4965c841ccff6b3cc-0.tsv
@@ -1,0 +1,1 @@
+trinity=2.4.0,bioconductor-goseq=1.26.0,r-cluster=2.0.6,bioconductor-qvalue=2.6.0


### PR DESCRIPTION
**Hash**: mulled-v2-f28912445c51f6e1f3a8395b01424fb1a080370e:373e36f12b9ecc5ff0c4a9d4965c841ccff6b3cc

**Packages**:
- trinity=2.4.0
- bioconductor-goseq=1.26.0
- r-cluster=2.0.6
- bioconductor-qvalue=2.6.0

**For** :
- analyze_diff_expr.xml

Generated with Planemo.