### PR TITLE
Add container mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:836dcc5480c9c7e02b70a54568a699027e24aa12.

### DIFF
--- a/combinations/mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:836dcc5480c9c7e02b70a54568a699027e24aa12-0.tsv
+++ b/combinations/mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:836dcc5480c9c7e02b70a54568a699027e24aa12-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tar=1.32,pyyaml=5.1.2,maxquant=1.6.17.0,python=3.7,r-ptxqc=1.0.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-795058a223bc38fcee39b97525846c52cbd08579:836dcc5480c9c7e02b70a54568a699027e24aa12

**Packages**:
- tar=1.32
- pyyaml=5.1.2
- maxquant=1.6.17.0
- python=3.7
- r-ptxqc=1.0.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- maxquant.xml
- maxquant_mqpar.xml

Generated with Planemo.