### PR TITLE
Add container mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:12f898e0ebde581d73a96a4c0c7c0f613efb4141.

### DIFF
--- a/combinations/mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:12f898e0ebde581d73a96a4c0c7c0f613efb4141-0.tsv
+++ b/combinations/mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:12f898e0ebde581d73a96a4c0c7c0f613efb4141-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rust-ncbitaxonomy=1.0.7,spaln=2.4.03,python=3.8	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:12f898e0ebde581d73a96a4c0c7c0f613efb4141

**Packages**:
- rust-ncbitaxonomy=1.0.7
- spaln=2.4.03
- python=3.8
Base Image:bgruening/busybox-bash:0.1

**For** :
- list_spaln_tables.xml

Generated with Planemo.