### PR TITLE
Add container mulled-v2-f87af2e0a8dc82bed85233a219768fcd16ef3e42:68c4d4631c652af7715ff33bf0221b2f57442465.

### DIFF
--- a/combinations/mulled-v2-f87af2e0a8dc82bed85233a219768fcd16ef3e42:68c4d4631c652af7715ff33bf0221b2f57442465-0.tsv
+++ b/combinations/mulled-v2-f87af2e0a8dc82bed85233a219768fcd16ef3e42:68c4d4631c652af7715ff33bf0221b2f57442465-0.tsv
@@ -1,0 +1,1 @@
+r-scales=0.5.0,bioconductor-limma=3.34.9,r-statmod=1.4.30,r-getopt=1.20.0,r-gplots=3.0.1,bioconductor-edger=3.20.7,r-rjson=0.2.15


### PR DESCRIPTION
**Hash**: mulled-v2-f87af2e0a8dc82bed85233a219768fcd16ef3e42:68c4d4631c652af7715ff33bf0221b2f57442465

**Packages**:
- r-scales=0.5.0
- bioconductor-limma=3.34.9
- r-statmod=1.4.30
- r-getopt=1.20.0
- r-gplots=3.0.1
- bioconductor-edger=3.20.7
- r-rjson=0.2.15

**For** :
- limma_voom.xml

Generated with Planemo.