### PR TITLE
Add container mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:efb302fcdf5ee583cb6aa4992d908e6dd1f1d165.

### DIFF
--- a/combinations/mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:efb302fcdf5ee583cb6aa4992d908e6dd1f1d165-0.tsv
+++ b/combinations/mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:efb302fcdf5ee583cb6aa4992d908e6dd1f1d165-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-org.mm.eg.db=3.8.2,r-optparse=1.6.2,bioconductor-org.dm.eg.db=3.8.2,r-dplyr=0.8.3,bioconductor-goseq=1.36.0,bioconductor-org.dr.eg.db=3.8.2,r-ggplot2=3.2.1,bioconductor-org.hs.eg.db=3.8.2


### PR DESCRIPTION
**Hash**: mulled-v2-57df51bcc40b3d753b407e3824408f26d6af6674:efb302fcdf5ee583cb6aa4992d908e6dd1f1d165

**Packages**:
- bioconductor-org.mm.eg.db=3.8.2
- r-optparse=1.6.2
- bioconductor-org.dm.eg.db=3.8.2
- r-dplyr=0.8.3
- bioconductor-goseq=1.36.0
- bioconductor-org.dr.eg.db=3.8.2
- r-ggplot2=3.2.1
- bioconductor-org.hs.eg.db=3.8.2

**For** :
- goseq.xml

Generated with Planemo.