### PR TITLE
Add container mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:2b2d92ba764b1bd94dcc7988ee99fb724dde7ff7.

### DIFF
--- a/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:2b2d92ba764b1bd94dcc7988ee99fb724dde7ff7-0.tsv
+++ b/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:2b2d92ba764b1bd94dcc7988ee99fb724dde7ff7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pretextmap=0.1.6,samtools=1.12	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
**Hash**: mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:2b2d92ba764b1bd94dcc7988ee99fb724dde7ff7

**Packages**:
- pretextmap=0.1.6
- samtools=1.12
Base Image:bgruening/busybox-bash:0.1

**For** :
- pretext_map.xml

Generated with Planemo.