### PR TITLE
Add container mulled-v2-ceb396848bd4205fab17b9a25292063db3e0bd2c:28fa3a0848d6f0d93bded373cf994654a25e377a.

### DIFF
--- a/combinations/mulled-v2-ceb396848bd4205fab17b9a25292063db3e0bd2c:28fa3a0848d6f0d93bded373cf994654a25e377a-0.tsv
+++ b/combinations/mulled-v2-ceb396848bd4205fab17b9a25292063db3e0bd2c:28fa3a0848d6f0d93bded373cf994654a25e377a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+graphicsmagick=1.3.26,r-snow=0.4_3,bioconductor-multtest=2.48.0,zip=3.0,bioconductor-camera=1.48.0,r-batch=1.1_5,bioconductor-genomeinfodbdata=1.2.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ceb396848bd4205fab17b9a25292063db3e0bd2c:28fa3a0848d6f0d93bded373cf994654a25e377a

**Packages**:
- graphicsmagick=1.3.26
- r-snow=0.4_3
- bioconductor-multtest=2.48.0
- zip=3.0
- bioconductor-camera=1.48.0
- r-batch=1.1_5
- bioconductor-genomeinfodbdata=1.2.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- abims_CAMERA_annotateDiffreport.xml
- abims_CAMERA_combinexsAnnos.xml

Generated with Planemo.