### PR TITLE
Add container mulled-v2-7a11736824cbf4811b6a68bec81db44b9e12604b:ccde748295676bd5cf68563245a1dcd10b9661e3.

### DIFF
--- a/combinations/mulled-v2-7a11736824cbf4811b6a68bec81db44b9e12604b:ccde748295676bd5cf68563245a1dcd10b9661e3-0.tsv
+++ b/combinations/mulled-v2-7a11736824cbf4811b6a68bec81db44b9e12604b:ccde748295676bd5cf68563245a1dcd10b9661e3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9=h10a08f8_12,r-lattice=0.20_38=r36hcdcec82_1002,bowtie=1.2.0,r-optparse=1.6.4=r36h6115d3f_0,pysam=0.15.3=py27hda2845c_1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-7a11736824cbf4811b6a68bec81db44b9e12604b:ccde748295676bd5cf68563245a1dcd10b9661e3

**Packages**:
- samtools=1.9=h10a08f8_12
- r-lattice=0.20_38=r36hcdcec82_1002
- bowtie=1.2.0
- r-optparse=1.6.4=r36h6115d3f_0
- pysam=0.15.3=py27hda2845c_1
Base Image:bgruening/busybox-bash:0.1

**For** :
- mircounts.xml

Generated with Planemo.