### PR TITLE
Add container mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477.

### DIFF
--- a/combinations/mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477-0.tsv
+++ b/combinations/mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=0.1.18,gatk=1.4	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477

**Packages**:
- samtools=0.1.18
- gatk=1.4
Base Image:bgruening/busybox-bash:0.1

**For** :
- table_recalibration.xml
- variant_annotator.xml
- realigner_target_creator.xml
- count_covariates.xml
- print_reads.xml
- depth_of_coverage.xml
- indel_realigner.xml
- unified_genotyper.xml

Generated with Planemo.