### PR TITLE
Add container mulled-v2-f324756a1c6b87e240fc14565b281c35640bd3aa:357520601968ea596f1e952b43e7ad4820f81193.

### DIFF
--- a/combinations/mulled-v2-f324756a1c6b87e240fc14565b281c35640bd3aa:357520601968ea596f1e952b43e7ad4820f81193-0.tsv
+++ b/combinations/mulled-v2-f324756a1c6b87e240fc14565b281c35640bd3aa:357520601968ea596f1e952b43e7ad4820f81193-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl-bioperl=1.7.2,gnuplot=5.2.7,python=3.7.6	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-f324756a1c6b87e240fc14565b281c35640bd3aa:357520601968ea596f1e952b43e7ad4820f81193

**Packages**:
- perl-bioperl=1.7.2
- gnuplot=5.2.7
- python=3.7.6
Base Image:bgruening/busybox-bash:0.1

**For** :
- assembly_stats_txt.xml

Generated with Planemo.