### PR TITLE
Add container mulled-v2-9a9f31fdd4196df237c06c90e6e77fe27cdd5c1f:8148bc7b912a3499dffccc48ea2e197cdce37a33.

### DIFF
--- a/combinations/mulled-v2-9a9f31fdd4196df237c06c90e6e77fe27cdd5c1f:8148bc7b912a3499dffccc48ea2e197cdce37a33-0.tsv
+++ b/combinations/mulled-v2-9a9f31fdd4196df237c06c90e6e77fe27cdd5c1f:8148bc7b912a3499dffccc48ea2e197cdce37a33-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tifffile=0.15.1,pillow=4.0.0,mahotas=1.4.3,numpy=1.12	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-9a9f31fdd4196df237c06c90e6e77fe27cdd5c1f:8148bc7b912a3499dffccc48ea2e197cdce37a33

**Packages**:
- tifffile=0.15.1
- pillow=4.0.0
- mahotas=1.4.3
- numpy=1.12
Base Image:bgruening/busybox-bash:0.1

**For** :
- mahotas_features.xml

Generated with Planemo.