### PR TITLE
Bwa with samtools container updates

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -1,4 +1,6 @@
 #targets	base_image	image_build
+bwa=0.7.17,samtools=1.10	bgruening/busybox-bash:0.1	0
+bwakit=0.7.17.dev1,samtools=1.10	bgruening/busybox-bash:0.1	0
 bwa=0.7.15,samtools=1.3.1	bgruening/busybox-bash:0.1	0
 bwa=0.7.17,samtools=1.6	bgruening/busybox-bash:0.1	0
 blast=2.6.0,diamond=0.8.9,megahit=1.1.1,pauda=1.0.1,spades=3.9.0,velvet=1.2.10	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
samtools 1.10 Fixes some memory leaks which is very nice on HPC environments where memory needs to be reserved. (Jobs get killed if they go above this limit). 
Since sorting the BAM file as it is produced by BWA using a pipe is most efficient I request these containers.