### PR TITLE
fix: added missing ghostscript for mars-seq pipeline

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -144,4 +144,4 @@ bwa=0.7.17,samtools=1.9,bcftools=1.9	quay.io/bioconda/base-glibc-debian-bash:lat
 star=2.7.9a,samtools=1.13,gawk=5.1.0
 python=3.9,pandas=1.3.0,seaborn=0.11.0,rich=10.6.0,typer=0.3.2,bcbio-gff=0.6.6,dna_features_viewer=3.0.3
 r-base=4.0.3,r-alakazam=1.0.2,r-shazam=1.0.2,r-airr=1.3.0,r-kableextra=1.3.4,r-dt=0.18,r-knitr=1.33,r-rmarkdown=2.8,r-dplyr=1.0.6
-r-mass=7.3_54,r-zoo=1.8_9,r-gplots=3.1.1
+r-mass=7.3_54,r-zoo=1.8_9,r-gplots=3.1.1,ghostscript


### PR DESCRIPTION
Turns out that when the pipeline generates pdf it uses `gs`. In this PR I just include the requirement. Thank you 🙂 