### PR TITLE
Add container mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:61e9390a09e085e5ad307991770af8a3294df518.

### DIFF
--- a/combinations/mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:61e9390a09e085e5ad307991770af8a3294df518-0.tsv
+++ b/combinations/mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:61e9390a09e085e5ad307991770af8a3294df518-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.7,stacks=2.53,findutils=4.6.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:61e9390a09e085e5ad307991770af8a3294df518

**Packages**:
- python=3.7
- stacks=2.53
- findutils=4.6.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- stacks_sstacks.xml
- stacks_refmap.xml
- stacks_shortreads.xml
- stacks_ustacks.xml
- stacks_denovomap.xml
- stacks_populations.xml
- stacks_cstacks.xml
- stacks_kmerfilter.xml
- stacks_clonefilter.xml
- stacks_tsv2bam.xml
- stacks_procrad.xml

Generated with Planemo.