### PR TITLE
Add container mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:5cdab260729918bea603468d389de51e306cf1e2.

### DIFF
--- a/combinations/mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:5cdab260729918bea603468d389de51e306cf1e2-0.tsv
+++ b/combinations/mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:5cdab260729918bea603468d389de51e306cf1e2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-gridextra=2.3,bioconductor-cardinal=2.6.0,r-rcolorbrewer=1.1_2,r-pheatmap=1.0.12,r-ggplot2=3.3.2,r-scales=1.1.1,r-kernsmooth=2.23_17	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:5cdab260729918bea603468d389de51e306cf1e2

**Packages**:
- r-gridextra=2.3
- bioconductor-cardinal=2.6.0
- r-rcolorbrewer=1.1_2
- r-pheatmap=1.0.12
- r-ggplot2=3.3.2
- r-scales=1.1.1
- r-kernsmooth=2.23_17
Base Image:bgruening/busybox-bash:0.1

**For** :
- quality_report.xml

Generated with Planemo.