### PR TITLE
Add container with star=2.6.1d samtools=1.10

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -126,3 +126,4 @@ rapidnj=2.3.2,biopython=1.78
 r-base=4.0.3,r-optparse=1.6.6,r-rmariadb=1.1.0,bioconductor-edger=3.32.0,bioconductor-grohmm=1.24.0,bioconductor-org.hs.eg.db=3.12.0,bioconductor-txdb.hsapiens.ucsc.hg19.knowngene=3.2.2
 kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
+star=2.6.1d,samtools=1.10


### PR DESCRIPTION
Need a container pinned to this version of STAR because our AWS iGenomes indices are only compatible up to that version. Need SAMtools to try and calculate `--genomeSAindexNbases` on the fly in the nf-core/module using the bash magic below:

```console
awk '{total = total + $2}END{if ((log(total)/log(2))/2 - 1 > 14) {printf "%.0f", 14} else {printf "%.0f", (log(total)/log(2))/2 - 1}}'
```