### PR TITLE
Add container mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:12095fd98a4a484373526153625fedc8fef1dffa.

### DIFF
--- a/combinations/mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:12095fd98a4a484373526153625fedc8fef1dffa-0.tsv
+++ b/combinations/mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:12095fd98a4a484373526153625fedc8fef1dffa-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-org.mm.eg.db=3.6.0,bioconductor-goseq=1.32.0,r-dplyr=0.7.8,bioconductor-org.hs.eg.db=3.6.0,bioconductor-org.dm.eg.db=3.6.0,bioconductor-org.dr.eg.db=3.6.0,r-ggplot2=3.1.0,r-optparse=1.6.0


### PR DESCRIPTION
**Hash**: mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:12095fd98a4a484373526153625fedc8fef1dffa

**Packages**:
- bioconductor-org.mm.eg.db=3.6.0
- bioconductor-goseq=1.32.0
- r-dplyr=0.7.8
- bioconductor-org.hs.eg.db=3.6.0
- bioconductor-org.dm.eg.db=3.6.0
- bioconductor-org.dr.eg.db=3.6.0
- r-ggplot2=3.1.0
- r-optparse=1.6.0

**For** :
- goseq.xml

Generated with Planemo.