### PR TITLE
Add container mulled-v2-bed980113b035ff354a9f6ddea5ce3e983b67f41:bbe6a4a3e51fdd665a354ef583820242c957cdbd.

### DIFF
--- a/combinations/mulled-v2-bed980113b035ff354a9f6ddea5ce3e983b67f41:bbe6a4a3e51fdd665a354ef583820242c957cdbd-0.tsv
+++ b/combinations/mulled-v2-bed980113b035ff354a9f6ddea5ce3e983b67f41:bbe6a4a3e51fdd665a354ef583820242c957cdbd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-goseq=1.22.0,bioconductor-rtracklayer=1.30,r-reshape2=1.4.1=r3.2.2_1a,r-optparse=1.3.0=r3.2.2_1,r-data.table=1.9.6=r3.2.2_0a	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-bed980113b035ff354a9f6ddea5ce3e983b67f41:bbe6a4a3e51fdd665a354ef583820242c957cdbd

**Packages**:
- bioconductor-goseq=1.22.0
- bioconductor-rtracklayer=1.30
- r-reshape2=1.4.1=r3.2.2_1a
- r-optparse=1.3.0=r3.2.2_1
- r-data.table=1.9.6=r3.2.2_0a
Base Image:bgruening/busybox-bash:0.1

**For** :
- goseq.xml
- getgo.xml
- get_length_and_gc_content.xml

Generated with Planemo.