### PR TITLE
Add container mulled-v2-55c4a2cea8aa35488858171d2840bc8d7f970ab4:4c201476db7bf5097c621ae966fa21cc09ab77f4.

### DIFF
--- a/combinations/mulled-v2-55c4a2cea8aa35488858171d2840bc8d7f970ab4:4c201476db7bf5097c621ae966fa21cc09ab77f4-0.tsv
+++ b/combinations/mulled-v2-55c4a2cea8aa35488858171d2840bc8d7f970ab4:4c201476db7bf5097c621ae966fa21cc09ab77f4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rjson=0.2.20,r-statmod=1.4.36,r-optparse=1.6.6,bioconductor-egsea=1.20.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-55c4a2cea8aa35488858171d2840bc8d7f970ab4:4c201476db7bf5097c621ae966fa21cc09ab77f4

**Packages**:
- r-rjson=0.2.20
- r-statmod=1.4.36
- r-optparse=1.6.6
- bioconductor-egsea=1.20.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- egsea.xml

Generated with Planemo.