### PR TITLE
Add container mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:29caa544bca952d35af73626d2f14b710e99196e.

### DIFF
--- a/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:29caa544bca952d35af73626d2f14b710e99196e-0.tsv
+++ b/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:29caa544bca952d35af73626d2f14b710e99196e-0.tsv
@@ -1,0 +1,1 @@
+bioconductor-goseq=1.36.0,r-fastcluster=1.1.25,bioconductor-qvalue=2.18.0,r-cluster=2.0.8,trinity=2.8.5


### PR DESCRIPTION
**Hash**: mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:29caa544bca952d35af73626d2f14b710e99196e

**Packages**:
- bioconductor-goseq=1.36.0
- r-fastcluster=1.1.25
- bioconductor-qvalue=2.18.0
- r-cluster=2.0.8
- trinity=2.8.5

**For** :
- analyze_diff_expr.xml

Generated with Planemo.