### PR TITLE
Add container mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:a0768a19526977858dc766bca043bebddf290a58.

### DIFF
--- a/combinations/mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:a0768a19526977858dc766bca043bebddf290a58-0.tsv
+++ b/combinations/mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:a0768a19526977858dc766bca043bebddf290a58-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+openpyxl=3.0.7,pysam=0.16.0.1,biopython=1.79,pandas=1.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:a0768a19526977858dc766bca043bebddf290a58

**Packages**:
- openpyxl=3.0.7
- pysam=0.16.0.1
- biopython=1.79
- pandas=1.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_add_zero_coverage.xml

Generated with Planemo.