### PR TITLE
Add container mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:876003adaffc37b1a3f7ecf4164fe97f454823b5.

### DIFF
--- a/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:876003adaffc37b1a3f7ecf4164fe97f454823b5-0.tsv
+++ b/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:876003adaffc37b1a3f7ecf4164fe97f454823b5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hicexplorer=3.6,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:876003adaffc37b1a3f7ecf4164fe97f454823b5

**Packages**:
- hicexplorer=3.6
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- hicBuildMatrix.xml

Generated with Planemo.