### PR TITLE
Add container mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:b138034865deffa4778e1b975e1113457fa6bb6f.

### DIFF
--- a/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:b138034865deffa4778e1b975e1113457fa6bb6f-0.tsv
+++ b/combinations/mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:b138034865deffa4778e1b975e1113457fa6bb6f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.7,star=2.7.8a,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8cfdc41dda2d426ae8668e63080a6dac4e3b4e5a:b138034865deffa4778e1b975e1113457fa6bb6f

**Packages**:
- python=3.7
- star=2.7.8a
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- rna_star_index_builder.xml

Generated with Planemo.