### PR TITLE
Add container mulled-v2-559d27fc099979ce742b74284f84f871f90dc790:bc959cefa047dbe6b27bc8682d05392bd6cb5f38.

### DIFF
--- a/combinations/mulled-v2-559d27fc099979ce742b74284f84f871f90dc790:bc959cefa047dbe6b27bc8682d05392bd6cb5f38-0.tsv
+++ b/combinations/mulled-v2-559d27fc099979ce742b74284f84f871f90dc790:bc959cefa047dbe6b27bc8682d05392bd6cb5f38-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.11.2.1=py27_0,r-gridextra=2.2.1=r3.3.2_0,bowtie=1.2.0=py27_0,r-optparse=1.3.2=r3.3.2_0,r-latticeextra=0.6_28=r3.3.2_0,numpy=1.9.3	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-559d27fc099979ce742b74284f84f871f90dc790:bc959cefa047dbe6b27bc8682d05392bd6cb5f38

**Packages**:
- pysam=0.11.2.1=py27_0
- r-gridextra=2.2.1=r3.3.2_0
- bowtie=1.2.0=py27_0
- r-optparse=1.3.2=r3.3.2_0
- r-latticeextra=0.6_28=r3.3.2_0
- numpy=1.9.3
Base Image:bgruening/busybox-bash:0.1

**For** :
- size_histogram.xml

Generated with Planemo.