### PR TITLE
Add container mulled-v2-02af5f7aa2143da904328f2909cc972b6a3dcae3:f570a8dc08c98f17b408ba790111afe364047690.

### DIFF
--- a/combinations/mulled-v2-02af5f7aa2143da904328f2909cc972b6a3dcae3:f570a8dc08c98f17b408ba790111afe364047690-0.tsv
+++ b/combinations/mulled-v2-02af5f7aa2143da904328f2909cc972b6a3dcae3:f570a8dc08c98f17b408ba790111afe364047690-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.11,imagemagick=7.0.10_62,jvarkit-wgscoverageplotter=20201223	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-02af5f7aa2143da904328f2909cc972b6a3dcae3:f570a8dc08c98f17b408ba790111afe364047690

**Packages**:
- samtools=1.11
- imagemagick=7.0.10_62
- jvarkit-wgscoverageplotter=20201223
Base Image:bgruening/busybox-bash:0.1

**For** :
- jvarkit_wgscoverageplotter.xml

Generated with Planemo.