### PR TITLE
Add container mulled-v2-2a8b7954e8e428b297b202bdaab247a1d328c4cd:03b8050afc23a77ebef5009bf4b497ad445cafda.

### DIFF
--- a/combinations/mulled-v2-2a8b7954e8e428b297b202bdaab247a1d328c4cd:03b8050afc23a77ebef5009bf4b497ad445cafda-0.tsv
+++ b/combinations/mulled-v2-2a8b7954e8e428b297b202bdaab247a1d328c4cd:03b8050afc23a77ebef5009bf4b497ad445cafda-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rust-ncbitaxonomy=1.0.5,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-2a8b7954e8e428b297b202bdaab247a1d328c4cd:03b8050afc23a77ebef5009bf4b497ad445cafda

**Packages**:
- rust-ncbitaxonomy=1.0.5
- python=3.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- ncbi_taxonomy_sqlite_builder.xml

Generated with Planemo.