### PR TITLE
Add container mulled-v2-3a7e726cb919cb51dada45df506fad0c05d7ace6:8933ab62fb5642b2ecd9fe5c34fd32aca17d238e.

### DIFF
--- a/combinations/mulled-v2-3a7e726cb919cb51dada45df506fad0c05d7ace6:8933ab62fb5642b2ecd9fe5c34fd32aca17d238e-0.tsv
+++ b/combinations/mulled-v2-3a7e726cb919cb51dada45df506fad0c05d7ace6:8933ab62fb5642b2ecd9fe5c34fd32aca17d238e-0.tsv
@@ -1,0 +1,1 @@
+r-maldiquant=1.18,bioconductor-cardinal=1.10.0,r-ggplot2=2.2.1,r-gridextra=2.2.1,r-maldiquantforeign=0.11.5


### PR DESCRIPTION
**Hash**: mulled-v2-3a7e726cb919cb51dada45df506fad0c05d7ace6:8933ab62fb5642b2ecd9fe5c34fd32aca17d238e

**Packages**:
- r-maldiquant=1.18
- bioconductor-cardinal=1.10.0
- r-ggplot2=2.2.1
- r-gridextra=2.2.1
- r-maldiquantforeign=0.11.5

**For** :
- maldi_quant_peakdetection.xml
- maldi_quant_preprocessing.xml

Generated with Planemo.