### PR TITLE
Add container mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:4f77b710967ddebe9f29712ea090ac6aa72712f8.

### DIFF
--- a/combinations/mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:4f77b710967ddebe9f29712ea090ac6aa72712f8-0.tsv
+++ b/combinations/mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:4f77b710967ddebe9f29712ea090ac6aa72712f8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.15.3=py37hbcae180_3,samtools=1.10=h9402c20_2,r-ggplot2=3.2.1=r36h6115d3f_0,bedtools=2.29.2=hc088bd4_0,r-optparse=1.6.4=r36h6115d3f_0,numpy=1.17.3=py37h95a1406_0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:4f77b710967ddebe9f29712ea090ac6aa72712f8

**Packages**:
- pysam=0.15.3=py37hbcae180_3
- samtools=1.10=h9402c20_2
- r-ggplot2=3.2.1=r36h6115d3f_0
- bedtools=2.29.2=hc088bd4_0
- r-optparse=1.6.4=r36h6115d3f_0
- numpy=1.17.3=py37h95a1406_0
Base Image:bgruening/busybox-bash:0.1

**For** :
- probecoverage.xml

Generated with Planemo.