### PR TITLE
Add container mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:36f3c07772292028637518619d7296a2769804ae.

### DIFF
--- a/combinations/mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:36f3c07772292028637518619d7296a2769804ae-0.tsv
+++ b/combinations/mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:36f3c07772292028637518619d7296a2769804ae-0.tsv
@@ -1,0 +1,1 @@
+ucsc-fatotwobit=377,bx-python=0.7.1,six=1.13.0


### PR DESCRIPTION
**Hash**: mulled-v2-08aaf543a7ecdb31eb11104b02e0fa8eee501d70:36f3c07772292028637518619d7296a2769804ae

**Packages**:
- ucsc-fatotwobit=377
- bx-python=0.7.1
- six=1.13.0

**For** :
- extract_genomic_dna.xml

Generated with Planemo.