### PR TITLE
Add container mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:8afe60c10a5a7ca149a56d8e32a78be383d8bf03.

### DIFF
--- a/combinations/mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:8afe60c10a5a7ca149a56d8e32a78be383d8bf03-0.tsv
+++ b/combinations/mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:8afe60c10a5a7ca149a56d8e32a78be383d8bf03-0.tsv
@@ -1,0 +1,1 @@
+scikit-image=0.14.2,scipy=1.1.0,tifffile=0.15.1,numpy=1.15.4


### PR DESCRIPTION
**Hash**: mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:8afe60c10a5a7ca149a56d8e32a78be383d8bf03

**Packages**:
- scikit-image=0.14.2
- scipy=1.1.0
- tifffile=0.15.1
- numpy=1.15.4

**For** :
- slice_image.xml

Generated with Planemo.