### PR TITLE
add bwa + picard package container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -14,3 +14,4 @@ anndata=0.6.13,loompy=2.0.16,r-seurat=2.3.4,qt=5.6.2
 astropy=3.0.5--py37h7b6447c_1
 flashlfq=0.1.111--0
 moods=1.9.0,pybigwig=0.3.4,pysam=0.9.1.4
+bwa=0.7.17,picard=2.18.7


### PR DESCRIPTION
Adding a container with BWA and picard, allowing for `picard SortSam` to be used instead of `samtools sort`.