### PR TITLE
Add container mulled-v2-ec2fcf32a1a603de5711bab395757c60c7e8ffa9:29c39025140abde706c8973d96eed6843ee1879c.

### DIFF
--- a/combinations/mulled-v2-ec2fcf32a1a603de5711bab395757c60c7e8ffa9:29c39025140abde706c8973d96eed6843ee1879c-0.tsv
+++ b/combinations/mulled-v2-ec2fcf32a1a603de5711bab395757c60c7e8ffa9:29c39025140abde706c8973d96eed6843ee1879c-0.tsv
@@ -1,0 +1,1 @@
+ghostscript=9.10,mummer=3.23,gnuplot=5.2.7


### PR DESCRIPTION
**Hash**: mulled-v2-ec2fcf32a1a603de5711bab395757c60c7e8ffa9:29c39025140abde706c8973d96eed6843ee1879c

**Packages**:
- ghostscript=9.10
- mummer=3.23
- gnuplot=5.2.7

**For** :
- mummer.xml

Generated with Planemo.