### PR TITLE
Add container mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:5ba01bc7e5b4a6b4b710393faa4156d843145afb.

### DIFF
--- a/combinations/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:5ba01bc7e5b4a6b4b710393faa4156d843145afb-0.tsv
+++ b/combinations/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:5ba01bc7e5b4a6b4b710393faa4156d843145afb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pigz=2.5,sra-tools=2.11.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:5ba01bc7e5b4a6b4b710393faa4156d843145afb

**Packages**:
- pigz=2.5
- sra-tools=2.11.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fasterq_dump.xml
- fastq_dump.xml

Generated with Planemo.