### PR TITLE
Add container mulled-v2-b689328eafe368e2df14b2d44efcc69bf85963ef:2035685760ad7b00e22d2d8b9468fe400e209ae5.

### DIFF
--- a/combinations/mulled-v2-b689328eafe368e2df14b2d44efcc69bf85963ef:2035685760ad7b00e22d2d8b9468fe400e209ae5-0.tsv
+++ b/combinations/mulled-v2-b689328eafe368e2df14b2d44efcc69bf85963ef:2035685760ad7b00e22d2d8b9468fe400e209ae5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.11.2.1=py27_0,numpy=1.11.2=py27_0,bowtie=1.1.2,r-latticeextra=0.6_28=r3.3.2_0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-b689328eafe368e2df14b2d44efcc69bf85963ef:2035685760ad7b00e22d2d8b9468fe400e209ae5

**Packages**:
- pysam=0.11.2.1=py27_0
- numpy=1.11.2=py27_0
- bowtie=1.1.2
- r-latticeextra=0.6_28=r3.3.2_0
Base Image:bgruening/busybox-bash:0.1

**For** :
- signature.xml

Generated with Planemo.