### PR TITLE
Add container mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:d67d021ff194d58c15cca934dd3dfe948d1c7145.

### DIFF
--- a/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:d67d021ff194d58c15cca934dd3dfe948d1c7145-0.tsv
+++ b/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:d67d021ff194d58c15cca934dd3dfe948d1c7145-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,hicexplorer=3.4.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:d67d021ff194d58c15cca934dd3dfe948d1c7145

**Packages**:
- samtools=1.9
- hicexplorer=3.4.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- hicBuildMatrix.xml

Generated with Planemo.