### PR TITLE
Add container mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:76372e2369774b6dbaa30779e0f075127e335d57.

### DIFF
--- a/combinations/mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:76372e2369774b6dbaa30779e0f075127e335d57-0.tsv
+++ b/combinations/mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:76372e2369774b6dbaa30779e0f075127e335d57-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pillow=4.0.0,scikit-learn=0.18.1,tifffile=0.15.1,numpy=1.12,scikit-image=0.14.2	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:76372e2369774b6dbaa30779e0f075127e335d57

**Packages**:
- pillow=4.0.0
- scikit-learn=0.18.1
- tifffile=0.15.1
- numpy=1.12
- scikit-image=0.14.2
Base Image:bgruening/busybox-bash:0.1

**For** :
- color-deconvolution.xml

Generated with Planemo.