### PR TITLE
Add container mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:c8a37cc0472938ba8b9e30cf00c43f2fb56b7005.

### DIFF
--- a/combinations/mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:c8a37cc0472938ba8b9e30cf00c43f2fb56b7005-0.tsv
+++ b/combinations/mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:c8a37cc0472938ba8b9e30cf00c43f2fb56b7005-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trinity=2.9.1,r-cluster=2.0.6,r-fastcluster=1.1.24,bioconductor-biobase=2.38.0,bioconductor-qvalue=2.10.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-536d2ef67515406389db48f6e00b8a1a475403a1:c8a37cc0472938ba8b9e30cf00c43f2fb56b7005

**Packages**:
- trinity=2.9.1
- r-cluster=2.0.6
- r-fastcluster=1.1.24
- bioconductor-biobase=2.38.0
- bioconductor-qvalue=2.10.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- samples_qccheck.xml

Generated with Planemo.