### PR TITLE
Add Python 3.9, pandas, seaborn, bcbio-gff, dna_features_viewer

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -142,3 +142,4 @@ r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1	quay.io/bioconda/base-glibc-de
 python=3.9,pandas=1.3.0,seaborn=0.11.0
 bwa=0.7.17,samtools=1.9,bcftools=1.9	quay.io/bioconda/base-glibc-debian-bash:latest	0
 star=2.7.9a,samtools=1.13,gawk=5.1.0
+python=3.9,pandas=1.3.0,seaborn=0.11.0,rich=10.6.0,typer=0.3.2,bcbio-gff=0.6.6,dna_features_viewer=3.0.3


### PR DESCRIPTION
Adds multi-container for

* `python=3.9`
* `pandas=1.3.0`
* `seaborn=0.11.0`
* `rich=10.6.0`
* `typer=0.3.2`
* `bcbio-gff=0.6.6`
* `dna_features_viewer=3.0.3`