### PR TITLE
Add container mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:b6a7ef2fa392cae74b553b7601945d7b6f9fca13.

### DIFF
--- a/combinations/mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:b6a7ef2fa392cae74b553b7601945d7b6f9fca13-0.tsv
+++ b/combinations/mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:b6a7ef2fa392cae74b553b7601945d7b6f9fca13-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kallisto=0.46.2,samtools=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:b6a7ef2fa392cae74b553b7601945d7b6f9fca13

**Packages**:
- kallisto=0.46.2
- samtools=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kallisto_pseudo.xml
- kallisto_quant.xml

Generated with Planemo.