### PR TITLE
Add container mulled-v2-76138fae381092ad1f9b99bff152a05bded7f84e:73b2e0c1767e24516c39639e6a0c3b063e927522.

### DIFF
--- a/combinations/mulled-v2-76138fae381092ad1f9b99bff152a05bded7f84e:73b2e0c1767e24516c39639e6a0c3b063e927522-0.tsv
+++ b/combinations/mulled-v2-76138fae381092ad1f9b99bff152a05bded7f84e:73b2e0c1767e24516c39639e6a0c3b063e927522-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+snpsift=4.3.1t,perl=5.26,coreutils=8.25	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-76138fae381092ad1f9b99bff152a05bded7f84e:73b2e0c1767e24516c39639e6a0c3b063e927522

**Packages**:
- snpsift=4.3.1t
- perl=5.26
- coreutils=8.25
Base Image:bgruening/busybox-bash:0.1

**For** :
- snpSift_geneSets.xml
- snpSift_dbnsfp.xml
- snpSift_vartype.xml
- snpSift_extractFields.xml
- snpSift_annotate.xml
- snpSift_rmInfo.xml
- snpSift_filter.xml
- snpSift_int.xml
- snpSift_vcfCheck.xml
- snpSift_caseControl.xml

Generated with Planemo.