### PR TITLE
Add container mulled-v2-1caf376ae397942a37714c9a3e833e7135baddad:495f3815c20179075a8cd4505dc5776146a91f00.

### DIFF
--- a/combinations/mulled-v2-1caf376ae397942a37714c9a3e833e7135baddad:495f3815c20179075a8cd4505dc5776146a91f00-0.tsv
+++ b/combinations/mulled-v2-1caf376ae397942a37714c9a3e833e7135baddad:495f3815c20179075a8cd4505dc5776146a91f00-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.31,seq2hla=2.2	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-1caf376ae397942a37714c9a3e833e7135baddad:495f3815c20179075a8cd4505dc5776146a91f00

**Packages**:
- coreutils=8.31
- seq2hla=2.2
Base Image:bgruening/busybox-bash:0.1

**For** :
- seq2hla.xml

Generated with Planemo.