### PR TITLE
Add container mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:8ae92fc631c5771492cbb37fa1f4c6a53291077d.

### DIFF
--- a/combinations/mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:8ae92fc631c5771492cbb37fa1f4c6a53291077d-0.tsv
+++ b/combinations/mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:8ae92fc631c5771492cbb37fa1f4c6a53291077d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-edger=3.34.0,r-statmod=1.4.36,r-scales=1.1.1,r-getopt=1.20.3,r-rjson=0.2.20,bioconductor-limma=3.48.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:8ae92fc631c5771492cbb37fa1f4c6a53291077d

**Packages**:
- bioconductor-edger=3.34.0
- r-statmod=1.4.36
- r-scales=1.1.1
- r-getopt=1.20.3
- r-rjson=0.2.20
- bioconductor-limma=3.48.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- edger.xml

Generated with Planemo.