### PR TITLE
Add container mulled-v2-a4c30dc1a2dfc3f31070c6a8acc1c627f7a22916:3255c0a2d99e5718efb40269116cc85ded9b1200.

### DIFF
--- a/combinations/mulled-v2-a4c30dc1a2dfc3f31070c6a8acc1c627f7a22916:3255c0a2d99e5718efb40269116cc85ded9b1200-0.tsv
+++ b/combinations/mulled-v2-a4c30dc1a2dfc3f31070c6a8acc1c627f7a22916:3255c0a2d99e5718efb40269116cc85ded9b1200-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tabix=0.2.5,samtools=1.9,gatk4=4.1.7.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-a4c30dc1a2dfc3f31070c6a8acc1c627f7a22916:3255c0a2d99e5718efb40269116cc85ded9b1200

**Packages**:
- tabix=0.2.5
- samtools=1.9
- gatk4=4.1.7.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- gatk4_Mutect2.xml

Generated with Planemo.