### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:99e8e9e2a576f61774b8991437d9e2f65fda9f69.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:99e8e9e2a576f61774b8991437d9e2f65fda9f69-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:99e8e9e2a576f61774b8991437d9e2f65fda9f69-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fonts-conda-ecosystem=1,busco=5.2.1,tar=1.32	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:99e8e9e2a576f61774b8991437d9e2f65fda9f69

**Packages**:
- fonts-conda-ecosystem=1
- busco=5.2.1
- tar=1.32
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.