### PR TITLE
Add container mulled-v2-fd78fa31940ea6c432ebff010d72aeae4a19c1f6:8619acfd0f8a8ffd9a3f7aa405236ae1f94e49aa.

### DIFF
--- a/combinations/mulled-v2-fd78fa31940ea6c432ebff010d72aeae4a19c1f6:8619acfd0f8a8ffd9a3f7aa405236ae1f94e49aa-0.tsv
+++ b/combinations/mulled-v2-fd78fa31940ea6c432ebff010d72aeae4a19c1f6:8619acfd0f8a8ffd9a3f7aa405236ae1f94e49aa-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,lofreq=2.1.4	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-fd78fa31940ea6c432ebff010d72aeae4a19c1f6:8619acfd0f8a8ffd9a3f7aa405236ae1f94e49aa

**Packages**:
- samtools=1.9
- lofreq=2.1.4
Base Image:bgruening/busybox-bash:0.1

**For** :
- lofreq_viterbi.xml

Generated with Planemo.