### PR TITLE
Add container mulled-v2-7b39dc8707cf5db4725f81c750908e6d5c0079e0:9c4ffd0da09f7dbe0d271faf1c5a121e41e0bc77.

### DIFF
--- a/combinations/mulled-v2-7b39dc8707cf5db4725f81c750908e6d5c0079e0:9c4ffd0da09f7dbe0d271faf1c5a121e41e0bc77-0.tsv
+++ b/combinations/mulled-v2-7b39dc8707cf5db4725f81c750908e6d5c0079e0:9c4ffd0da09f7dbe0d271faf1c5a121e41e0bc77-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kobas=2.1.1,r-base=3.4,biopython=1.72	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-7b39dc8707cf5db4725f81c750908e6d5c0079e0:9c4ffd0da09f7dbe0d271faf1c5a121e41e0bc77

**Packages**:
- kobas=2.1.1
- r-base=3.4
- biopython=1.72
Base Image:bgruening/busybox-bash:0.1

**For** :
- kobas_identify.xml
- kobas_annotate.xml

Generated with Planemo.