### PR TITLE
Add container mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:44af5695f993427dad053c85fa52277061e040ba.

### DIFF
--- a/combinations/mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:44af5695f993427dad053c85fa52277061e040ba-0.tsv
+++ b/combinations/mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:44af5695f993427dad053c85fa52277061e040ba-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-biobase=2.44.0,r-cluster=2.0.8,trinity=2.9.1,r-fastcluster=1.1.25	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8b08855c91031463faca8585074a73ea994b4cda:44af5695f993427dad053c85fa52277061e040ba

**Packages**:
- bioconductor-biobase=2.44.0
- r-cluster=2.0.8
- trinity=2.9.1
- r-fastcluster=1.1.25
Base Image:bgruening/busybox-bash:0.1

**For** :
- define_clusters_by_cutting_tree.xml

Generated with Planemo.