### PR TITLE
Add container mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:ee6d24681c5a4f51845a26e8211314ec8e46c3bc.

### DIFF
--- a/combinations/mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:ee6d24681c5a4f51845a26e8211314ec8e46c3bc-0.tsv
+++ b/combinations/mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:ee6d24681c5a4f51845a26e8211314ec8e46c3bc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rdkit=2019.03.2.0,scipy=1.3.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:ee6d24681c5a4f51845a26e8211314ec8e46c3bc

**Packages**:
- rdkit=2019.03.2.0
- scipy=1.3.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- sucos_cluster.xml

Generated with Planemo.