### PR TITLE
Add container mulled-v2-15783676606ae508c2f799c8201037c26dbe8a73:20ce71cc880ec5dc5ef1c22efc13fd3c3e93b99f.

### DIFF
--- a/combinations/mulled-v2-15783676606ae508c2f799c8201037c26dbe8a73:20ce71cc880ec5dc5ef1c22efc13fd3c3e93b99f-0.tsv
+++ b/combinations/mulled-v2-15783676606ae508c2f799c8201037c26dbe8a73:20ce71cc880ec5dc5ef1c22efc13fd3c3e93b99f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+subread=2.0.1,samtools=1.11,coreutils=8.31	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-15783676606ae508c2f799c8201037c26dbe8a73:20ce71cc880ec5dc5ef1c22efc13fd3c3e93b99f

**Packages**:
- subread=2.0.1
- samtools=1.11
- coreutils=8.31
Base Image:bgruening/busybox-bash:0.1

**For** :
- featurecounts.xml

Generated with Planemo.