### PR TITLE
Add git to planemo - it is required and absence causes mysterious failures in a biocontainer

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,4 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
-python=3.8.5,planemo=0.74.3,galaxyxml=0.4.14
+planemo=0.74.3,git=2.30.2

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,4 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
-planemo=0.74.3,git=2.30.2
+planemo=0.74.3,git=2.30.2,galaxyxml=0.4.14

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,3 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
+planemo=0.74.3,bioblend=0.15.0,ephemeris=0.10.6,galaxyxml=0.4.14

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,4 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
-python=3.9.4,planemo=0.74.3,galaxyxml=0.4.14
+python=3.8.5,planemo=0.74.3,galaxyxml=0.4.14

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -128,4 +128,4 @@ kraken2=2.1.1,pigz=2.6
 merqury=1.1,tar=1.34,findutils=4.6.0
 star=2.6.1d,samtools=1.10
 star=2.6.1d,samtools=1.10,gawk=5.1.0
-planemo=0.74.3,bioblend=0.15.0,ephemeris=0.10.6,galaxyxml=0.4.14
+python=3.9.4,planemo=0.74.3,galaxyxml=0.4.14


### PR DESCRIPTION
Taken me a long time to figure out why the biocontainer using planemo was failing strangely and without any helpful feedback from the container. @nsoranzo pointed out that it can't be part of the planemo requirements as it's not a python package so there's no reliable way to use it in a biocontainer without git.