### PR TITLE
Add container mulled-v2-e0ce9899a3647606dd0b362ef3b857b2f7297da2:0c3da3c7939a976b926534fca505e6d2d4713bae.

### DIFF
--- a/combinations/mulled-v2-e0ce9899a3647606dd0b362ef3b857b2f7297da2:0c3da3c7939a976b926534fca505e6d2d4713bae-0.tsv
+++ b/combinations/mulled-v2-e0ce9899a3647606dd0b362ef3b857b2f7297da2:0c3da3c7939a976b926534fca505e6d2d4713bae-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sra-tools=2.11.0,awscli=1.18.222,pigz=2.5	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-e0ce9899a3647606dd0b362ef3b857b2f7297da2:0c3da3c7939a976b926534fca505e6d2d4713bae

**Packages**:
- sra-tools=2.11.0
- awscli=1.18.222
- pigz=2.5
Base Image:bgruening/busybox-bash:0.1

**For** :
- fastq_dump.xml
- fasterq_dump.xml

Generated with Planemo.