### PR TITLE
Add container mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:22b21b0a08ff5753b0d52a54d5fc6a7d32d65ba0.

### DIFF
--- a/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:22b21b0a08ff5753b0d52a54d5fc6a7d32d65ba0-0.tsv
+++ b/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:22b21b0a08ff5753b0d52a54d5fc6a7d32d65ba0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pretextmap=0.1.7,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:22b21b0a08ff5753b0d52a54d5fc6a7d32d65ba0

**Packages**:
- pretextmap=0.1.7
- samtools=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pretext_map.xml

Generated with Planemo.