### PR TITLE
Add container mulled-v2-a86aaf10d8d6e1498ee64028a3005ac2e03822b3:61e43a914a980f1d52857135969c84a1fe755584.

### DIFF
--- a/combinations/mulled-v2-a86aaf10d8d6e1498ee64028a3005ac2e03822b3:61e43a914a980f1d52857135969c84a1fe755584-0.tsv
+++ b/combinations/mulled-v2-a86aaf10d8d6e1498ee64028a3005ac2e03822b3:61e43a914a980f1d52857135969c84a1fe755584-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.3.2,qiime=1.9.1,r-vegan=2.3_4,r-base=3.3	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a86aaf10d8d6e1498ee64028a3005ac2e03822b3:61e43a914a980f1d52857135969c84a1fe755584

**Packages**:
- r-optparse=1.3.2
- qiime=1.9.1
- r-vegan=2.3_4
- r-base=3.3
Base Image:bioconda/extended-base-image:latest

**For** :
- compare_categories.xml

Generated with Planemo.