### PR TITLE
Add container mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:bf21b66a687d5ebd7ccfacb3868656a1fc7f8bba.

### DIFF
--- a/combinations/mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:bf21b66a687d5ebd7ccfacb3868656a1fc7f8bba-0.tsv
+++ b/combinations/mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:bf21b66a687d5ebd7ccfacb3868656a1fc7f8bba-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tar=1.32,snippy=4.5.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:bf21b66a687d5ebd7ccfacb3868656a1fc7f8bba

**Packages**:
- tar=1.32
- snippy=4.5.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- snippy-core.xml
- snippy_clean_full_aln.xml
- snippy.xml

Generated with Planemo.