### PR TITLE
Add container mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:d913a46447e18700c852c976af33c0d5e50aecc0.

### DIFF
--- a/combinations/mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:d913a46447e18700c852c976af33c0d5e50aecc0-0.tsv
+++ b/combinations/mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:d913a46447e18700c852c976af33c0d5e50aecc0-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-biobase=2.38.0,r-fastcluster=1.1.24,trinity=2.8.3,bioconductor-qvalue=2.10.0,r-cluster=2.0.6


### PR DESCRIPTION
**Hash**: mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:d913a46447e18700c852c976af33c0d5e50aecc0

**Packages**:
- bioconductor-biobase=2.38.0
- r-fastcluster=1.1.24
- trinity=2.8.3
- bioconductor-qvalue=2.10.0
- r-cluster=2.0.6

**For** :
- samples_qccheck.xml

Generated with Planemo.