### PR TITLE
Add container mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:bafcc2acd0c8c0d5af970d6224dae3d5c6256067.

### DIFF
--- a/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:bafcc2acd0c8c0d5af970d6224dae3d5c6256067-0.tsv
+++ b/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:bafcc2acd0c8c0d5af970d6224dae3d5c6256067-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+star=2.7.2b,samtools=1.9,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:bafcc2acd0c8c0d5af970d6224dae3d5c6256067

**Packages**:
- star=2.7.2b
- samtools=1.9
- python=3.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- rna_star_index_builder.xml

Generated with Planemo.