### PR TITLE
Add container mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:72218bd2f7aac9561df2645294d087b513d17221.

### DIFF
--- a/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:72218bd2f7aac9561df2645294d087b513d17221-0.tsv
+++ b/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:72218bd2f7aac9561df2645294d087b513d17221-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,biopython=1.72,jbrowse=1.16.9,bcbiogff=0.6.4,findutils=4.6.0,python=2.7,tabix=0.2.6,pyyaml=3.13	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:72218bd2f7aac9561df2645294d087b513d17221

**Packages**:
- samtools=1.9
- biopython=1.72
- jbrowse=1.16.9
- bcbiogff=0.6.4
- findutils=4.6.0
- python=2.7
- tabix=0.2.6
- pyyaml=3.13
Base Image:bgruening/busybox-bash:0.1

**For** :
- jbrowse.xml
- jbrowse-fromdir.xml

Generated with Planemo.