### PR TITLE
Add container mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477.

### DIFF
--- a/combinations/mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477-0.tsv
+++ b/combinations/mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gatk=1.4,samtools=0.1.18	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:9bd97ac60f664f6f72157d3cb53525a19eb75477

**Packages**:
- gatk=1.4
- samtools=0.1.18
Base Image:bgruening/busybox-bash:0.1

**For** :
- indel_realigner.xml
- unified_genotyper.xml
- depth_of_coverage.xml
- variant_annotator.xml
- realigner_target_creator.xml
- count_covariates.xml
- table_recalibration.xml
- print_reads.xml

Generated with Planemo.