### PR TITLE
Add container mulled-v2-a0befa8208a1194e8046a119d802824811d98efe:5eeecf5d1ece2d5ed914cb65967a744b8bf0a27c.

### DIFF
--- a/combinations/mulled-v2-a0befa8208a1194e8046a119d802824811d98efe:5eeecf5d1ece2d5ed914cb65967a744b8bf0a27c-0.tsv
+++ b/combinations/mulled-v2-a0befa8208a1194e8046a119d802824811d98efe:5eeecf5d1ece2d5ed914cb65967a744b8bf0a27c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+libmagic=5.32,snpeff=4.3.1t,biopython=1.70,python=3.6,python-magic=0.4.15	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-a0befa8208a1194e8046a119d802824811d98efe:5eeecf5d1ece2d5ed914cb65967a744b8bf0a27c

**Packages**:
- libmagic=5.32
- snpeff=4.3.1t
- biopython=1.70
- python=3.6
- python-magic=0.4.15
Base Image:bgruening/busybox-bash:0.1

**For** :
- snpEff_create_db.xml

Generated with Planemo.