### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:e56330e2963346b9e6e4d21c60b77b73fdbb3a4a.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:e56330e2963346b9e6e4d21c60b77b73fdbb3a4a-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:e56330e2963346b9e6e4d21c60b77b73fdbb3a4a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasta3=36.3.8,mafft=7.455	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:e56330e2963346b9e6e4d21c60b77b73fdbb3a4a

**Packages**:
- fasta3=36.3.8
- mafft=7.455
Base Image:bgruening/busybox-bash:0.1

**For** :
- mafft-add.xml
- mafft.xml

Generated with Planemo.