### PR TITLE
Rebuild bioconductor-scran=1.10.1,r-raceid=0.1.3 with extended-base

### DIFF
--- a/combinations/mulled-v2-ea4f5d4e734403fd876c56467cab8b1011d95d75:d531b53fe65484e335601875c966b614f8aecac5-1.tsv
+++ b/combinations/mulled-v2-ea4f5d4e734403fd876c56467cab8b1011d95d75:d531b53fe65484e335601875c966b614f8aecac5-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-scran=1.10.1,r-raceid=0.1.3	bioconda/extended-base-image:latest	1


### PR DESCRIPTION
Needed for https://github.com/galaxyproject/tools-iuc/pull/2825