### PR TITLE
Add container mulled-v2-5881dc417dee18fbf3008cffeac9ed704d282aab:38161a37ad5fdb154a7035d393a053861e8e4854. **Hash**: mulled-v2-5881dc417dee18fbf3008cffeac9ed704d282aab:38161a37ad5fdb154a7035d393a053861e8e4854

### DIFF
--- a/combinations/mulled-v2-5881dc417dee18fbf3008cffeac9ed704d282aab:38161a37ad5fdb154a7035d393a053861e8e4854-0.tsv
+++ b/combinations/mulled-v2-5881dc417dee18fbf3008cffeac9ed704d282aab:38161a37ad5fdb154a7035d393a053861e8e4854-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.25,pysam=0.15.4	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Packages**:
- coreutils=8.25
- pysam=0.15.4
Base Image:bgruening/busybox-bash:0.1

**For** :
- vcf_to_vcf_bgzip_converter.xml

Generated with Planemo.