### PR TITLE
Add container mulled-v2-755fcadb19072ca3f80d3c2d6a0f45ec8c43d933:eb7da4fed8ba187298b1528fbec9e24044b8ab67.

### DIFF
--- a/combinations/mulled-v2-755fcadb19072ca3f80d3c2d6a0f45ec8c43d933:eb7da4fed8ba187298b1528fbec9e24044b8ab67-0.tsv
+++ b/combinations/mulled-v2-755fcadb19072ca3f80d3c2d6a0f45ec8c43d933:eb7da4fed8ba187298b1528fbec9e24044b8ab67-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+instrain=1.5.3,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-755fcadb19072ca3f80d3c2d6a0f45ec8c43d933:eb7da4fed8ba187298b1528fbec9e24044b8ab67

**Packages**:
- instrain=1.5.3
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- instrain_profile.xml

Generated with Planemo.