### PR TITLE
Create hisat2 + samtools 1.10 container.

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -1,4 +1,5 @@
 #targets	base_image	image_build
+hisat2=2.2.0,samtools=1.10	bgruening/busybox-bash:0.1	0
 bwa=0.7.17,samtools=1.10	bgruening/busybox-bash:0.1	0
 bwakit=0.7.17.dev1,samtools=1.10	bgruening/busybox-bash:0.1	0
 bwa=0.7.15,samtools=1.3.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
samtools 1.10 fixes some memory leaks which make it reliably use the memory specified on the command line. This is necessary on SLURM clusters where the amount of used memory needs to be specified beforehand.