### PR TITLE
Add container mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0aa04dd81406183395ac6e27142e75129077c734.

### DIFF
--- a/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0aa04dd81406183395ac6e27142e75129077c734-0.tsv
+++ b/combinations/mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0aa04dd81406183395ac6e27142e75129077c734-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trinity=2.9.1,r-fastcluster=1.1.25,bioconductor-goseq=1.36.0,bioconductor-qvalue=2.18.0,r-cluster=2.0.8	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-55f55c7464b1f39174774a696def4e1b848ba335:0aa04dd81406183395ac6e27142e75129077c734

**Packages**:
- trinity=2.9.1
- r-fastcluster=1.1.25
- bioconductor-goseq=1.36.0
- bioconductor-qvalue=2.18.0
- r-cluster=2.0.8
Base Image:bgruening/busybox-bash:0.1

**For** :
- analyze_diff_expr.xml

Generated with Planemo.