### PR TITLE
Add container mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:3e211859dd4bdadc6f5648c7cacbccdf032b4461.

### DIFF
--- a/combinations/mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:3e211859dd4bdadc6f5648c7cacbccdf032b4461-0.tsv
+++ b/combinations/mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:3e211859dd4bdadc6f5648c7cacbccdf032b4461-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.6.4=r36h6115d3f_0,samtools=1.10=h9402c20_2,pysam=0.16.0.1,bedtools=2.29.2=hc088bd4_0,numpy=1.17.3=py37h95a1406_0,r-ggplot2=3.2.1=r36h6115d3f_0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e148fe04b62ba2eb78ae2fb5ec95a485e769bd1:3e211859dd4bdadc6f5648c7cacbccdf032b4461

**Packages**:
- r-optparse=1.6.4=r36h6115d3f_0
- samtools=1.10=h9402c20_2
- pysam=0.16.0.1
- bedtools=2.29.2=hc088bd4_0
- numpy=1.17.3=py37h95a1406_0
- r-ggplot2=3.2.1=r36h6115d3f_0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- probecoverage.xml

Generated with Planemo.