### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0b4b94141868d1a6bae9653f22b29f2b54fd0c1f.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0b4b94141868d1a6bae9653f22b29f2b54fd0c1f-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0b4b94141868d1a6bae9653f22b29f2b54fd0c1f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hifiasm=0.15.4,yak=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0b4b94141868d1a6bae9653f22b29f2b54fd0c1f

**Packages**:
- hifiasm=0.15.4
- yak=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.