### PR TITLE
Add container mulled-v2-d0d87da6dbf3ca570d193a1a10d5b93e811a7223:26a15a0a1160cf8db54b411483fe4785c3dadb4c.

### DIFF
--- a/combinations/mulled-v2-d0d87da6dbf3ca570d193a1a10d5b93e811a7223:26a15a0a1160cf8db54b411483fe4785c3dadb4c-0.tsv
+++ b/combinations/mulled-v2-d0d87da6dbf3ca570d193a1a10d5b93e811a7223:26a15a0a1160cf8db54b411483fe4785c3dadb4c-0.tsv
@@ -1,0 +1,1 @@
+bcbiogff=0.6.4,biopython=1.72,jbrowse=1.16.4,pyyaml=3.13,tabix=0.2.6,samtools=1.9,python=2.7


### PR DESCRIPTION
**Hash**: mulled-v2-d0d87da6dbf3ca570d193a1a10d5b93e811a7223:26a15a0a1160cf8db54b411483fe4785c3dadb4c

**Packages**:
- bcbiogff=0.6.4
- biopython=1.72
- jbrowse=1.16.4
- pyyaml=3.13
- tabix=0.2.6
- samtools=1.9
- python=2.7

**For** :
- jbrowse-fromdir.xml
- jbrowse.xml

Generated with Planemo.