### PR TITLE
Add container mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:ab479f3709cc0622f094f08704a1d9474bbd6c9e.

### DIFF
--- a/combinations/mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:ab479f3709cc0622f094f08704a1d9474bbd6c9e-0.tsv
+++ b/combinations/mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:ab479f3709cc0622f094f08704a1d9474bbd6c9e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-limma=3.48.0,r-rjson=0.2.20,r-gplots=3.1.1,r-scales=1.1.1,r-getopt=1.20.3,bioconductor-edger=3.34.0,bioconductor-glimma=2.2.0,r-statmod=1.4.36	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:ab479f3709cc0622f094f08704a1d9474bbd6c9e

**Packages**:
- bioconductor-limma=3.48.0
- r-rjson=0.2.20
- r-gplots=3.1.1
- r-scales=1.1.1
- r-getopt=1.20.3
- bioconductor-edger=3.34.0
- bioconductor-glimma=2.2.0
- r-statmod=1.4.36
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- limma_voom.xml

Generated with Planemo.