### PR TITLE
Add container mulled-v2-59f3e016c86a830eb76f8b359d188314ea1b1329:9a87f27d1c98c9ed072feca9e4c1aa4f27965696.

### DIFF
--- a/combinations/mulled-v2-59f3e016c86a830eb76f8b359d188314ea1b1329:9a87f27d1c98c9ed072feca9e4c1aa4f27965696-0.tsv
+++ b/combinations/mulled-v2-59f3e016c86a830eb76f8b359d188314ea1b1329:9a87f27d1c98c9ed072feca9e4c1aa4f27965696-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-wavethresh=4.6.8,r-waveslim=1.7.5	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-59f3e016c86a830eb76f8b359d188314ea1b1329:9a87f27d1c98c9ed072feca9e4c1aa4f27965696

**Packages**:
- r-wavethresh=4.6.8
- r-waveslim=1.7.5
Base Image:bgruening/busybox-bash:0.1

**For** :
- execute_dwt_cor_aVa_perClass.xml
- execute_dwt_var_perClass.xml
- execute_dwt_IvC_all.xml
- execute_dwt_cor_aVb_all.xml

Generated with Planemo.