### PR TITLE
Pin galaxy-tool-util below 20.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies
       run: |
-        python -m pip install requests "galaxy-tool-util>=20.1.0.dev5"
+        python -m pip install requests "galaxy-tool-util>=20.1.0.dev5,<20.5.0.dev1"
     - run: docker --version
     - run: docker info
     - name: Build images


### PR DESCRIPTION
As is done in .travis.yml. Looks like builds are broken with newer galaxy-tool-util versions. One difference in the logs is https://github.com/galaxyproject/galaxy/pull/9223/commits/71a70ea1f12cca48c33ee5569bd74035f96376f7