### PR TITLE
Add container mulled-v2-259a9242611409e48cf515e19961d8ab56135f22:c164432f47ad10dfccedc2b1ddcc6cb74ff35c9b.

### DIFF
--- a/combinations/mulled-v2-259a9242611409e48cf515e19961d8ab56135f22:c164432f47ad10dfccedc2b1ddcc6cb74ff35c9b-0.tsv
+++ b/combinations/mulled-v2-259a9242611409e48cf515e19961d8ab56135f22:c164432f47ad10dfccedc2b1ddcc6cb74ff35c9b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie2=2.3.5=py37he860b03_0,bowtie=1.2.3=py37hc9558a2_0,rsem=1.3.0=pl526r341h4f16992_4	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-259a9242611409e48cf515e19961d8ab56135f22:c164432f47ad10dfccedc2b1ddcc6cb74ff35c9b

**Packages**:
- bowtie2=2.3.5=py37he860b03_0
- bowtie=1.2.3=py37hc9558a2_0
- rsem=1.3.0=pl526r341h4f16992_4
Base Image:bgruening/busybox-bash:0.1

**For** :
- extract_transcript_to_gene_map_from_trinity.xml
- rsem.xml
- rsem-bwt2.xml

Generated with Planemo.