### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:a7a123d5768b4790322f055e44f6504b910dbaed.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:a7a123d5768b4790322f055e44f6504b910dbaed-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:a7a123d5768b4790322f055e44f6504b910dbaed-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasta3=36.3.8,mafft=7.464	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:a7a123d5768b4790322f055e44f6504b910dbaed

**Packages**:
- fasta3=36.3.8
- mafft=7.464
Base Image:bgruening/busybox-bash:0.1

**For** :
- mafft-add.xml
- mafft.xml

Generated with Planemo.