### PR TITLE
Add python to galaxyxml/planemo biocontainer

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,3 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
+planemo=0.74.3,bioblend=0.15.0,ephemeris=0.10.6,galaxyxml=0.4.14

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,4 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
-python=3.9.4,planemo=0.74.3,galaxyxml=0.4.14
+python=3.8.5,planemo=0.74.3,galaxyxml=0.4.14

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,4 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
-planemo=0.74.3,bioblend=0.15.0,ephemeris=0.10.6,galaxyxml=0.4.14
+python=3.9.4,planemo=0.74.3,galaxyxml=0.4.14


### PR DESCRIPTION
With apologies for my error - without python the container is not very useful - it does work correctly but any tools trying to use it will be flummoxed when they try to load galaxyxml since whatever python is outside the container will likely know nothing of galaxy_utils and so fail to load properly.
I am learning slowly and when properly constructed, biocontainers work well....
Will updating hash.tsv be all that's needed or do I need to do anything to make it go away? It is not much use to anyone.