### PR TITLE
Add container mulled-v2-1c5b83a78ec253ebdcf0528849b796807d9879eb:052c696fba26604c148f55a375ade42578f97dfb.

### DIFF
--- a/combinations/mulled-v2-1c5b83a78ec253ebdcf0528849b796807d9879eb:052c696fba26604c148f55a375ade42578f97dfb-0.tsv
+++ b/combinations/mulled-v2-1c5b83a78ec253ebdcf0528849b796807d9879eb:052c696fba26604c148f55a375ade42578f97dfb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.11.2.1=py27_0,bowtie=1.1.2=py27_0,r-gridextra=2.2.1=r3.3.2_0,numpy=1.11.2=py27_0,r-reshape2=1.4.2=r3.3.2_0,r-optparse=1.3.2=r3.3.2_0,r-latticeextra=0.6_28=r3.3.2_0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-1c5b83a78ec253ebdcf0528849b796807d9879eb:052c696fba26604c148f55a375ade42578f97dfb

**Packages**:
- pysam=0.11.2.1=py27_0
- bowtie=1.1.2=py27_0
- r-gridextra=2.2.1=r3.3.2_0
- numpy=1.11.2=py27_0
- r-reshape2=1.4.2=r3.3.2_0
- r-optparse=1.3.2=r3.3.2_0
- r-latticeextra=0.6_28=r3.3.2_0
Base Image:bgruening/busybox-bash:0.1

**For** :
- readmap.xml

Generated with Planemo.