### PR TITLE
Add container mulled-v2-9877de470c48ff56dc3548002c623c33db89ca17:b584f1c27dd13e2f1251efe97edfe921cd1afe1a.

### DIFF
--- a/combinations/mulled-v2-9877de470c48ff56dc3548002c623c33db89ca17:b584f1c27dd13e2f1251efe97edfe921cd1afe1a-0.tsv
+++ b/combinations/mulled-v2-9877de470c48ff56dc3548002c623c33db89ca17:b584f1c27dd13e2f1251efe97edfe921cd1afe1a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rgccacmd=3.0.2,r-base=4.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9877de470c48ff56dc3548002c623c33db89ca17:b584f1c27dd13e2f1251efe97edfe921cd1afe1a

**Packages**:
- rgccacmd=3.0.2
- r-base=4.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rgcca.xml

Generated with Planemo.