### PR TITLE
Add container mulled-v2-a5b4225e3a5b97de91a1f81d26da641b16ef55fa:df419aea7a137d1e4594dc5f6f466c5b9947409a.

### DIFF
--- a/combinations/mulled-v2-a5b4225e3a5b97de91a1f81d26da641b16ef55fa:df419aea7a137d1e4594dc5f6f466c5b9947409a-0.tsv
+++ b/combinations/mulled-v2-a5b4225e3a5b97de91a1f81d26da641b16ef55fa:df419aea7a137d1e4594dc5f6f466c5b9947409a-0.tsv
@@ -1,0 +1,1 @@
+r-rjson=0.2.15,bioconductor-diffbind=2.6.6,r-getopt=1.20.0


### PR DESCRIPTION
**Hash**: mulled-v2-a5b4225e3a5b97de91a1f81d26da641b16ef55fa:df419aea7a137d1e4594dc5f6f466c5b9947409a

**Packages**:
- r-rjson=0.2.15
- bioconductor-diffbind=2.6.6
- r-getopt=1.20.0

**For** :
- diffbind.xml

Generated with Planemo.