### PR TITLE
Add container mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:3fe65af0054e6df849b3c9b62d47caa405e7993a.

### DIFF
--- a/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:3fe65af0054e6df849b3c9b62d47caa405e7993a-0.tsv
+++ b/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:3fe65af0054e6df849b3c9b62d47caa405e7993a-0.tsv
@@ -1,0 +1,1 @@
+r-fastcluster=1.1.24,trinity=2.8.3,bioconductor-qvalue=2.10.0,bioconductor-goseq=1.30.0,r-cluster=2.0.6


### PR DESCRIPTION
**Hash**: mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:3fe65af0054e6df849b3c9b62d47caa405e7993a

**Packages**:
- r-fastcluster=1.1.24
- trinity=2.8.3
- bioconductor-qvalue=2.10.0
- bioconductor-goseq=1.30.0
- r-cluster=2.0.6

**For** :
- analyze_diff_expr.xml

Generated with Planemo.