### PR TITLE
Add container mulled-v2-9a0f70c00478459c29ce5b80db6563c0b0b77d0b:e4e5563123a64339deeadd468693d49d42f7f284.

### DIFF
--- a/combinations/mulled-v2-9a0f70c00478459c29ce5b80db6563c0b0b77d0b:e4e5563123a64339deeadd468693d49d42f7f284-0.tsv
+++ b/combinations/mulled-v2-9a0f70c00478459c29ce5b80db6563c0b0b77d0b:e4e5563123a64339deeadd468693d49d42f7f284-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.15.2,pandas=0.23.4,tifffile=0.15.1,scipy=1.1.0,scikit-image=0.14.2	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-9a0f70c00478459c29ce5b80db6563c0b0b77d0b:e4e5563123a64339deeadd468693d49d42f7f284

**Packages**:
- numpy=1.15.2
- pandas=0.23.4
- tifffile=0.15.1
- scipy=1.1.0
- scikit-image=0.14.2
Base Image:bgruening/busybox-bash:0.1

**For** :
- image_registration_affine.xml

Generated with Planemo.