### PR TITLE
Add container mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:a866965b2374b518ed3a19e20ed6d80b644b8d3e.

### DIFF
--- a/combinations/mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:a866965b2374b518ed3a19e20ed6d80b644b8d3e-0.tsv
+++ b/combinations/mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:a866965b2374b518ed3a19e20ed6d80b644b8d3e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.5.6,xarray=0.18.2,python=3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:a866965b2374b518ed3a19e20ed6d80b644b8d3e

**Packages**:
- netcdf4=1.5.6
- xarray=0.18.2
- python=3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_netcdf2netcdf.xml

Generated with Planemo.