### PR TITLE
Add container mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:4e714fc911c0f4e1e039ea52bfb134024d1d0ada.

### DIFF
--- a/combinations/mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:4e714fc911c0f4e1e039ea52bfb134024d1d0ada-0.tsv
+++ b/combinations/mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:4e714fc911c0f4e1e039ea52bfb134024d1d0ada-0.tsv
@@ -1,0 +1,1 @@
+r-scales=0.5.0,r-statmod=1.4.30,r-getopt=1.20.0,bioconductor-limma=3.34.6,bioconductor-edger=3.20.7,r-rjson=0.2.15


### PR DESCRIPTION
**Hash**: mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:4e714fc911c0f4e1e039ea52bfb134024d1d0ada

**Packages**:
- r-scales=0.5.0
- r-statmod=1.4.30
- r-getopt=1.20.0
- bioconductor-limma=3.34.6
- bioconductor-edger=3.20.7
- r-rjson=0.2.15

**For** :
- limma_voom.xml

Generated with Planemo.