### PR TITLE
Add container mulled-v2-c6777c159625854546a5d1f3a5a56b79d4096edc:e04e43313eb78752f66c61a8587de8ed271596f9.

### DIFF
--- a/combinations/mulled-v2-c6777c159625854546a5d1f3a5a56b79d4096edc:e04e43313eb78752f66c61a8587de8ed271596f9-0.tsv
+++ b/combinations/mulled-v2-c6777c159625854546a5d1f3a5a56b79d4096edc:e04e43313eb78752f66c61a8587de8ed271596f9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.12,winnowmap=2.03	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-c6777c159625854546a5d1f3a5a56b79d4096edc:e04e43313eb78752f66c61a8587de8ed271596f9

**Packages**:
- samtools=1.12
- winnowmap=2.03
Base Image:bgruening/busybox-bash:0.1

**For** :
- winnowmap.xml

Generated with Planemo.