### PR TITLE
Add container mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:b8db32403495d47728d6cb36466eb47615fb8925.

### DIFF
--- a/combinations/mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:b8db32403495d47728d6cb36466eb47615fb8925-0.tsv
+++ b/combinations/mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:b8db32403495d47728d6cb36466eb47615fb8925-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.70,circos-tools=0.23,pybigwig=0.3.13,circos=0.69.8,python=2.7,grep=3.4,bcbiogff=0.6.4,tar=1.29,gawk=5.1.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:b8db32403495d47728d6cb36466eb47615fb8925

**Packages**:
- biopython=1.70
- circos-tools=0.23
- pybigwig=0.3.13
- circos=0.69.8
- python=2.7
- grep=3.4
- bcbiogff=0.6.4
- tar=1.29
- gawk=5.1.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- tiles-from-interval.xml
- gc_skew.xml
- text-from-interval.xml
- alignments-to-links.xml
- stack-histogram.xml
- binlinks.xml
- scatter-from-wiggle.xml
- resample.xml
- circos.xml
- tableviewer.xml
- bundlelinks.xml

Generated with Planemo.