### PR TITLE
Add container mulled-v2-798e194831067a5d72ff3a40502ff6c9b410ce77:ec727c67d481a59866863f4badf2d6ba91461151.

### DIFF
--- a/combinations/mulled-v2-798e194831067a5d72ff3a40502ff6c9b410ce77:ec727c67d481a59866863f4badf2d6ba91461151-0.tsv
+++ b/combinations/mulled-v2-798e194831067a5d72ff3a40502ff6c9b410ce77:ec727c67d481a59866863f4badf2d6ba91461151-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.6.6,r-sequenza=3.0.0,bioconductor-biocparallel=1.24.0,tzdata=2021a=he74cb21_0,r-tidyverse=1.3.0,sequenza-utils=3.0.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-798e194831067a5d72ff3a40502ff6c9b410ce77:ec727c67d481a59866863f4badf2d6ba91461151

**Packages**:
- r-optparse=1.6.6
- r-sequenza=3.0.0
- bioconductor-biocparallel=1.24.0
- tzdata=2021a=he74cb21_0
- r-tidyverse=1.3.0
- sequenza-utils=3.0.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- snvtocnv.xml

Generated with Planemo.