### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:69657e900f81b0253c58942b23b592d8b5bf7561.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:69657e900f81b0253c58942b23b592d8b5bf7561-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:69657e900f81b0253c58942b23b592d8b5bf7561-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+busco=5.2.2,fonts-conda-ecosystem=1,tar=1.34	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:69657e900f81b0253c58942b23b592d8b5bf7561

**Packages**:
- busco=5.2.2
- fonts-conda-ecosystem=1
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.