### PR TITLE
Add container mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:891ed9df33e4865505211c28ca3481014f23da76. **Hash**: mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:891ed9df33e4865505211c28ca3481014f23da76

### DIFF
--- a/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:891ed9df33e4865505211c28ca3481014f23da76-0.tsv
+++ b/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:891ed9df33e4865505211c28ca3481014f23da76-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+findutils=4.6.0,tabix=0.2.6,python=2.7,pyyaml=3.13,bcbiogff=0.6.4,samtools=1.9,biopython=1.72,jbrowse=1.16.5	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Packages**:
- findutils=4.6.0
- tabix=0.2.6
- python=2.7
- pyyaml=3.13
- bcbiogff=0.6.4
- samtools=1.9
- biopython=1.72
- jbrowse=1.16.5
Base Image:bgruening/busybox-bash:0.1

**For** :
- jbrowse.xml

Generated with Planemo.