### PR TITLE
Add container mulled-v2-93ae6b4422529a465b6850d9c964adcedd59e34b:94208fbcdcda26825f6d4a70e0096fc2e4c17aaa.

### DIFF
--- a/combinations/mulled-v2-93ae6b4422529a465b6850d9c964adcedd59e34b:94208fbcdcda26825f6d4a70e0096fc2e4c17aaa-0.tsv
+++ b/combinations/mulled-v2-93ae6b4422529a465b6850d9c964adcedd59e34b:94208fbcdcda26825f6d4a70e0096fc2e4c17aaa-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.12,bellerophon=1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-93ae6b4422529a465b6850d9c964adcedd59e34b:94208fbcdcda26825f6d4a70e0096fc2e4c17aaa

**Packages**:
- samtools=1.12
- bellerophon=1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bellerophon.xml

Generated with Planemo.