### PR TITLE
Add container mulled-v2-a2c8e2a21aeee25b8b11010c0e796518dd79e2f7:2c7dd264644d2b10f539e0f9d7aa7c05771f48b9.

### DIFF
--- a/combinations/mulled-v2-a2c8e2a21aeee25b8b11010c0e796518dd79e2f7:2c7dd264644d2b10f539e0f9d7aa7c05771f48b9-0.tsv
+++ b/combinations/mulled-v2-a2c8e2a21aeee25b8b11010c0e796518dd79e2f7:2c7dd264644d2b10f539e0f9d7aa7c05771f48b9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tophat=1.4.0,bowtie=0.12.7,samtools=0.1.18	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-a2c8e2a21aeee25b8b11010c0e796518dd79e2f7:2c7dd264644d2b10f539e0f9d7aa7c05771f48b9

**Packages**:
- tophat=1.4.0
- bowtie=0.12.7
- samtools=0.1.18
Base Image:bgruening/busybox-bash:0.1

**For** :
- tophat_wrapper.xml

Generated with Planemo.