### PR TITLE
Add container mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:d65f7d4c7173fc0746c50d044d0c337a0b60ef3f.

### DIFF
--- a/combinations/mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:d65f7d4c7173fc0746c50d044d0c337a0b60ef3f-0.tsv
+++ b/combinations/mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:d65f7d4c7173fc0746c50d044d0c337a0b60ef3f-0.tsv
@@ -1,0 +1,1 @@
+trinity=2.6.6,bioconductor-limma=3.34.9,bioconductor-deseq2=1.18.1,bioconductor-edger=3.20.7


### PR DESCRIPTION
**Hash**: mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:d65f7d4c7173fc0746c50d044d0c337a0b60ef3f

**Packages**:
- trinity=2.6.6
- bioconductor-limma=3.34.9
- bioconductor-deseq2=1.18.1
- bioconductor-edger=3.20.7

**For** :
- run_de_analysis.xml

Generated with Planemo.