### PR TITLE
Add container mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:b473b2cc4aa06377324725f3ae47c42939131dbf.

### DIFF
--- a/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:b473b2cc4aa06377324725f3ae47c42939131dbf-0.tsv
+++ b/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:b473b2cc4aa06377324725f3ae47c42939131dbf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyyaml=3.13,jbrowse=1.16.8,samtools=1.9,tabix=0.2.6,python=2.7,bcbiogff=0.6.4,findutils=4.6.0,biopython=1.72	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:b473b2cc4aa06377324725f3ae47c42939131dbf

**Packages**:
- pyyaml=3.13
- jbrowse=1.16.8
- samtools=1.9
- tabix=0.2.6
- python=2.7
- bcbiogff=0.6.4
- findutils=4.6.0
- biopython=1.72
Base Image:bgruening/busybox-bash:0.1

**For** :
- jbrowse.xml
- jbrowse-fromdir.xml

Generated with Planemo.