### PR TITLE
Add container mulled-v2-eaf771378ecf2523e003c72304be6eb8ca2233a0:223e08d6fe868660f956e0bc097404dfddd9394f.

### DIFF
--- a/combinations/mulled-v2-eaf771378ecf2523e003c72304be6eb8ca2233a0:223e08d6fe868660f956e0bc097404dfddd9394f-0.tsv
+++ b/combinations/mulled-v2-eaf771378ecf2523e003c72304be6eb8ca2233a0:223e08d6fe868660f956e0bc097404dfddd9394f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.6,bioconductor-gwastools=1.30.0,r-optparse=1.6.4	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-eaf771378ecf2523e003c72304be6eb8ca2233a0:223e08d6fe868660f956e0bc097404dfddd9394f

**Packages**:
- r-base=3.6
- bioconductor-gwastools=1.30.0
- r-optparse=1.6.4
Base Image:bgruening/busybox-bash:0.1

**For** :
- manhattan_plot.xml

Generated with Planemo.