### PR TITLE
Add pinned transit version

### DIFF
--- a/combinations/mulled-v2-98e94080f7dfc7de31b799237ba9a50efe3d7fd8:b1fdad9795a35d257e267de57ccfb6e18d8da4f5-0.tsv
+++ b/combinations/mulled-v2-98e94080f7dfc7de31b799237ba9a50efe3d7fd8:b1fdad9795a35d257e267de57ccfb6e18d8da4f5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+transit=3.0.2=py_1,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
Again. This time it should be built with the correct image name.
(Fixed in https://github.com/galaxyproject/galaxy/pull/9268)