### PR TITLE
Add container mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:ea0568c298913c89fa976f7bbef24e1918b45542.

### DIFF
--- a/combinations/mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:ea0568c298913c89fa976f7bbef24e1918b45542-0.tsv
+++ b/combinations/mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:ea0568c298913c89fa976f7bbef24e1918b45542-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+snippy=4.6.0,tar=1.32	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-246f3b0b9fa8d15fd96cbccd11dc328e19b263b1:ea0568c298913c89fa976f7bbef24e1918b45542

**Packages**:
- snippy=4.6.0
- tar=1.32
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snippy-core.xml
- snippy_clean_full_aln.xml
- snippy.xml

Generated with Planemo.