### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3b60029b26dffd91d25ee23ebab81dbb630ad135.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3b60029b26dffd91d25ee23ebab81dbb630ad135-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3b60029b26dffd91d25ee23ebab81dbb630ad135-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils,nextclade=1.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3b60029b26dffd91d25ee23ebab81dbb630ad135

**Packages**:
- coreutils
- nextclade=1.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.