### PR TITLE
Add pigz support to qcat output

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -93,3 +93,4 @@ r-base=4.0,r-optparse=1.6.6,r-ggplot2=3.3.2,bioconductor-txdb.hsapiens.ucsc.hg19
 searchgui=4.0.4,zip=3.0	bioconda/extended-base-image:latest	0
 bowtie2=2.4.2,samtools=1.11,pigz=2.3.4
 r-base=4.0,bioconductor-edger=3.32.0,bioconductor-limma=3.46.0,r-rjson=0.2.20,r-getopt=1.20.3,r-statmod=1.4.35,r-scales=1.1.1	bgruening/busybox-bash:0.1	0
+qcat=1.1.0,pigz=2.3.4	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION

Hi @bgruening ! This is great by the way 😎. I have been using individual BioContainers exclusively in a couple of nf-core pipelines and I imagine this will only get more popular in the future. Been meaning to try and build multi package containers for a while and now I have the perfect excuse. 

Currently, [`qcat`](https://anaconda.org/bioconda/qcat) doesnt support zipped `fastq` files as input or output so it would be useful to create a  BioContainer that has both. 

I couldnt find `qcat` in the [helper service](https://biocontainers.pro/#/multipackage) link in the main [`README.md`](https://github.com/BioContainers/multi-package-containers/blob/master/README.md) but Im assuming it will be ok?

Thanks in advance!