### PR TITLE
Add container mulled-v2-73670ad0b275d2b3ac5608694d2ca11a4ec7cc85:fe67ee7b59eae7855b286aacbcd8356ce6861b15.

### DIFF
--- a/combinations/mulled-v2-73670ad0b275d2b3ac5608694d2ca11a4ec7cc85:fe67ee7b59eae7855b286aacbcd8356ce6861b15-0.tsv
+++ b/combinations/mulled-v2-73670ad0b275d2b3ac5608694d2ca11a4ec7cc85:fe67ee7b59eae7855b286aacbcd8356ce6861b15-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.8,bowtie2=2.4.4,bismark=0.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-73670ad0b275d2b3ac5608694d2ca11a4ec7cc85:fe67ee7b59eae7855b286aacbcd8356ce6861b15

**Packages**:
- samtools=1.8
- bowtie2=2.4.4
- bismark=0.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bismark_methylation_extractor.xml

Generated with Planemo.