### PR TITLE
Add container mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:96e86af9351a06c450f266035ca0e37f88ee8189.

### DIFF
--- a/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:96e86af9351a06c450f266035ca0e37f88ee8189-0.tsv
+++ b/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:96e86af9351a06c450f266035ca0e37f88ee8189-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,deeptools=3.4.2	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:96e86af9351a06c450f266035ca0e37f88ee8189

**Packages**:
- samtools=1.9
- deeptools=3.4.2
Base Image:bgruening/busybox-bash:0.1

**For** :
- plotEnrichment.xml
- computeGCBias.xml
- plotPCA.xml
- bamPEFragmentSize.xml
- multiBamSummary.xml
- estimateReadFiltering.xml
- bigwigCompare.xml
- plotCoverage.xml
- multiBigwigSummary.xml
- plotHeatmap.xml
- bamCompare.xml
- plotProfiler.xml
- computeMatrix.xml
- plotFingerprint.xml
- bamCoverage.xml
- computeMatrixOperations.xml
- plotCorrelation.xml
- alignmentSieve.xml
- correctGCBias.xml

Generated with Planemo.