### PR TITLE
Add container mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:92be6be3826078ef65953b7f3bd356d19bfe45d5.

### DIFF
--- a/combinations/mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:92be6be3826078ef65953b7f3bd356d19bfe45d5-0.tsv
+++ b/combinations/mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:92be6be3826078ef65953b7f3bd356d19bfe45d5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-kernsmooth=2.23_20,r-scales=1.1.1,r-rcolorbrewer=1.1_2,r-ggplot2=3.3.5,bioconductor-cardinal=2.10.0,r-gridextra=2.3,r-pheatmap=1.0.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-01faa1938d8e492ca7fa7c64f8bff8f1cf12b007:92be6be3826078ef65953b7f3bd356d19bfe45d5

**Packages**:
- r-kernsmooth=2.23_20
- r-scales=1.1.1
- r-rcolorbrewer=1.1_2
- r-ggplot2=3.3.5
- bioconductor-cardinal=2.10.0
- r-gridextra=2.3
- r-pheatmap=1.0.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- quality_report.xml

Generated with Planemo.