### PR TITLE
Add container mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:e217abbcbd63df7593ddbe1da505fbb75fd82e9c.

### DIFF
--- a/combinations/mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:e217abbcbd63df7593ddbe1da505fbb75fd82e9c-0.tsv
+++ b/combinations/mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:e217abbcbd63df7593ddbe1da505fbb75fd82e9c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+htslib=1.10,bcftools=1.10,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:e217abbcbd63df7593ddbe1da505fbb75fd82e9c

**Packages**:
- htslib=1.10
- bcftools=1.10
- python=3.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- bcftools_plugin_counts.xml

Generated with Planemo.