### PR TITLE
Rebuild glimmer_biopython container

### DIFF
--- a/combinations/mulled-v2-59222ced4dacf17ea7c0eff361be3f60a3d80015:fb098c7df20a09accc515635d10263db4f92c421-1.tsv
+++ b/combinations/mulled-v2-59222ced4dacf17ea7c0eff361be3f60a3d80015:fb098c7df20a09accc515635d10263db4f92c421-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+glimmer=3.02,biopython=1.70	bgruening/busybox-bash:0.1	1


### PR DESCRIPTION
Previous container failed with
```
window-acgt: error while loading shared libraries: libstdc++.so.6:
cannot open shared object file: No such file or directory
```
But that got fixed in glimmer 3.02-3