### PR TITLE
Add environment for busco

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -98,3 +98,4 @@ qcat=1.1.0,pigz=2.3.4	bgruening/busybox-bash:0.1	0
 r-base=4.0.2,r-devtools=2.3.2,r-gmodels=2.18.1,r-optparse=1.6.6,bioconductor-deseq2=1.30.0,bioconductor-edger=3.32.0,bioconductor-genomicalignments=1.26.0,bioconductor-org.hs.eg.db=3.12.0,bioconductor-rsubread=2.4.0
 r-base=4.0.3,r-reshape2=1.4.4,r-optparse=1.6.6,r-ggplot2=3.3.3,r-scales=1.1.1,r-viridis=0.5.1,r-tidyverse=1.3.0,bioconductor-biostrings=2.58.0,bioconductor-complexheatmap=2.6.2
 metabat2=2.15,python=3.6.7,biopython=1.74,pandas=1.1.5
+python=3.7.3,prodigal=2.6.3,augustus=3.3.3,diamond=2.0.1,hmmer=3.1b2,blast=2.10.1,sepp=4.3.10,cairo=1.16.0,r-rgtk2=2.20.36,fonts-conda-ecosystem=1,r-base=4.0.2,r-ggplot2=3.3.2,busco=4.1.4


### PR DESCRIPTION
Add: 
`python=3.7.3,prodigal=2.6.3,augustus=3.3.3,diamond=2.0.1,hmmer=3.1b2,blast=2.10.1,sepp=4.3.10,cairo=1.16.0,r-rgtk2=2.20.36,fonts-conda-ecosystem=1,r-base=4.0.2,r-ggplot2=3.3.2,busco=4.1.4`