### PR TITLE
Add container mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:180dbb150de631462bb999864d420672173ddf30.

### DIFF
--- a/combinations/mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:180dbb150de631462bb999864d420672173ddf30-0.tsv
+++ b/combinations/mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:180dbb150de631462bb999864d420672173ddf30-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,star=2.7.5b	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:180dbb150de631462bb999864d420672173ddf30

**Packages**:
- samtools=1.9
- star=2.7.5b
Base Image:bgruening/busybox-bash:0.1

**For** :
- rg_rnaStarSolo.xml
- rg_rnaStar.xml

Generated with Planemo.