### PR TITLE
Add container mulled-v2-5b53309c4f8449fec3814df567dbf53f97b59e8e:212a36e3118912bba1d51d7df43493e3fd7c935d.

### DIFF
--- a/combinations/mulled-v2-5b53309c4f8449fec3814df567dbf53f97b59e8e:212a36e3118912bba1d51d7df43493e3fd7c935d-0.tsv
+++ b/combinations/mulled-v2-5b53309c4f8449fec3814df567dbf53f97b59e8e:212a36e3118912bba1d51d7df43493e3fd7c935d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trinotate=3.2.1,gnu-wget=1.18	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-5b53309c4f8449fec3814df567dbf53f97b59e8e:212a36e3118912bba1d51d7df43493e3fd7c935d

**Packages**:
- trinotate=3.2.1
- gnu-wget=1.18
Base Image:bgruening/busybox-bash:0.1

**For** :
- trinotate.xml

Generated with Planemo.