### PR TITLE
Add container mulled-v2-ae5a35aee49054fb3942c81b133130890c0a2ea7:37a57b25f908e0d6a887c35c376a2bdb6fb69ece.

### DIFF
--- a/combinations/mulled-v2-ae5a35aee49054fb3942c81b133130890c0a2ea7:37a57b25f908e0d6a887c35c376a2bdb6fb69ece-0.tsv
+++ b/combinations/mulled-v2-ae5a35aee49054fb3942c81b133130890c0a2ea7:37a57b25f908e0d6a887c35c376a2bdb6fb69ece-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+busco=4.1.2,tar=1.32	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-ae5a35aee49054fb3942c81b133130890c0a2ea7:37a57b25f908e0d6a887c35c376a2bdb6fb69ece

**Packages**:
- busco=4.1.2
- tar=1.32
Base Image:bgruening/busybox-bash:0.1

**For** :
- busco.xml

Generated with Planemo.