### PR TITLE
Add container mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:0ad7c207c30a252773c65f93d450c65e9330275f.

### DIFF
--- a/combinations/mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:0ad7c207c30a252773c65f93d450c65e9330275f-0.tsv
+++ b/combinations/mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:0ad7c207c30a252773c65f93d450c65e9330275f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pretextsnapshot=0.0.3,rename=1.601	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:0ad7c207c30a252773c65f93d450c65e9330275f

**Packages**:
- pretextsnapshot=0.0.3
- rename=1.601
Base Image:bgruening/busybox-bash:0.1

**For** :
- pretext_snapshot.xml

Generated with Planemo.