### PR TITLE
Add container mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:64a67115bff949d83aefcadda0db68d72a90be26.

### DIFF
--- a/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:64a67115bff949d83aefcadda0db68d72a90be26-0.tsv
+++ b/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:64a67115bff949d83aefcadda0db68d72a90be26-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,star=2.7.5b,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:64a67115bff949d83aefcadda0db68d72a90be26

**Packages**:
- samtools=1.9
- star=2.7.5b
- python=3.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- rna_star_index_builder.xml

Generated with Planemo.