### PR TITLE
Add container mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:05404be5589f67ec741a7d5090cc16d5b0174b6a.

### DIFF
--- a/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:05404be5589f67ec741a7d5090cc16d5b0174b6a-0.tsv
+++ b/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:05404be5589f67ec741a7d5090cc16d5b0174b6a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.1.0,vardict-java=1.8.2,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:05404be5589f67ec741a7d5090cc16d5b0174b6a

**Packages**:
- gawk=5.1.0
- vardict-java=1.8.2
- samtools=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vardict.xml

Generated with Planemo.