### PR TITLE
Add container mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:9796fae7f3dc33539425911572b1af41da23d71c.

### DIFF
--- a/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:9796fae7f3dc33539425911572b1af41da23d71c-0.tsv
+++ b/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:9796fae7f3dc33539425911572b1af41da23d71c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+deeptools=3.4.0,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:9796fae7f3dc33539425911572b1af41da23d71c

**Packages**:
- deeptools=3.4.0
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- plotEnrichment.xml
- computeGCBias.xml
- plotPCA.xml
- bamPEFragmentSize.xml
- multiBamSummary.xml
- estimateReadFiltering.xml
- bigwigCompare.xml
- plotCoverage.xml
- multiBigwigSummary.xml
- plotHeatmap.xml
- bamCompare.xml
- plotProfiler.xml
- computeMatrix.xml
- plotFingerprint.xml
- bamCoverage.xml
- computeMatrixOperations.xml
- plotCorrelation.xml
- alignmentSieve.xml
- correctGCBias.xml

Generated with Planemo.