### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:12cc5e6cec1d752303abd17574cc2051d66f4091.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:12cc5e6cec1d752303abd17574cc2051d66f4091-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:12cc5e6cec1d752303abd17574cc2051d66f4091-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasta3=36.3.8,mafft=7.475	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:12cc5e6cec1d752303abd17574cc2051d66f4091

**Packages**:
- fasta3=36.3.8
- mafft=7.475
Base Image:bgruening/busybox-bash:0.1

**For** :
- mafft.xml
- mafft-add.xml

Generated with Planemo.