### PR TITLE
Add container mulled-v2-45855af8567c5eb64cd8e9742916ef5b338f9717:b1ea6d245adeb42dab27b3abf1731f88e784e1fd.

### DIFF
--- a/combinations/mulled-v2-45855af8567c5eb64cd8e9742916ef5b338f9717:b1ea6d245adeb42dab27b3abf1731f88e784e1fd-0.tsv
+++ b/combinations/mulled-v2-45855af8567c5eb64cd8e9742916ef5b338f9717:b1ea6d245adeb42dab27b3abf1731f88e784e1fd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fastx_toolkit=0.0.14,bzip2=1.0.8	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-45855af8567c5eb64cd8e9742916ef5b338f9717:b1ea6d245adeb42dab27b3abf1731f88e784e1fd

**Packages**:
- fastx_toolkit=0.0.14
- bzip2=1.0.8
Base Image:bioconda/extended-base-image:latest

**For** :
- fastx_reverse_complement.xml
- fastx_renamer.xml
- fastx_artifacts_filter.xml
- fastx_clipper.xml
- fastx_trimmer.xml
- fastq_quality_filter.xml

Generated with Planemo.