### PR TITLE
Add container mulled-v2-8d74d0dc728415885dfb1ab835913c8fa2377ded:419aad9ae58d970b351310cb619cd6fc2533d0cb.

### DIFF
--- a/combinations/mulled-v2-8d74d0dc728415885dfb1ab835913c8fa2377ded:419aad9ae58d970b351310cb619cd6fc2533d0cb-0.tsv
+++ b/combinations/mulled-v2-8d74d0dc728415885dfb1ab835913c8fa2377ded:419aad9ae58d970b351310cb619cd6fc2533d0cb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie=0.12.7,numpy=1.9,pysam=0.7.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8d74d0dc728415885dfb1ab835913c8fa2377ded:419aad9ae58d970b351310cb619cd6fc2533d0cb

**Packages**:
- bowtie=0.12.7
- numpy=1.9
- pysam=0.7.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- FeaturesParser.xml

Generated with Planemo.