### PR TITLE
Add container mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0b153b59683bcb0d035f045cada113020637164e.

### DIFF
--- a/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0b153b59683bcb0d035f045cada113020637164e-0.tsv
+++ b/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0b153b59683bcb0d035f045cada113020637164e-0.tsv
@@ -1,0 +1,1 @@
+r-fastcluster=1.1.24,r-cluster=2.0.6,bioconductor-qvalue=2.10.0,trinity=2.8.4,bioconductor-goseq=1.30.0


### PR DESCRIPTION
**Hash**: mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0b153b59683bcb0d035f045cada113020637164e

**Packages**:
- r-fastcluster=1.1.24
- r-cluster=2.0.6
- bioconductor-qvalue=2.10.0
- trinity=2.8.4
- bioconductor-goseq=1.30.0

**For** :
- analyze_diff_expr.xml

Generated with Planemo.