### PR TITLE
Add container mulled-v2-4011f1376338ab5fb1cf9b54c7b0a36417e291cc:30bf64273ecf52281013f3c37195c473b3ca72e9.

### DIFF
--- a/combinations/mulled-v2-4011f1376338ab5fb1cf9b54c7b0a36417e291cc:30bf64273ecf52281013f3c37195c473b3ca72e9-0.tsv
+++ b/combinations/mulled-v2-4011f1376338ab5fb1cf9b54c7b0a36417e291cc:30bf64273ecf52281013f3c37195c473b3ca72e9-0.tsv
@@ -1,0 +1,1 @@
+r-ggrepel=0.6.5,r-pheatmap=1.0.8,bioconductor-deseq2=1.18.1,bioconductor-tximport=1.6.0,bioconductor-genomicfeatures=1.30.0


### PR DESCRIPTION
**Hash**: mulled-v2-4011f1376338ab5fb1cf9b54c7b0a36417e291cc:30bf64273ecf52281013f3c37195c473b3ca72e9

**Packages**:
- r-ggrepel=0.6.5
- r-pheatmap=1.0.8
- bioconductor-deseq2=1.18.1
- bioconductor-tximport=1.6.0
- bioconductor-genomicfeatures=1.30.0

**For** :
- deseq2.xml

Generated with Planemo.