### PR TITLE
Add container mulled-v2-92052faeecbe5f953eef16041758cd97c3c8f117:9b1f27a4809261eafb0723adbbcc7ddf21bc05de.

### DIFF
--- a/combinations/mulled-v2-92052faeecbe5f953eef16041758cd97c3c8f117:9b1f27a4809261eafb0723adbbcc7ddf21bc05de-0.tsv
+++ b/combinations/mulled-v2-92052faeecbe5f953eef16041758cd97c3c8f117:9b1f27a4809261eafb0723adbbcc7ddf21bc05de-0.tsv
@@ -1,0 +1,1 @@
+rnaz=2.1,pybedtools=0.8.0,python=3.6.7


### PR DESCRIPTION
**Hash**: mulled-v2-92052faeecbe5f953eef16041758cd97c3c8f117:9b1f27a4809261eafb0723adbbcc7ddf21bc05de

**Packages**:
- rnaz=2.1
- pybedtools=0.8.0
- python=3.6.7

**For** :
- rnazAnnotate.xml

Generated with Planemo.