### PR TITLE
Add container mulled-v2-0cf584608bb976de310b6ba23cfc7c267a479760:d75ce1f221a78e383148b2e2dfbe1ee822b0dc89.

### DIFF
--- a/combinations/mulled-v2-0cf584608bb976de310b6ba23cfc7c267a479760:d75ce1f221a78e383148b2e2dfbe1ee822b0dc89-0.tsv
+++ b/combinations/mulled-v2-0cf584608bb976de310b6ba23cfc7c267a479760:d75ce1f221a78e383148b2e2dfbe1ee822b0dc89-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rasterstats=0.13.1,geopandas=0.4.1,xarray=0.11.3,netcdf4=1.5.1.2,python=3	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-0cf584608bb976de310b6ba23cfc7c267a479760:d75ce1f221a78e383148b2e2dfbe1ee822b0dc89

**Packages**:
- rasterstats=0.13.1
- geopandas=0.4.1
- xarray=0.11.3
- netcdf4=1.5.1.2
- python=3
Base Image:bgruening/busybox-bash:0.1

**For** :
- mean-per-zone.xml

Generated with Planemo.