### PR TITLE
Add container mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:39c99076e1ccf8b2a70f94675f6d71c008adac39.

### DIFF
--- a/combinations/mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:39c99076e1ccf8b2a70f94675f6d71c008adac39-0.tsv
+++ b/combinations/mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:39c99076e1ccf8b2a70f94675f6d71c008adac39-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-limma=3.34.9,bioconductor-deseq2=1.18.1,trinity=2.8.4,bioconductor-edger=3.20.7


### PR DESCRIPTION
**Hash**: mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:39c99076e1ccf8b2a70f94675f6d71c008adac39

**Packages**:
- bioconductor-limma=3.34.9
- bioconductor-deseq2=1.18.1
- trinity=2.8.4
- bioconductor-edger=3.20.7

**For** :
- run_de_analysis.xml

Generated with Planemo.