### PR TITLE
Rebuild python containers to enable DNS resolving in singularity

### DIFF
--- a/combinations/python:3.6-1.tsv
+++ b/combinations/python:3.6-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.6	quay.io/bioconda/base-glibc-busybox-bash:latest	1

--- a/combinations/python:3.7-1.tsv
+++ b/combinations/python:3.7-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.7	quay.io/bioconda/base-glibc-busybox-bash:latest	1

--- a/combinations/python:3.8-1.tsv
+++ b/combinations/python:3.8-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8	quay.io/bioconda/base-glibc-busybox-bash:latest	1

--- a/combinations/python:3.9-1.tsv
+++ b/combinations/python:3.9-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.9	quay.io/bioconda/base-glibc-busybox-bash:latest	1


### PR DESCRIPTION
For galaxyproject/galaxy#12184

The tool in question has been updated to Python 3.8 and ran into the same issue.