### PR TITLE
Add container mulled-v2-c74236c06fa8ef2a42a5de56b499beb2d6858c2b.

### DIFF
--- a/combinations/mulled-v2-c74236c06fa8ef2a42a5de56b499beb2d6858c2b-0.tsv
+++ b/combinations/mulled-v2-c74236c06fa8ef2a42a5de56b499beb2d6858c2b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-geometadb,bioconductor-affy,r-jsonlite,r-dplyr,bioconductor-geoquery,bioconductor-biobase,bioconductor-limma,r-optparse	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c74236c06fa8ef2a42a5de56b499beb2d6858c2b

**Packages**:
- bioconductor-geometadb
- bioconductor-affy
- r-jsonlite
- r-dplyr
- bioconductor-geoquery
- bioconductor-biobase
- bioconductor-limma
- r-optparse
Base Image:bioconda/extended-base-image:latest

**For** :
- Analyse.xml

Generated with Planemo.