### PR TITLE
Add container mulled-v2-14c7cd348d2c9b6e226f62affb265340dec806db:a49143c3946c76264194e3405c3c5adcfe534460.

### DIFF
--- a/combinations/mulled-v2-14c7cd348d2c9b6e226f62affb265340dec806db:a49143c3946c76264194e3405c3c5adcfe534460-0.tsv
+++ b/combinations/mulled-v2-14c7cd348d2c9b6e226f62affb265340dec806db:a49143c3946c76264194e3405c3c5adcfe534460-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+lastz=1.02.00,bx-python=0.7.2,lastz=1.0.2	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-14c7cd348d2c9b6e226f62affb265340dec806db:a49143c3946c76264194e3405c3c5adcfe534460

**Packages**:
- lastz=1.02.00
- bx-python=0.7.2
- lastz=1.0.2
Base Image:bgruening/busybox-bash:0.1

**For** :
- lastz_wrapper.xml

Generated with Planemo.