### PR TITLE
Add container mulled-v2-6ed46bb014d9efe57c15a2e51b4be8fed2d7be30:24c8124c42ce709f0fbcf725f55b149a7a16f524.

### DIFF
--- a/combinations/mulled-v2-6ed46bb014d9efe57c15a2e51b4be8fed2d7be30:24c8124c42ce709f0fbcf725f55b149a7a16f524-0.tsv
+++ b/combinations/mulled-v2-6ed46bb014d9efe57c15a2e51b4be8fed2d7be30:24c8124c42ce709f0fbcf725f55b149a7a16f524-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggrepel=0.9.1,bioconductor-genomicfeatures=1.44.0,bioconductor-deseq2=1.32.0,r-reshape2=1.4.4,r-getopt=1.20.3,bioconductor-tximport=1.20.0,bioconductor-ruvseq=1.26.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6ed46bb014d9efe57c15a2e51b4be8fed2d7be30:24c8124c42ce709f0fbcf725f55b149a7a16f524

**Packages**:
- r-ggrepel=0.9.1
- bioconductor-genomicfeatures=1.44.0
- bioconductor-deseq2=1.32.0
- r-reshape2=1.4.4
- r-getopt=1.20.3
- bioconductor-tximport=1.20.0
- bioconductor-ruvseq=1.26.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ruvseq.xml

Generated with Planemo.