### PR TITLE
Add container mulled-v2-a315650eb862d7aa6dc5f664de66ffd547262f86:2975b7743a211bfe51b76272ac55364ac12ca237.

### DIFF
--- a/combinations/mulled-v2-a315650eb862d7aa6dc5f664de66ffd547262f86:2975b7743a211bfe51b76272ac55364ac12ca237-0.tsv
+++ b/combinations/mulled-v2-a315650eb862d7aa6dc5f664de66ffd547262f86:2975b7743a211bfe51b76272ac55364ac12ca237-0.tsv
@@ -1,0 +1,1 @@
+r-testthat=2.0.1,bioconductor-variantannotation=1.28.3,r-rmysql=0.10.13,r-sqldf=0.4_11,r-plyr=1.8.4,r-devtools=2.0.1,r-getoptlong=0.1.7,bioconductor-rgalaxy=1.26.0,r-data.table=1.12.0


### PR DESCRIPTION
**Hash**: mulled-v2-a315650eb862d7aa6dc5f664de66ffd547262f86:2975b7743a211bfe51b76272ac55364ac12ca237

**Packages**:
- r-testthat=2.0.1
- bioconductor-variantannotation=1.28.3
- r-rmysql=0.10.13
- r-sqldf=0.4_11
- r-plyr=1.8.4
- r-devtools=2.0.1
- r-getoptlong=0.1.7
- bioconductor-rgalaxy=1.26.0
- r-data.table=1.12.0

**For** :
- customProDB.xml

Generated with Planemo.