### PR TITLE
Add container mulled-v2-0c036454ee8b61bd8c19b18e29d64f33d76de728:48635248e5c0002e29602c2dc3e6ec6d6a360895.

### DIFF
--- a/combinations/mulled-v2-0c036454ee8b61bd8c19b18e29d64f33d76de728:48635248e5c0002e29602c2dc3e6ec6d6a360895-0.tsv
+++ b/combinations/mulled-v2-0c036454ee8b61bd8c19b18e29d64f33d76de728:48635248e5c0002e29602c2dc3e6ec6d6a360895-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-scran=1.12.1=r36he1b5a44_0,r-optparse=1.6.2	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-0c036454ee8b61bd8c19b18e29d64f33d76de728:48635248e5c0002e29602c2dc3e6ec6d6a360895

**Packages**:
- bioconductor-scran=1.12.1=r36he1b5a44_0
- r-optparse=1.6.2
Base Image:bgruening/busybox-bash:0.1

**For** :
- scran_normalize.xml

Generated with Planemo.