### PR TITLE
Add container mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:2200fd433290bb814a952b2fd7cc8013499de840.

### DIFF
--- a/combinations/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:2200fd433290bb814a952b2fd7cc8013499de840-0.tsv
+++ b/combinations/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:2200fd433290bb814a952b2fd7cc8013499de840-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bedtools=2.30.0,samtools=1.9	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:2200fd433290bb814a952b2fd7cc8013499de840

**Packages**:
- bedtools=2.30.0
- samtools=1.9
Base Image:bgruening/busybox-bash:0.1

**For** :
- coverageBed.xml
- intersectBed.xml
- bamToBed.xml

Generated with Planemo.