### PR TITLE
Add container with whatshap and tabix

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -67,3 +67,4 @@ bedtools=2.29.0,bioconductor-biocparallel=1.18.0,bioconductor-deseq2=1.24.0,bioc
 r-readr=1.3.1
 ambertools=20.4 
 picard=2.22.8--0,bwa=0.7.17	bgruening/busybox-bash:0.1	0
+whatshap=1.0--py37h9a982cc_1,tabix=0.2.6--ha92aebf_0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
whatshap does not index it's output VCF files by default, but doest require tabix indexed VCF files as intput. 

Therefore, adding a container with both whatshap and tabix will make it easier to work with whatshap.