### PR TITLE
Add container mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:fde6357a91c2f52781719d03f34666bd55d07442.

### DIFF
--- a/combinations/mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:fde6357a91c2f52781719d03f34666bd55d07442-0.tsv
+++ b/combinations/mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:fde6357a91c2f52781719d03f34666bd55d07442-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-cluster=2.0.6,trinity=2.9.1,r-fastcluster=1.1.24,bioconductor-biobase=2.38.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:fde6357a91c2f52781719d03f34666bd55d07442

**Packages**:
- r-cluster=2.0.6
- trinity=2.9.1
- r-fastcluster=1.1.24
- bioconductor-biobase=2.38.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- define_clusters_by_cutting_tree.xml

Generated with Planemo.