### PR TITLE
Add container mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:54593588875b845d6aa73ce48a35fd89e5d8d2b9.

### DIFF
--- a/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:54593588875b845d6aa73ce48a35fd89e5d8d2b9-0.tsv
+++ b/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:54593588875b845d6aa73ce48a35fd89e5d8d2b9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+vardict-java=1.7.0,samtools=1.10,gawk=5.0.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:54593588875b845d6aa73ce48a35fd89e5d8d2b9

**Packages**:
- vardict-java=1.7.0
- samtools=1.10
- gawk=5.0.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- vardict.xml

Generated with Planemo.