### PR TITLE
Add container mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:00c95db20c3bd2391334c535e6c956e41e496b3f.

### DIFF
--- a/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:00c95db20c3bd2391334c535e6c956e41e496b3f-0.tsv
+++ b/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:00c95db20c3bd2391334c535e6c956e41e496b3f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+star=2.7.7a,python=3.7,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:00c95db20c3bd2391334c535e6c956e41e496b3f

**Packages**:
- star=2.7.7a
- python=3.7
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- rna_star_index_builder.xml

Generated with Planemo.