### PR TITLE
Add container mulled-v2-8c125371ebff2e31321392313b2d9003cb1537ac:cf8eee7269d33855301c368470dbf2e02e848344.

### DIFF
--- a/combinations/mulled-v2-8c125371ebff2e31321392313b2d9003cb1537ac:cf8eee7269d33855301c368470dbf2e02e848344-0.tsv
+++ b/combinations/mulled-v2-8c125371ebff2e31321392313b2d9003cb1537ac:cf8eee7269d33855301c368470dbf2e02e848344-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+six=1.10,urllib3=1.12,curl=7.49.0,xmltramp2=3.1.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8c125371ebff2e31321392313b2d9003cb1537ac:cf8eee7269d33855301c368470dbf2e02e848344

**Packages**:
- six=1.10
- urllib3=1.12
- curl=7.49.0
- xmltramp2=3.1.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- ebi_metagenomics_run_downloader.xml

Generated with Planemo.