### PR TITLE
Add container mulled-v2-8be7b137ff946d950197b9d071d09a3f2d52fc21:78ed75d569960e38c54977044e0f8bbb4bace2e5.

### DIFF
--- a/combinations/mulled-v2-8be7b137ff946d950197b9d071d09a3f2d52fc21:78ed75d569960e38c54977044e0f8bbb4bace2e5-0.tsv
+++ b/combinations/mulled-v2-8be7b137ff946d950197b9d071d09a3f2d52fc21:78ed75d569960e38c54977044e0f8bbb4bace2e5-0.tsv
@@ -1,0 +1,1 @@
+r-optparse=1.6.1,bioconductor-chipseeker=1.18.0


### PR DESCRIPTION
**Hash**: mulled-v2-8be7b137ff946d950197b9d071d09a3f2d52fc21:78ed75d569960e38c54977044e0f8bbb4bace2e5

**Packages**:
- r-optparse=1.6.1
- bioconductor-chipseeker=1.18.0

**For** :
- chipseeker.xml

Generated with Planemo.