### PR TITLE
Add container mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:f7f35d8f4102a5de392cc02fbba2d8fb67efcd8d.

### DIFF
--- a/combinations/mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:f7f35d8f4102a5de392cc02fbba2d8fb67efcd8d-0.tsv
+++ b/combinations/mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:f7f35d8f4102a5de392cc02fbba2d8fb67efcd8d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+seqtk=1.3,hisat2=2.2.1,samtools=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:f7f35d8f4102a5de392cc02fbba2d8fb67efcd8d

**Packages**:
- seqtk=1.3
- hisat2=2.2.1
- samtools=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hisat2.xml

Generated with Planemo.