### PR TITLE
Add container mulled-v2-427ef1db0aa596d761169a2b643488a2a807f397:fa06153a05361b233bbc80b465dc920622fd92e5.

### DIFF
--- a/combinations/mulled-v2-427ef1db0aa596d761169a2b643488a2a807f397:fa06153a05361b233bbc80b465dc920622fd92e5-0.tsv
+++ b/combinations/mulled-v2-427ef1db0aa596d761169a2b643488a2a807f397:fa06153a05361b233bbc80b465dc920622fd92e5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xmltramp2=3.1.1,urllib3=1.12,six=1.10	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-427ef1db0aa596d761169a2b643488a2a807f397:fa06153a05361b233bbc80b465dc920622fd92e5

**Packages**:
- xmltramp2=3.1.1
- urllib3=1.12
- six=1.10
Base Image:bgruening/busybox-bash:0.1

**For** :
- ebi_search_rest_results.xml

Generated with Planemo.