### PR TITLE
Add container mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:81c44a178625c9673c4666d63e829a94c52781e1.

### DIFF
--- a/combinations/mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:81c44a178625c9673c4666d63e829a94c52781e1-0.tsv
+++ b/combinations/mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:81c44a178625c9673c4666d63e829a94c52781e1-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-scater=1.10.1,r-optparse=1.6.2,r-workflowscriptscommon=0.0.4,bioconductor-loomexperiment=1.0.4


### PR DESCRIPTION
**Hash**: mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:81c44a178625c9673c4666d63e829a94c52781e1

**Packages**:
- bioconductor-scater=1.10.1
- r-optparse=1.6.2
- r-workflowscriptscommon=0.0.4
- bioconductor-loomexperiment=1.0.4

**For** :
- scater-plot-pca.xml
- scater-normalize.xml
- scater-create-qcmetric-ready-sce.xml

Generated with Planemo.