### PR TITLE
Add container mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:040f1809d0d7571a74add37a7960fc0231c6d4f0.

### DIFF
--- a/combinations/mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:040f1809d0d7571a74add37a7960fc0231c6d4f0-0.tsv
+++ b/combinations/mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:040f1809d0d7571a74add37a7960fc0231c6d4f0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+diffutils=3.7,sed=4.8	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:040f1809d0d7571a74add37a7960fc0231c6d4f0

**Packages**:
- diffutils=3.7
- sed=4.8
Base Image:bgruening/busybox-bash:0.1

**For** :
- diff.xml

Generated with Planemo.