### PR TITLE
Add container mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:d45df516bea2d8b3a6bd546576a550cc0dd6ab80.

### DIFF
--- a/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:d45df516bea2d8b3a6bd546576a550cc0dd6ab80-0.tsv
+++ b/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:d45df516bea2d8b3a6bd546576a550cc0dd6ab80-0.tsv
@@ -1,0 +1,1 @@
+trinity=2.6.6,bioconductor-qvalue=2.10.0,bioconductor-goseq=1.30.0,r-fastcluster=1.1.24,r-cluster=2.0.6


### PR DESCRIPTION
**Hash**: mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:d45df516bea2d8b3a6bd546576a550cc0dd6ab80

**Packages**:
- trinity=2.6.6
- bioconductor-qvalue=2.10.0
- bioconductor-goseq=1.30.0
- r-fastcluster=1.1.24
- r-cluster=2.0.6

**For** :
- analyze_diff_expr.xml

Generated with Planemo.