### PR TITLE
Add container mulled-v2-4ed2a48ecb146207be6706b6271bb1185442bdf2:d5403de2dbc7aad222b90c495a29277bdd30573a.

### DIFF
--- a/combinations/mulled-v2-4ed2a48ecb146207be6706b6271bb1185442bdf2:d5403de2dbc7aad222b90c495a29277bdd30573a-0.tsv
+++ b/combinations/mulled-v2-4ed2a48ecb146207be6706b6271bb1185442bdf2:d5403de2dbc7aad222b90c495a29277bdd30573a-0.tsv
@@ -1,0 +1,1 @@
+r-ggrepel=0.6.5,r-pheatmap=1.0.8,bioconductor-deseq2=1.18.1,bioconductor-tximport=1.6.0


### PR DESCRIPTION
**Hash**: mulled-v2-4ed2a48ecb146207be6706b6271bb1185442bdf2:d5403de2dbc7aad222b90c495a29277bdd30573a

**Packages**:
- r-ggrepel=0.6.5
- r-pheatmap=1.0.8
- bioconductor-deseq2=1.18.1
- bioconductor-tximport=1.6.0

**For** :
- deseq2.xml

Generated with Planemo.