### PR TITLE
Add container mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:9025eb5ddfcb91c22600aa9c2a545dd56db4881b.

### DIFF
--- a/combinations/mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:9025eb5ddfcb91c22600aa9c2a545dd56db4881b-0.tsv
+++ b/combinations/mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:9025eb5ddfcb91c22600aa9c2a545dd56db4881b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.3.1,numpy=1.11.2=py27_0,lumpy-sv=0.2.13	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:9025eb5ddfcb91c22600aa9c2a545dd56db4881b

**Packages**:
- samtools=1.3.1
- numpy=1.11.2=py27_0
- lumpy-sv=0.2.13
Base Image:bgruening/busybox-bash:0.1

**For** :
- lumpy.xml

Generated with Planemo.