### PR TITLE
Add CAT 4.6 and Diamond 2.0.6

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -112,3 +112,4 @@ pigz=2.3.4
 jq=1.6
 r-base=4.0.3,r-shazam=1.0.2,r-tigger=1.0.0
 r-base=4.0.3,r-shazam=1.0.2,r-tigger=1.0.0,tzdata=2021a
+cat=4.6,diamond=2.0.6


### PR DESCRIPTION
Hi, I need a container with CAT 4.6 and Diamond 2.0.6

The problem with CAT and the current bioconda recipe is that one needs to use the same Diamond version that was used to build the CAT database. Thus one would need different containers for different CAT databases (see also https://github.com/dutilh/CAT/issues/54). 