### PR TITLE
Add container mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:6c1dbf15984af2225995ff66d548799490ac0d08.

### DIFF
--- a/combinations/mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:6c1dbf15984af2225995ff66d548799490ac0d08-0.tsv
+++ b/combinations/mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:6c1dbf15984af2225995ff66d548799490ac0d08-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+openpyxl=3.0.7,biopython=1.79,pandas=1.3.0,numpy=1.21.1,xlrd=2.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:6c1dbf15984af2225995ff66d548799490ac0d08

**Packages**:
- openpyxl=3.0.7
- biopython=1.79
- pandas=1.3.0
- numpy=1.21.1
- xlrd=2.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_statistics.xml

Generated with Planemo.