### PR TITLE
Add container mulled-v2-374b2141964201351e992c411ce6c775efa37626:c667abd391943d373700d0b9c8ceb0c7b7355812.

### DIFF
--- a/combinations/mulled-v2-374b2141964201351e992c411ce6c775efa37626:c667abd391943d373700d0b9c8ceb0c7b7355812-0.tsv
+++ b/combinations/mulled-v2-374b2141964201351e992c411ce6c775efa37626:c667abd391943d373700d0b9c8ceb0c7b7355812-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggplot2=3.3.5,r-maldiquantforeign=0.12,r-maldiquant=1.20,bioconductor-cardinal=2.10.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-374b2141964201351e992c411ce6c775efa37626:c667abd391943d373700d0b9c8ceb0c7b7355812

**Packages**:
- r-ggplot2=3.3.5
- r-maldiquantforeign=0.12
- r-maldiquant=1.20
- bioconductor-cardinal=2.10.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- combine.xml

Generated with Planemo.