### PR TITLE
Add container mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ef53b88e73a0ebe343b2fda60b40abd8778ebd41.

### DIFF
--- a/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ef53b88e73a0ebe343b2fda60b40abd8778ebd41-0.tsv
+++ b/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ef53b88e73a0ebe343b2fda60b40abd8778ebd41-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.12,pretextmap=0.1.5	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ef53b88e73a0ebe343b2fda60b40abd8778ebd41

**Packages**:
- samtools=1.12
- pretextmap=0.1.5
Base Image:bgruening/busybox-bash:0.1

**For** :
- pretext_map.xml

Generated with Planemo.