### PR TITLE
Add container mulled-v2-87d98e385c6d1e79e373451259d5cabeef3fbab4:2b4aaac13162a8c9d8d876608b00bbb4c3061aad.

### DIFF
--- a/combinations/mulled-v2-87d98e385c6d1e79e373451259d5cabeef3fbab4:2b4aaac13162a8c9d8d876608b00bbb4c3061aad-0.tsv
+++ b/combinations/mulled-v2-87d98e385c6d1e79e373451259d5cabeef3fbab4:2b4aaac13162a8c9d8d876608b00bbb4c3061aad-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.20.2,openpyxl=3.0.7,scipy=1.6.2,pandas=1.2.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-87d98e385c6d1e79e373451259d5cabeef3fbab4:2b4aaac13162a8c9d8d876608b00bbb4c3061aad

**Packages**:
- numpy=1.20.2
- openpyxl=3.0.7
- scipy=1.6.2
- pandas=1.2.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- curve_fitting.xml

Generated with Planemo.