### PR TITLE
Add container mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:e97f6fc3ff91e3e8cdcf301992aa31a5f91b1712.

### DIFF
--- a/combinations/mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:e97f6fc3ff91e3e8cdcf301992aa31a5f91b1712-0.tsv
+++ b/combinations/mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:e97f6fc3ff91e3e8cdcf301992aa31a5f91b1712-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyyaml=5.1.2,maxquant=1.6.10.43,python=3.7,tar=1.32,r-ptxqc=0.92.6	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:e97f6fc3ff91e3e8cdcf301992aa31a5f91b1712

**Packages**:
- pyyaml=5.1.2
- maxquant=1.6.10.43
- python=3.7
- tar=1.32
- r-ptxqc=0.92.6
Base Image:bgruening/busybox-bash:0.1

**For** :
- maxquant.xml
- maxquant_mqpar.xml

Generated with Planemo.