### PR TITLE
Add container mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:97a0c63266475f738e0ea69be4d7f4a04b90d905.

### DIFF
--- a/combinations/mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:97a0c63266475f738e0ea69be4d7f4a04b90d905-0.tsv
+++ b/combinations/mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:97a0c63266475f738e0ea69be4d7f4a04b90d905-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-edger=3.16.5,bioconductor-limma=3.30.13,r-rjson=0.2.15,r-getopt=1.20.0


### PR DESCRIPTION
**Hash**: mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:97a0c63266475f738e0ea69be4d7f4a04b90d905

**Packages**:
- bioconductor-edger=3.16.5
- bioconductor-limma=3.30.13
- r-rjson=0.2.15
- r-getopt=1.20.0

**For** :
- edger-repenrich.xml

Generated with Planemo.