### PR TITLE
Add container mulled-v2-2661e9bc82ac497862e54d15820cf5621be8f2fb:4e2e7e4c4d60068c4901d175895c6c35b83a15db.

### DIFF
--- a/combinations/mulled-v2-2661e9bc82ac497862e54d15820cf5621be8f2fb:4e2e7e4c4d60068c4901d175895c6c35b83a15db-0.tsv
+++ b/combinations/mulled-v2-2661e9bc82ac497862e54d15820cf5621be8f2fb:4e2e7e4c4d60068c4901d175895c6c35b83a15db-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+transdecoder=5.5.0,zip=3.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-2661e9bc82ac497862e54d15820cf5621be8f2fb:4e2e7e4c4d60068c4901d175895c6c35b83a15db

**Packages**:
- transdecoder=5.5.0
- zip=3.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- transdecoder.xml

Generated with Planemo.