### PR TITLE
Add container mulled-v2-3e526ef0106b7da55e0ab949f2b8942a33907e15:20eb375b20e151c0c17503bdc4d4642afde13e96.

### DIFF
--- a/combinations/mulled-v2-3e526ef0106b7da55e0ab949f2b8942a33907e15:20eb375b20e151c0c17503bdc4d4642afde13e96-0.tsv
+++ b/combinations/mulled-v2-3e526ef0106b7da55e0ab949f2b8942a33907e15:20eb375b20e151c0c17503bdc4d4642afde13e96-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcbiogff=0.6.4,pybigwig=0.3.13,python=2.7,circos=0.69.8,biopython=1.70,circos-tools=0.23,tar=1.29	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-3e526ef0106b7da55e0ab949f2b8942a33907e15:20eb375b20e151c0c17503bdc4d4642afde13e96

**Packages**:
- bcbiogff=0.6.4
- pybigwig=0.3.13
- python=2.7
- circos=0.69.8
- biopython=1.70
- circos-tools=0.23
- tar=1.29
Base Image:bgruening/busybox-bash:0.1

**For** :
- tiles-from-interval.xml
- gc_skew.xml
- text-from-interval.xml
- alignments-to-links.xml
- binlinks.xml
- scatter-from-wiggle.xml
- resample.xml
- circos.xml
- tableviewer.xml
- bundlelinks.xml

Generated with Planemo.