### PR TITLE
Add container mulled-v2-6c548a842f80fb1cfb492efe77f76c500e6a4e9e:edb778dde64d1493eb3314715f64862a72aeb612.

### DIFF
--- a/combinations/mulled-v2-6c548a842f80fb1cfb492efe77f76c500e6a4e9e:edb778dde64d1493eb3314715f64862a72aeb612-0.tsv
+++ b/combinations/mulled-v2-6c548a842f80fb1cfb492efe77f76c500e6a4e9e:edb778dde64d1493eb3314715f64862a72aeb612-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.9,rpy2=2.8.5	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-6c548a842f80fb1cfb492efe77f76c500e6a4e9e:edb778dde64d1493eb3314715f64862a72aeb612

**Packages**:
- numpy=1.9
- rpy2=2.8.5
Base Image:bgruening/busybox-bash:0.1

**For** :
- scatterplot.xml

Generated with Planemo.