### PR TITLE
Add container mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:1b1dcd442bbdaa9e1d74335af12cfaac3f2d0565.

### DIFF
--- a/combinations/mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:1b1dcd442bbdaa9e1d74335af12cfaac3f2d0565-0.tsv
+++ b/combinations/mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:1b1dcd442bbdaa9e1d74335af12cfaac3f2d0565-0.tsv
@@ -1,0 +1,1 @@
+r-getopt=1.20.2,r-pheatmap=1.0.10,r-ggrepel=0.8.0,bioconductor-rhdf5=2.26.2,bioconductor-genomicfeatures=1.34.1,r-rjson=0.2.20,r-gplots=3.0.1,bioconductor-deseq2=1.22.1,bioconductor-tximport=1.10.0


### PR DESCRIPTION
**Hash**: mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:1b1dcd442bbdaa9e1d74335af12cfaac3f2d0565

**Packages**:
- r-getopt=1.20.2
- r-pheatmap=1.0.10
- r-ggrepel=0.8.0
- bioconductor-rhdf5=2.26.2
- bioconductor-genomicfeatures=1.34.1
- r-rjson=0.2.20
- r-gplots=3.0.1
- bioconductor-deseq2=1.22.1
- bioconductor-tximport=1.10.0

**For** :
- deseq2.xml

Generated with Planemo.