### PR TITLE
Add container mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:5b17aa8c6dbf081e888f6482f3d662a79fe607c7.

### DIFF
--- a/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:5b17aa8c6dbf081e888f6482f3d662a79fe607c7-0.tsv
+++ b/combinations/mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:5b17aa8c6dbf081e888f6482f3d662a79fe607c7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcbiogff=0.6.4,python=2.7,jbrowse=1.16.10,tabix=0.2.6,samtools=1.9,findutils=4.6.0,biopython=1.72,pyyaml=3.13	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-de19c44eeee083c68bc61ea8799d8cb400736db6:5b17aa8c6dbf081e888f6482f3d662a79fe607c7

**Packages**:
- bcbiogff=0.6.4
- python=2.7
- jbrowse=1.16.10
- tabix=0.2.6
- samtools=1.9
- findutils=4.6.0
- biopython=1.72
- pyyaml=3.13
Base Image:bgruening/busybox-bash:0.1

**For** :
- jbrowse.xml
- jbrowse-fromdir.xml

Generated with Planemo.