### PR TITLE
Add container mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:106067d19ca885da0a60ab162849f3a2cce1d568.

### DIFF
--- a/combinations/mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:106067d19ca885da0a60ab162849f3a2cce1d568-0.tsv
+++ b/combinations/mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:106067d19ca885da0a60ab162849f3a2cce1d568-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.32,findutils=4.6.0,merqury=1.3,tar=1.34	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:106067d19ca885da0a60ab162849f3a2cce1d568

**Packages**:
- coreutils=8.32
- findutils=4.6.0
- merqury=1.3
- tar=1.34
Base Image:bgruening/busybox-bash:0.1

**For** :
- merqury.xml

Generated with Planemo.