### PR TITLE
Add container mulled-v2-bc19ab06ed8076bdc128104014a8b93265bc0059:42392056c2ef4b84e30436c14317f7b334aa5095.

### DIFF
--- a/combinations/mulled-v2-bc19ab06ed8076bdc128104014a8b93265bc0059:42392056c2ef4b84e30436c14317f7b334aa5095-0.tsv
+++ b/combinations/mulled-v2-bc19ab06ed8076bdc128104014a8b93265bc0059:42392056c2ef4b84e30436c14317f7b334aa5095-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-scpipe=1.0.0,r-knitr=1.20,r-readr=1.1.1,r-optparse=1.6.0,bioconductor-scater=1.6.0,r-dt=0.4,bioconductor-scran=1.6.2,r-rtsne=0.13,r-ggplot2=2.2.1,r-plotly=4.7.1,bioconductor-rsubread=1.28.1,r-rmarkdown=1.10


### PR DESCRIPTION
**Hash**: mulled-v2-bc19ab06ed8076bdc128104014a8b93265bc0059:42392056c2ef4b84e30436c14317f7b334aa5095

**Packages**:
- bioconductor-scpipe=1.0.0
- r-knitr=1.20
- r-readr=1.1.1
- r-optparse=1.6.0
- bioconductor-scater=1.6.0
- r-dt=0.4
- bioconductor-scran=1.6.2
- r-rtsne=0.13
- r-ggplot2=2.2.1
- r-plotly=4.7.1
- bioconductor-rsubread=1.28.1
- r-rmarkdown=1.10

**For** :
- scpipe.xml

Generated with Planemo.