### PR TITLE
Add container mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:8d42fa001d0c9c6c6feae938146c2199692e0aab.

### DIFF
--- a/combinations/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:8d42fa001d0c9c6c6feae938146c2199692e0aab-0.tsv
+++ b/combinations/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:8d42fa001d0c9c6c6feae938146c2199692e0aab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pigz=2.3.4,sra-tools=2.10.8	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:8d42fa001d0c9c6c6feae938146c2199692e0aab

**Packages**:
- pigz=2.3.4
- sra-tools=2.10.8
Base Image:bgruening/busybox-bash:0.1

**For** :
- fastq_dump.xml
- fasterq_dump.xml

Generated with Planemo.