### PR TITLE
Add container mulled-v2-41782a374559e545356a13433fb8b034c89ebd82:2374c54c84ef316de0eeae191e537afc75f37812.

### DIFF
--- a/combinations/mulled-v2-41782a374559e545356a13433fb8b034c89ebd82:2374c54c84ef316de0eeae191e537afc75f37812-0.tsv
+++ b/combinations/mulled-v2-41782a374559e545356a13433fb8b034c89ebd82:2374c54c84ef316de0eeae191e537afc75f37812-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bx-python=0.8.8,galaxy_sequence_utils=1.1.4	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-41782a374559e545356a13433fb8b034c89ebd82:2374c54c84ef316de0eeae191e537afc75f37812

**Packages**:
- bx-python=0.8.8
- galaxy_sequence_utils=1.1.4
Base Image:bioconda/extended-base-image:latest

**For** :
- vcf_to_interval_index_converter.xml

Generated with Planemo.