### PR TITLE
Add container mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:26fa90e5bca490ccf5ba8db752fa36fd5834ef00.

### DIFF
--- a/combinations/mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:26fa90e5bca490ccf5ba8db752fa36fd5834ef00-0.tsv
+++ b/combinations/mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:26fa90e5bca490ccf5ba8db752fa36fd5834ef00-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hisat2=2.1.0,samtools=1.11,seqtk=1.3	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:26fa90e5bca490ccf5ba8db752fa36fd5834ef00

**Packages**:
- hisat2=2.1.0
- samtools=1.11
- seqtk=1.3
Base Image:bgruening/busybox-bash:0.1

**For** :
- hisat2.xml

Generated with Planemo.