### PR TITLE
Add container mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:edeeaf6daf835a1e1decb527c022f25e2d2b536c.

### DIFF
--- a/combinations/mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:edeeaf6daf835a1e1decb527c022f25e2d2b536c-0.tsv
+++ b/combinations/mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:edeeaf6daf835a1e1decb527c022f25e2d2b536c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ptxqc=1.0.9,maxquant=1.6.10.43,tar=1.32,python=3.7,pyyaml=5.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:edeeaf6daf835a1e1decb527c022f25e2d2b536c

**Packages**:
- r-ptxqc=1.0.9
- maxquant=1.6.10.43
- tar=1.32
- python=3.7
- pyyaml=5.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- maxquant.xml
- maxquant_mqpar.xml

Generated with Planemo.