### PR TITLE
Add container mulled-v2-f8e93b33329505528c36add9458ba9896deb793c:a2e7849fa46cdc754c2d0e3a883ebf49fad9e0ff.

### DIFF
--- a/combinations/mulled-v2-f8e93b33329505528c36add9458ba9896deb793c:a2e7849fa46cdc754c2d0e3a883ebf49fad9e0ff-0.tsv
+++ b/combinations/mulled-v2-f8e93b33329505528c36add9458ba9896deb793c:a2e7849fa46cdc754c2d0e3a883ebf49fad9e0ff-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.20.2,scikit-image=0.18.1,imageio=2.9.0,pandas=1.2.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f8e93b33329505528c36add9458ba9896deb793c:a2e7849fa46cdc754c2d0e3a883ebf49fad9e0ff

**Packages**:
- numpy=1.20.2
- scikit-image=0.18.1
- imageio=2.9.0
- pandas=1.2.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- spot_detection_2d.xml

Generated with Planemo.