### PR TITLE
Add container mulled-v2-f18b9be9ab767652d90b81d63f34d69e7b88ee8b:43ec1ded47948647bb12d194636a7ef7a375d08b.

### DIFF
--- a/combinations/mulled-v2-f18b9be9ab767652d90b81d63f34d69e7b88ee8b:43ec1ded47948647bb12d194636a7ef7a375d08b-0.tsv
+++ b/combinations/mulled-v2-f18b9be9ab767652d90b81d63f34d69e7b88ee8b:43ec1ded47948647bb12d194636a7ef7a375d08b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+quast=3.1,python=2.7.10,perl=5.18.1	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f18b9be9ab767652d90b81d63f34d69e7b88ee8b:43ec1ded47948647bb12d194636a7ef7a375d08b

**Packages**:
- quast=3.1
- python=2.7.10
- perl=5.18.1
Base Image:bioconda/extended-base-image:latest

**For** :
- quast.xml

Generated with Planemo.