### PR TITLE
Add container mulled-v2-a0d3bf2aa6e4255087a5fc18e8881735a726c90b:84c0e0862ed307b3cc1d99b73fb6b93b59b18f6f.

### DIFF
--- a/combinations/mulled-v2-a0d3bf2aa6e4255087a5fc18e8881735a726c90b:84c0e0862ed307b3cc1d99b73fb6b93b59b18f6f-0.tsv
+++ b/combinations/mulled-v2-a0d3bf2aa6e4255087a5fc18e8881735a726c90b:84c0e0862ed307b3cc1d99b73fb6b93b59b18f6f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+graphicsmagick=1.3.35,bioconductor-multtest=2.46.0,r-batch=1.1_5,r-snow=0.4_3,bioconductor-camera=1.46.0	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-a0d3bf2aa6e4255087a5fc18e8881735a726c90b:84c0e0862ed307b3cc1d99b73fb6b93b59b18f6f

**Packages**:
- graphicsmagick=1.3.35
- bioconductor-multtest=2.46.0
- r-batch=1.1_5
- r-snow=0.4_3
- bioconductor-camera=1.46.0
Base Image:bgruening/busybox-bash:0.1

**For** :
- abims_CAMERA_combinexsAnnos.xml
- abims_CAMERA_annotateDiffreport.xml

Generated with Planemo.