### PR TITLE
Add container mulled-v2-6bcf23f36e374f2041ca44adff8b58ac35968446:d0db49ae0a45fd4042326c9f32184674f06f7f1c.

### DIFF
--- a/combinations/mulled-v2-6bcf23f36e374f2041ca44adff8b58ac35968446:d0db49ae0a45fd4042326c9f32184674f06f7f1c-0.tsv
+++ b/combinations/mulled-v2-6bcf23f36e374f2041ca44adff8b58ac35968446:d0db49ae0a45fd4042326c9f32184674f06f7f1c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggplot2=3.3.3,r-cowplot=1.1.1,r-dplyr=1.0.5,r-ggcorrplot=0.1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6bcf23f36e374f2041ca44adff8b58ac35968446:d0db49ae0a45fd4042326c9f32184674f06f7f1c

**Packages**:
- r-ggplot2=3.3.3
- r-cowplot=1.1.1
- r-dplyr=1.0.5
- r-ggcorrplot=0.1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stat_presence_abs.xml

Generated with Planemo.