### PR TITLE
Add container mulled-v2-10fac1d65e710574e29b1371bc0ce6a681cfe252:0415d8a5b33fe6aec98b6f7541a2dca4afcce642.

### DIFF
--- a/combinations/mulled-v2-10fac1d65e710574e29b1371bc0ce6a681cfe252:0415d8a5b33fe6aec98b6f7541a2dca4afcce642-0.tsv
+++ b/combinations/mulled-v2-10fac1d65e710574e29b1371bc0ce6a681cfe252:0415d8a5b33fe6aec98b6f7541a2dca4afcce642-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+purge_dups=1.2.5,matplotlib-base=3.4.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-10fac1d65e710574e29b1371bc0ce6a681cfe252:0415d8a5b33fe6aec98b6f7541a2dca4afcce642

**Packages**:
- purge_dups=1.2.5
- matplotlib-base=3.4.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- purge_dups.xml

Generated with Planemo.