### PR TITLE
Add container mulled-v2-d95cd3d25c2322dc3827de2cb9c0bf8ce3769b1b:bcd9e9f107c096f85ba5d7f62e81cbc1df2b8370.

### DIFF
--- a/combinations/mulled-v2-d95cd3d25c2322dc3827de2cb9c0bf8ce3769b1b:bcd9e9f107c096f85ba5d7f62e81cbc1df2b8370-0.tsv
+++ b/combinations/mulled-v2-d95cd3d25c2322dc3827de2cb9c0bf8ce3769b1b:bcd9e9f107c096f85ba5d7f62e81cbc1df2b8370-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie2=2.0.0-beta7,bowtie=0.12.8	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-d95cd3d25c2322dc3827de2cb9c0bf8ce3769b1b:bcd9e9f107c096f85ba5d7f62e81cbc1df2b8370

**Packages**:
- bowtie2=2.0.0-beta7
- bowtie=0.12.8
Base Image:bgruening/busybox-bash:0.1

**For** :
- bismark_methylation_extractor.xml

Generated with Planemo.