### PR TITLE
Add container mulled-v2-4a4c6f1a296feae9e85bc6e22a340e2e7ac9277e:2060fe06190fbc2caab7e3093bb364f4681cbfef.

### DIFF
--- a/combinations/mulled-v2-4a4c6f1a296feae9e85bc6e22a340e2e7ac9277e:2060fe06190fbc2caab7e3093bb364f4681cbfef-0.tsv
+++ b/combinations/mulled-v2-4a4c6f1a296feae9e85bc6e22a340e2e7ac9277e:2060fe06190fbc2caab7e3093bb364f4681cbfef-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fates-emerald=2.0.1,python=3,binutils=2.35,perl-xml-libxml=2.0132,tar=1.32	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-4a4c6f1a296feae9e85bc6e22a340e2e7ac9277e:2060fe06190fbc2caab7e3093bb364f4681cbfef

**Packages**:
- fates-emerald=2.0.1
- python=3
- binutils=2.35
- perl-xml-libxml=2.0132
- tar=1.32
Base Image:bgruening/busybox-bash:0.1

**For** :
- ctsm-fates.xml

Generated with Planemo.