### PR TITLE
Add container mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:1befb7f3f6970ffe4d0ad2008e77969fe4d67946.

### DIFF
--- a/combinations/mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:1befb7f3f6970ffe4d0ad2008e77969fe4d67946-0.tsv
+++ b/combinations/mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:1befb7f3f6970ffe4d0ad2008e77969fe4d67946-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+findutils=4.6.0,stacks=2.55,python=3.7	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-476383b5c4260f6fbc28cf28279ee8d8361996b3:1befb7f3f6970ffe4d0ad2008e77969fe4d67946

**Packages**:
- findutils=4.6.0
- stacks=2.55
- python=3.7
Base Image:bgruening/busybox-bash:0.1

**For** :
- stacks_shortreads.xml
- stacks_ustacks.xml
- stacks_procrad.xml
- stacks_cstacks.xml
- stacks_tsv2bam.xml
- stacks_kmerfilter.xml
- stacks_refmap.xml
- stacks_denovomap.xml
- stacks_clonefilter.xml
- stacks_populations.xml
- stacks_sstacks.xml

Generated with Planemo.