### PR TITLE
Add container mulled-v2-6a23f76a7a4c6270c65301269e18eac29b2eb35e:7354e6c66e0f77ae153f2a134978ee1c642a9c46.

### DIFF
--- a/combinations/mulled-v2-6a23f76a7a4c6270c65301269e18eac29b2eb35e:7354e6c66e0f77ae153f2a134978ee1c642a9c46-0.tsv
+++ b/combinations/mulled-v2-6a23f76a7a4c6270c65301269e18eac29b2eb35e:7354e6c66e0f77ae153f2a134978ee1c642a9c46-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-dplyr=0.7.6,r-here=0.1.0,r-stringr=1.3.0,r-optparse=1.6.0,r-purrr=0.2.5,r-tidyr=0.8.1,r-jsonlite=1.5.0,r-base=3.4.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-6a23f76a7a4c6270c65301269e18eac29b2eb35e:7354e6c66e0f77ae153f2a134978ee1c642a9c46

**Packages**:
- r-dplyr=0.7.6
- r-here=0.1.0
- r-stringr=1.3.0
- r-optparse=1.6.0
- r-purrr=0.2.5
- r-tidyr=0.8.1
- r-jsonlite=1.5.0
- r-base=3.4.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- mykrobe_parser.xml

Generated with Planemo.