### PR TITLE
Add container mulled-v2-010446ed345a1eb14b72128906d9b1b629ef4983:3ddef1ee79767565d1229b8411e81abe31efff76.

### DIFF
--- a/combinations/mulled-v2-010446ed345a1eb14b72128906d9b1b629ef4983:3ddef1ee79767565d1229b8411e81abe31efff76-0.tsv
+++ b/combinations/mulled-v2-010446ed345a1eb14b72128906d9b1b629ef4983:3ddef1ee79767565d1229b8411e81abe31efff76-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rjson=0.2.20,r-getopt=1.20.3,r-base=3.5.1,bioconductor-diffbind=2.10.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-010446ed345a1eb14b72128906d9b1b629ef4983:3ddef1ee79767565d1229b8411e81abe31efff76

**Packages**:
- r-rjson=0.2.20
- r-getopt=1.20.3
- r-base=3.5.1
- bioconductor-diffbind=2.10.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- diffbind.xml

Generated with Planemo.