### PR TITLE
Add container mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:6203818d4ae215fd8c82ea5f7cc0f50f56066592.

### DIFF
--- a/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:6203818d4ae215fd8c82ea5f7cc0f50f56066592-0.tsv
+++ b/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:6203818d4ae215fd8c82ea5f7cc0f50f56066592-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.12,minimap2=2.20	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:6203818d4ae215fd8c82ea5f7cc0f50f56066592

**Packages**:
- samtools=1.12
- minimap2=2.20
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- minimap2.xml

Generated with Planemo.