### PR TITLE
Add container mulled-v2-9f42852121f611cb4daa9e9aa155f28f18e241fe:4772…

### DIFF
--- a/combinations/mulled-v2-9f42852121f611cb4daa9e9aa155f28f18e241fe:4772f92039dda74c54152b92873730edc204f530-0.tsv
+++ b/combinations/mulled-v2-9f42852121f611cb4daa9e9aa155f28f18e241fe:4772f92039dda74c54152b92873730edc204f530-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-annaffy,r-venndiagram,bioconductor-org.hs.eg.db,r-upsetr=1.3.3,bioconductor-geoquery,r-optparse,bioconductor-affy,r-metama	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
…f92039dda74c54152b92873730edc204f530.

**Hash**: mulled-v2-9f42852121f611cb4daa9e9aa155f28f18e241fe:4772f92039dda74c54152b92873730edc204f530

**Packages**:
- bioconductor-annaffy
- r-venndiagram
- bioconductor-org.hs.eg.db
- r-upsetr=1.3.3
- bioconductor-geoquery
- r-optparse
- bioconductor-affy
- r-metama
Base Image:bioconda/extended-base-image:latest

**For** :
- MetaMA.xml

Generated with Planemo.