### PR TITLE
Add container mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:a45c6b062fdd7d88a1a1ffc5972a5a7a41e0b9db.

### DIFF
--- a/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:a45c6b062fdd7d88a1a1ffc5972a5a7a41e0b9db-0.tsv
+++ b/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:a45c6b062fdd7d88a1a1ffc5972a5a7a41e0b9db-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.10,gawk=5.0.1,vardict-java=1.8.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:a45c6b062fdd7d88a1a1ffc5972a5a7a41e0b9db

**Packages**:
- samtools=1.10
- gawk=5.0.1
- vardict-java=1.8.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- vardict.xml

Generated with Planemo.