### PR TITLE
Add container mulled-v2-75464d4ba6517db7bcb979112a547460bfb2ea49:fd88e1332cae65cc6868f99b270277c2d63882e5.

### DIFF
--- a/combinations/mulled-v2-75464d4ba6517db7bcb979112a547460bfb2ea49:fd88e1332cae65cc6868f99b270277c2d63882e5-0.tsv
+++ b/combinations/mulled-v2-75464d4ba6517db7bcb979112a547460bfb2ea49:fd88e1332cae65cc6868f99b270277c2d63882e5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-argparse=1.0.4,fonts-conda-ecosystem=1,r-base=3.4.1,bioconductor-cummerbund=2.16.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-75464d4ba6517db7bcb979112a547460bfb2ea49:fd88e1332cae65cc6868f99b270277c2d63882e5

**Packages**:
- r-argparse=1.0.4
- fonts-conda-ecosystem=1
- r-base=3.4.1
- bioconductor-cummerbund=2.16.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- cummeRbund.xml

Generated with Planemo.