### PR TITLE
Add container mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:7913e8455b4060e2e37926381ccd251ecd5c4618.

### DIFF
--- a/combinations/mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:7913e8455b4060e2e37926381ccd251ecd5c4618-0.tsv
+++ b/combinations/mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:7913e8455b4060e2e37926381ccd251ecd5c4618-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xarray=0.15.1,shapely=1.7.0,geopandas=0.7.0,python=3,netcdf4=1.5.3	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:7913e8455b4060e2e37926381ccd251ecd5c4618

**Packages**:
- xarray=0.15.1
- shapely=1.7.0
- geopandas=0.7.0
- python=3
- netcdf4=1.5.3
Base Image:bgruening/busybox-bash:0.1

**For** :
- xarray_metadata_info.xml
- xarray_select.xml

Generated with Planemo.