### PR TITLE
Add container mulled-v2-374b2141964201351e992c411ce6c775efa37626:79dce3d4fa90b38efd7d65327971e78de33ed9bd.

### DIFF
--- a/combinations/mulled-v2-374b2141964201351e992c411ce6c775efa37626:79dce3d4fa90b38efd7d65327971e78de33ed9bd-0.tsv
+++ b/combinations/mulled-v2-374b2141964201351e992c411ce6c775efa37626:79dce3d4fa90b38efd7d65327971e78de33ed9bd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggplot2=3.3.2,bioconductor-cardinal=2.6.0,r-maldiquantforeign=0.12,r-maldiquant=1.19.3	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-374b2141964201351e992c411ce6c775efa37626:79dce3d4fa90b38efd7d65327971e78de33ed9bd

**Packages**:
- r-ggplot2=3.3.2
- bioconductor-cardinal=2.6.0
- r-maldiquantforeign=0.12
- r-maldiquant=1.19.3
Base Image:bgruening/busybox-bash:0.1

**For** :
- combine.xml

Generated with Planemo.