### PR TITLE
Add container mulled-v2-4480a8fc7f0035e6bddc39a1569b7cf4ef226e54:729849e013b4033dcc74ae5999035ec806f9c6b4.

### DIFF
--- a/combinations/mulled-v2-4480a8fc7f0035e6bddc39a1569b7cf4ef226e54:729849e013b4033dcc74ae5999035ec806f9c6b4-0.tsv
+++ b/combinations/mulled-v2-4480a8fc7f0035e6bddc39a1569b7cf4ef226e54:729849e013b4033dcc74ae5999035ec806f9c6b4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-gridextra=2.3,bioconductor-swath2stats=1.16.0,r-data.table=1.12.8,r-dplyr=0.8.4,pyprophet=2.1.4	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4480a8fc7f0035e6bddc39a1569b7cf4ef226e54:729849e013b4033dcc74ae5999035ec806f9c6b4

**Packages**:
- r-gridextra=2.3
- bioconductor-swath2stats=1.16.0
- r-data.table=1.12.8
- r-dplyr=0.8.4
- pyprophet=2.1.4
Base Image:bioconda/extended-base-image:latest

**For** :
- pyprophet_export.xml

Generated with Planemo.