### PR TITLE
Add container mulled-v2-21a090130f7dc301e7f961cd22f0cd8c731ad539:52d9d0aefaf6d6a04541c21da1520f1242367a60.

### DIFF
--- a/combinations/mulled-v2-21a090130f7dc301e7f961cd22f0cd8c731ad539:52d9d0aefaf6d6a04541c21da1520f1242367a60-0.tsv
+++ b/combinations/mulled-v2-21a090130f7dc301e7f961cd22f0cd8c731ad539:52d9d0aefaf6d6a04541c21da1520f1242367a60-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.6.1,bioconductor-cardinal=2.4.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-21a090130f7dc301e7f961cd22f0cd8c731ad539:52d9d0aefaf6d6a04541c21da1520f1242367a60

**Packages**:
- r-base=3.6.1
- bioconductor-cardinal=2.4.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- data_exporter.xml

Generated with Planemo.