### PR TITLE
Add container python:2.7.16.

### DIFF
--- a/combinations/python:2.7.16-0.tsv
+++ b/combinations/python:2.7.16-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=2.7.16	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: python:2.7.16

**Packages**:
- python=2.7.16
Base Image:bgruening/busybox-bash:0.1

**For** :
- convert_objects_to_image.xml
- common.xml
- measure_texture.xml
- export_to_spreadsheet.xml
- measure_image_quality.xml
- identify_primary_objects.xml
- measure_object_intensity.xml
- measure_granularity.xml
- save_images.xml
- measure_image_intensity.xml
- enhance_or_suppress_features.xml
- relate_objects.xml
- measure_object_size_shape.xml
- display_data_on_image.xml
- measure_image_area_occupied.xml
- gray_to_color.xml
- mask_image.xml

Generated with Planemo.