### PR TITLE
Add container mulled-v2-889f21b67a8967c3b4e99b056e8c8e547c38757c:ace55b75f57ea05df040bc0e78acb94a0130ddb7.

### DIFF
--- a/combinations/mulled-v2-889f21b67a8967c3b4e99b056e8c8e547c38757c:ace55b75f57ea05df040bc0e78acb94a0130ddb7-0.tsv
+++ b/combinations/mulled-v2-889f21b67a8967c3b4e99b056e8c8e547c38757c:ace55b75f57ea05df040bc0e78acb94a0130ddb7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bedtools=2.24,metilene=0.2.6,r-base=3.5.1,coreutils=8.25	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-889f21b67a8967c3b4e99b056e8c8e547c38757c:ace55b75f57ea05df040bc0e78acb94a0130ddb7

**Packages**:
- bedtools=2.24
- metilene=0.2.6
- r-base=3.5.1
- coreutils=8.25
Base Image:bgruening/busybox-bash:0.1

**For** :
- metilene.xml

Generated with Planemo.