### PR TITLE
Add container mulled-v2-22212648fde6bb0d7bedcdf2c29f0f2119069f70:10702b252ed6262f9af26483d333d1d3852f49f1.

### DIFF
--- a/combinations/mulled-v2-22212648fde6bb0d7bedcdf2c29f0f2119069f70:10702b252ed6262f9af26483d333d1d3852f49f1-0.tsv
+++ b/combinations/mulled-v2-22212648fde6bb0d7bedcdf2c29f0f2119069f70:10702b252ed6262f9af26483d333d1d3852f49f1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+autodock-vina=1.1.2,parallel=20200722,openbabel=3.1.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-22212648fde6bb0d7bedcdf2c29f0f2119069f70:10702b252ed6262f9af26483d333d1d3852f49f1

**Packages**:
- autodock-vina=1.1.2
- parallel=20200722
- openbabel=3.1.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- docking.xml

Generated with Planemo.