### PR TITLE
Add container mulled-v2-2d6a8bb0bfeac0a9e442db13185b0e575d84f541:0f72ef407bfcbff72e3e7f638dfd5d668eb99896.

### DIFF
--- a/combinations/mulled-v2-2d6a8bb0bfeac0a9e442db13185b0e575d84f541:0f72ef407bfcbff72e3e7f638dfd5d668eb99896-0.tsv
+++ b/combinations/mulled-v2-2d6a8bb0bfeac0a9e442db13185b0e575d84f541:0f72ef407bfcbff72e3e7f638dfd5d668eb99896-0.tsv
@@ -1,0 +1,1 @@
+scikit-image=0.14.2,pillow=5.3.0,scipy=1.2.1,tifffile=0.15.1,numpy=1.15.4


### PR DESCRIPTION
**Hash**: mulled-v2-2d6a8bb0bfeac0a9e442db13185b0e575d84f541:0f72ef407bfcbff72e3e7f638dfd5d668eb99896

**Packages**:
- scikit-image=0.14.2
- pillow=5.3.0
- scipy=1.2.1
- tifffile=0.15.1
- numpy=1.15.4

**For** :
- 2d_split_binaryimage_by_watershed.xml

Generated with Planemo.