### PR TITLE
Add container mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:0a37de2af99363a0deb1b931e57637dca79a53fd.

### DIFF
--- a/combinations/mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:0a37de2af99363a0deb1b931e57637dca79a53fd-0.tsv
+++ b/combinations/mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:0a37de2af99363a0deb1b931e57637dca79a53fd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trinity=2.9.1,bioconductor-deseq2=1.18.1,bioconductor-limma=3.34.9,bioconductor-edger=3.20.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-daff5c41a83768df6dc46a6c5e8065da61d074f0:0a37de2af99363a0deb1b931e57637dca79a53fd

**Packages**:
- trinity=2.9.1
- bioconductor-deseq2=1.18.1
- bioconductor-limma=3.34.9
- bioconductor-edger=3.20.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- run_de_analysis.xml

Generated with Planemo.