### PR TITLE
Add container mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:6bd731ce965e77855a475a1ee56571de071a5c1c.

### DIFF
--- a/combinations/mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:6bd731ce965e77855a475a1ee56571de071a5c1c-0.tsv
+++ b/combinations/mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:6bd731ce965e77855a475a1ee56571de071a5c1c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+infernal,infernal=1.1.2,coreutils=8.25	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:6bd731ce965e77855a475a1ee56571de071a5c1c

**Packages**:
- infernal
- infernal=1.1.2
- coreutils=8.25
Base Image:bgruening/busybox-bash:0.1

**For** :
- cmalign.xml
- cmstat.xml
- cmpress.xml
- cmscan.xml
- cmsearch.xml
- cmbuild.xml

Generated with Planemo.