### PR TITLE
Build dupRadar and r-kernsmooth container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -77,3 +77,4 @@ bedtools=2.29.0,pigz=2.3.4
 pandas=0.24.2,pigz=2.3.4
 star=2.7.5b,samtools=1.9,pigz=2.3.4
 umi_tools=1.0.1,samtools=1.1.0
+r-kernsmooth=2.23_17,bioconductor-dupradar=1.18.0	bioconda/extended-base-image:latest	0


### PR DESCRIPTION

Seeing exactly the same error as reported in [this issue](https://github.com/bioconda/bioconda-recipes/issues/8341) with the stand-alone [`dupRadar` Biocontainer](https://quay.io/repository/biocontainers/bioconductor-dupradar). Tested locally with a Conda install on a local script so hopefully should work.