### PR TITLE
Add container mulled-v2-2c3e67b5a486617b48b0b6400b1c2953f3c9c31b:05f878c65e421268e6049d5b3a79b79669a02c4b.

### DIFF
--- a/combinations/mulled-v2-2c3e67b5a486617b48b0b6400b1c2953f3c9c31b:05f878c65e421268e6049d5b3a79b79669a02c4b-0.tsv
+++ b/combinations/mulled-v2-2c3e67b5a486617b48b0b6400b1c2953f3c9c31b:05f878c65e421268e6049d5b3a79b79669a02c4b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kma=1.2.21,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-2c3e67b5a486617b48b0b6400b1c2953f3c9c31b:05f878c65e421268e6049d5b3a79b79669a02c4b

**Packages**:
- kma=1.2.21
- python=3.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- kma_build_index.xml

Generated with Planemo.