### PR TITLE
Add container mulled-v2-2e7779112fa51ab86a19b065831ee16283e97645:bb54eb1037d33ad88933e228b1e77c5499d72615.

### DIFF
--- a/combinations/mulled-v2-2e7779112fa51ab86a19b065831ee16283e97645:bb54eb1037d33ad88933e228b1e77c5499d72615-0.tsv
+++ b/combinations/mulled-v2-2e7779112fa51ab86a19b065831ee16283e97645:bb54eb1037d33ad88933e228b1e77c5499d72615-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trinity=2.9.1,kallisto=0.44.0,bioconductor-edger=3.20.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-2e7779112fa51ab86a19b065831ee16283e97645:bb54eb1037d33ad88933e228b1e77c5499d72615

**Packages**:
- trinity=2.9.1
- kallisto=0.44.0
- bioconductor-edger=3.20.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- abundance_estimates_to_matrix.xml

Generated with Planemo.