### PR TITLE
Add container mulled-v2-026bae89b0e994186fcc66a9b5764a979e0142b2:8200781ebcfd9fec1f5706d5cc43e9bc33072963.

### DIFF
--- a/combinations/mulled-v2-026bae89b0e994186fcc66a9b5764a979e0142b2:8200781ebcfd9fec1f5706d5cc43e9bc33072963-0.tsv
+++ b/combinations/mulled-v2-026bae89b0e994186fcc66a9b5764a979e0142b2:8200781ebcfd9fec1f5706d5cc43e9bc33072963-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.14,sed=4.4,python=2.7.13	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-026bae89b0e994186fcc66a9b5764a979e0142b2:8200781ebcfd9fec1f5706d5cc43e9bc33072963

**Packages**:
- numpy=1.14
- sed=4.4
- python=2.7.13
Base Image:bgruening/busybox-bash:0.1

**For** :
- column_maker.xml

Generated with Planemo.