### PR TITLE
Add container mulled-v2-557813cb01abcc9c2a8cf25415af954884af9f02:11d09f11a83a00be923125bef2b6e09ea46c3abb.

### DIFF
--- a/combinations/mulled-v2-557813cb01abcc9c2a8cf25415af954884af9f02:11d09f11a83a00be923125bef2b6e09ea46c3abb-0.tsv
+++ b/combinations/mulled-v2-557813cb01abcc9c2a8cf25415af954884af9f02:11d09f11a83a00be923125bef2b6e09ea46c3abb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+grep=3.4,fiji=20170530	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-557813cb01abcc9c2a8cf25415af954884af9f02:11d09f11a83a00be923125bef2b6e09ea46c3abb

**Packages**:
- grep=3.4
- fiji=20170530
Base Image:bgruening/busybox-bash:0.1

**For** :
- imagej2_binary_to_edm.xml
- imagej2_bunwarpj_align.xml
- imagej2_watershed_binary.xml
- imagej2_bunwarpj_convert_to_raw.xml
- imagej2_math.xml
- imagej2_bunwarpj_raw_transform.xml
- imagej2_analyze_particles_binary.xml
- imagej2_make_binary.xml
- imagej2_adjust_threshold_binary.xml
- imagej2_create_image.xml
- imagej2_bunwarpj_compare_elastic.xml
- imagej2_enhance_contrast.xml
- imagej2_shadows.xml
- imagej2_bunwarpj_adapt_transform.xml
- imagej2_smooth.xml
- imagej2_bunwarpj_compare_raw.xml
- imagej2_noise.xml
- imagej2_analyze_skeleton.xml
- imagej2_sharpen.xml
- imagej2_bunwarpj_compare_elastic_raw.xml
- imagej2_bunwarpj_elastic_transform.xml
- imagej2_bunwarpj_compose_elastic.xml
- imagej2_find_edges.xml
- imagej2_skeletonize3d.xml
- imagej2_find_maxima.xml
- imagej2_bunwarpj_compose_raw_elastic.xml
- imagej2_bunwarpj_compose_raw.xml

Generated with Planemo.