### PR TITLE
Add container mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:9899436ddb00095f3470f46fbffcca78775be8ad.

### DIFF
--- a/combinations/mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:9899436ddb00095f3470f46fbffcca78775be8ad-0.tsv
+++ b/combinations/mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:9899436ddb00095f3470f46fbffcca78775be8ad-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rdkit=2020.03.4,scipy=1.3.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-4f8129ed432c96261a8f255dbcc610e706d3a0ab:9899436ddb00095f3470f46fbffcca78775be8ad

**Packages**:
- rdkit=2020.03.4
- scipy=1.3.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- sucos_cluster.xml

Generated with Planemo.