### PR TITLE
Add container mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:b17687ed70f1bbb8e2a9de3cf8ae5b17946e1003.

### DIFF
--- a/combinations/mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:b17687ed70f1bbb8e2a9de3cf8ae5b17946e1003-0.tsv
+++ b/combinations/mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:b17687ed70f1bbb8e2a9de3cf8ae5b17946e1003-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-qvalue=2.10.0,r-cluster=2.0.6,r-fastcluster=1.1.24,bioconductor-biobase=2.38.0,trinity=2.8.5


### PR DESCRIPTION
**Hash**: mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:b17687ed70f1bbb8e2a9de3cf8ae5b17946e1003

**Packages**:
- bioconductor-qvalue=2.10.0
- r-cluster=2.0.6
- r-fastcluster=1.1.24
- bioconductor-biobase=2.38.0
- trinity=2.8.5

**For** :
- samples_qccheck.xml

Generated with Planemo.