### PR TITLE
Add container mulled-v2-5af27569c440c8c304d224cb5b3080059e846f33:213c741b65620209822f89d79636823b0522ff2f.

### DIFF
--- a/combinations/mulled-v2-5af27569c440c8c304d224cb5b3080059e846f33:213c741b65620209822f89d79636823b0522ff2f-0.tsv
+++ b/combinations/mulled-v2-5af27569c440c8c304d224cb5b3080059e846f33:213c741b65620209822f89d79636823b0522ff2f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl-pod-usage=1.69,perl-getopt-long=2.50	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-5af27569c440c8c304d224cb5b3080059e846f33:213c741b65620209822f89d79636823b0522ff2f

**Packages**:
- perl-pod-usage=1.69
- perl-getopt-long=2.50
Base Image:bgruening/busybox-bash:0.1

**For** :
- bundle_collection.xml

Generated with Planemo.