### PR TITLE
Add container mulled-v2-25edd710e800f87fa32d8442d0d2b8bde68e73cb:41b8d86c98873dd104821dfc9f7453469a003a86.

### DIFF
--- a/combinations/mulled-v2-25edd710e800f87fa32d8442d0d2b8bde68e73cb:41b8d86c98873dd104821dfc9f7453469a003a86-0.tsv
+++ b/combinations/mulled-v2-25edd710e800f87fa32d8442d0d2b8bde68e73cb:41b8d86c98873dd104821dfc9f7453469a003a86-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.6.1,bioconductor-cardinal=2.4.0,r-gridextra=2.3	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-25edd710e800f87fa32d8442d0d2b8bde68e73cb:41b8d86c98873dd104821dfc9f7453469a003a86

**Packages**:
- r-base=3.6.1
- bioconductor-cardinal=2.4.0
- r-gridextra=2.3
Base Image:bgruening/busybox-bash:0.1

**For** :
- mz_images.xml
- segmentation.xml

Generated with Planemo.