### PR TITLE
Add container mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:c27ddbb57400bf18d456874d34844c707afb4f13.

### DIFF
--- a/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:c27ddbb57400bf18d456874d34844c707afb4f13-0.tsv
+++ b/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:c27ddbb57400bf18d456874d34844c707afb4f13-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+diamond,last,blast,proteinortho=6.0.14,blat	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:c27ddbb57400bf18d456874d34844c707afb4f13

**Packages**:
- diamond
- last
- blast
- proteinortho=6.0.14
- blat
Base Image:bioconda/extended-base-image:latest

**For** :
- proteinortho_summary.xml
- proteinortho.xml
- proteinortho_grab_proteins.xml

Generated with Planemo.