### PR TITLE
Add container bioconductor-dada2:1.20.

### DIFF
--- a/combinations/bioconductor-dada2:1.20-0.tsv
+++ b/combinations/bioconductor-dada2:1.20-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-dada2=1.20	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: bioconductor-dada2:1.20

**Packages**:
- bioconductor-dada2=1.20
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- dada2_assignTaxonomyAddspecies.xml
- dada2_makeSequenceTable.xml
- dada2_plotComplexity.xml
- dada2_mergePairs.xml
- dada2_removeBimeraDenovo.xml
- dada2_seqCounts.xml
- dada2_plotQualityProfile.xml
- dada2_filterAndTrim.xml
- dada2_learnErrors.xml
- dada2_dada.xml

Generated with Planemo.