### PR TITLE
Multi-tool containers for some ebi-gxa SC tools

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -49,6 +49,6 @@ biopython=1.76,pybedtools=0.8.1,locus_processing=0.0.4,pyyaml=3.12	bgruening/bus
 varscan=2.4.2,samtools=1.3.1,tabix=0.2.6,grep=2.14	bgruening/busybox-bash:0.1	0
 bedtools=2.27.1,grep=2.14,gawk=5.0.1	bgruening/busybox-bash:0.1	0
 bedtools=2.27.1,grep=2.14,gawk=5.0.1,click=7,python=3.7	bgruening/busybox-bash:0.1	0
-bioconductor-rtracklayer=1.42.1,bioconductor-biostrings,r-optparse	bgruening/busybox-bash:0.1	0
-bioconductor-dropletutils=1.6.1,openblas,r-matrix,r-ggplot2,r-optparse,r-gridextra,bioconductor-delayedarray	bgruening/busybox-bash:0.1	0
-scipy,pandas	bgruening/busybox-bash:0.1	0
+bioconductor-rtracklayer=1.42.1,bioconductor-biostrings=2.50.2,r-optparse=1.6.4	bgruening/busybox-bash:0.1	0
+bioconductor-dropletutils=1.6.1,openblas=0.3.9,r-matrix=1.2,r-ggplot2=3.2.1,r-optparse=1.6.4,r-gridextra=2.3,bioconductor-delayedarray=0.12.0	bgruening/busybox-bash:0.1	0
+scipy=1.4.1,pandas=1.0.1	bgruening/busybox-bash:0.1	0

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -49,3 +49,6 @@ biopython=1.76,pybedtools=0.8.1,locus_processing=0.0.4,pyyaml=3.12	bgruening/bus
 varscan=2.4.2,samtools=1.3.1,tabix=0.2.6,grep=2.14	bgruening/busybox-bash:0.1	0
 bedtools=2.27.1,grep=2.14,gawk=5.0.1	bgruening/busybox-bash:0.1	0
 bedtools=2.27.1,grep=2.14,gawk=5.0.1,click=7,python=3.7	bgruening/busybox-bash:0.1	0
+bioconductor-rtracklayer=1.42.1,bioconductor-biostrings,r-optparse  bgruening/busybox-bash:0.1	0
+bioconductor-dropletutils=1.6.1,openblas,r-matrix,r-ggplot2,r-optparse,r-gridextra,bioconductor-delayedarray  bgruening/busybox-bash:0.1	0
+scipy,pandas  bgruening/busybox-bash:0.1	0

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -49,6 +49,6 @@ biopython=1.76,pybedtools=0.8.1,locus_processing=0.0.4,pyyaml=3.12	bgruening/bus
 varscan=2.4.2,samtools=1.3.1,tabix=0.2.6,grep=2.14	bgruening/busybox-bash:0.1	0
 bedtools=2.27.1,grep=2.14,gawk=5.0.1	bgruening/busybox-bash:0.1	0
 bedtools=2.27.1,grep=2.14,gawk=5.0.1,click=7,python=3.7	bgruening/busybox-bash:0.1	0
-bioconductor-rtracklayer=1.42.1,bioconductor-biostrings,r-optparse  bgruening/busybox-bash:0.1	0
-bioconductor-dropletutils=1.6.1,openblas,r-matrix,r-ggplot2,r-optparse,r-gridextra,bioconductor-delayedarray  bgruening/busybox-bash:0.1	0
-scipy,pandas  bgruening/busybox-bash:0.1	0
+bioconductor-rtracklayer=1.42.1,bioconductor-biostrings,r-optparse	bgruening/busybox-bash:0.1	0
+bioconductor-dropletutils=1.6.1,openblas,r-matrix,r-ggplot2,r-optparse,r-gridextra,bioconductor-delayedarray	bgruening/busybox-bash:0.1	0
+scipy,pandas	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
This PR adds multi tools configs for the dependencies of:

_ensembl_gtf2gene_list
_salmon_kallisto_mtx_to_10x
dropletBarcodePlot

Question: can this be done without pinning versions on all packages? The original galaxy tools for these not pinned to a particular version of the tools.