### PR TITLE
Add container mulled-v2-a38c62ea1867e66bf7e7a0fe48b6e08f52b28113:a892bf8bfabfca6f913d2e90882b665a988f626f.

### DIFF
--- a/combinations/mulled-v2-a38c62ea1867e66bf7e7a0fe48b6e08f52b28113:a892bf8bfabfca6f913d2e90882b665a988f626f-0.tsv
+++ b/combinations/mulled-v2-a38c62ea1867e66bf7e7a0fe48b6e08f52b28113:a892bf8bfabfca6f913d2e90882b665a988f626f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyfaidx=0.5.9.2,pyvcf=0.6.8,samtools=1.11	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-a38c62ea1867e66bf7e7a0fe48b6e08f52b28113:a892bf8bfabfca6f913d2e90882b665a988f626f

**Packages**:
- pyfaidx=0.5.9.2
- pyvcf=0.6.8
- samtools=1.11
Base Image:bgruening/busybox-bash:0.1

**For** :
- get_hrun.xml

Generated with Planemo.