### PR TITLE
Add container mulled-v2-b71166f10234b4d38960a022ed3964cb3714eb0b:07f10002eab43bc5755d704bb0c18095dcf47d3e.

### DIFF
--- a/combinations/mulled-v2-b71166f10234b4d38960a022ed3964cb3714eb0b:07f10002eab43bc5755d704bb0c18095dcf47d3e-0.tsv
+++ b/combinations/mulled-v2-b71166f10234b4d38960a022ed3964cb3714eb0b:07f10002eab43bc5755d704bb0c18095dcf47d3e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+leidenalg=0.8.3,loompy=2.0.17,louvain=0.7.0,scanpy=1.7.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-b71166f10234b4d38960a022ed3964cb3714eb0b:07f10002eab43bc5755d704bb0c18095dcf47d3e

**Packages**:
- leidenalg=0.8.3
- loompy=2.0.17
- louvain=0.7.0
- scanpy=1.7.1
Base Image:bgruening/busybox-bash:0.1

**For** :
- cluster_reduce_dimension.xml

Generated with Planemo.