### PR TITLE
Add container mulled-v2-1982c6126dbc97f7e81a0c2745997a1d0409d451:77d92659fdd59e8ec399e636f3094f03bf2d34e2.

### DIFF
--- a/combinations/mulled-v2-1982c6126dbc97f7e81a0c2745997a1d0409d451:77d92659fdd59e8ec399e636f3094f03bf2d34e2-0.tsv
+++ b/combinations/mulled-v2-1982c6126dbc97f7e81a0c2745997a1d0409d451:77d92659fdd59e8ec399e636f3094f03bf2d34e2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xlrd=1.2.0,ena-upload-cli=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1982c6126dbc97f7e81a0c2745997a1d0409d451:77d92659fdd59e8ec399e636f3094f03bf2d34e2

**Packages**:
- xlrd=1.2.0
- ena-upload-cli=0.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ena_upload.xml

Generated with Planemo.