### PR TITLE
Add container mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:96e86af9351a06c450f266035ca0e37f88ee8189.

### DIFF
--- a/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:96e86af9351a06c450f266035ca0e37f88ee8189-0.tsv
+++ b/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:96e86af9351a06c450f266035ca0e37f88ee8189-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hicexplorer=3.4.2,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:96e86af9351a06c450f266035ca0e37f88ee8189

**Packages**:
- hicexplorer=3.4.2
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- hicBuildMatrix.xml

Generated with Planemo.