### PR TITLE
Add container mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:8047ce78ee60f6a1f4390a36cee78a99371e4f59.

### DIFF
--- a/combinations/mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:8047ce78ee60f6a1f4390a36cee78a99371e4f59-0.tsv
+++ b/combinations/mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:8047ce78ee60f6a1f4390a36cee78a99371e4f59-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+star=2.7.8a,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:8047ce78ee60f6a1f4390a36cee78a99371e4f59

**Packages**:
- star=2.7.8a
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- rg_rnaStarSolo.xml
- rg_rnaStar.xml

Generated with Planemo.