### PR TITLE
Add container mulled-v2-f0eb558af3c21068f551d7a5dcab01d9c2b58ad6:badbfab24d51946be0b63e9ff240ca0a3e8f4725.

### DIFF
--- a/combinations/mulled-v2-f0eb558af3c21068f551d7a5dcab01d9c2b58ad6:badbfab24d51946be0b63e9ff240ca0a3e8f4725-0.tsv
+++ b/combinations/mulled-v2-f0eb558af3c21068f551d7a5dcab01d9c2b58ad6:badbfab24d51946be0b63e9ff240ca0a3e8f4725-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.5.6,python=3,xarray=0.18.2,cmcrameri=1.2,cartopy=0.19.0,matplotlib=3.4.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f0eb558af3c21068f551d7a5dcab01d9c2b58ad6:badbfab24d51946be0b63e9ff240ca0a3e8f4725

**Packages**:
- netcdf4=1.5.6
- python=3
- xarray=0.18.2
- cmcrameri=1.2
- cartopy=0.19.0
- matplotlib=3.4.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_mapplot.xml

Generated with Planemo.