### PR TITLE
Add container mulled-v2-3a63b40fc09993a8dbaeb7fe4d2367c6d532cde0:e527a8cfdece59eccb8388417d494b688b1b7356.

### DIFF
--- a/combinations/mulled-v2-3a63b40fc09993a8dbaeb7fe4d2367c6d532cde0:e527a8cfdece59eccb8388417d494b688b1b7356-0.tsv
+++ b/combinations/mulled-v2-3a63b40fc09993a8dbaeb7fe4d2367c6d532cde0:e527a8cfdece59eccb8388417d494b688b1b7356-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.11.2.1=py27_0,numpy=1.11.2=py27_0,bowtie=1.1.2,r-lattice=0.20_33=r3.3.1_0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-3a63b40fc09993a8dbaeb7fe4d2367c6d532cde0:e527a8cfdece59eccb8388417d494b688b1b7356

**Packages**:
- pysam=0.11.2.1=py27_0
- numpy=1.11.2=py27_0
- bowtie=1.1.2
- r-lattice=0.20_33=r3.3.1_0
Base Image:bgruening/busybox-bash:0.1

**For** :
- MirParser.xml

Generated with Planemo.