### PR TITLE
Add container mulled-v2-5f9af68cbba5a65e63088a597dd671d52ac290ed:f8e81b227aa8d33d64a1d8c9a34115e78af7b284.

### DIFF
--- a/combinations/mulled-v2-5f9af68cbba5a65e63088a597dd671d52ac290ed:f8e81b227aa8d33d64a1d8c9a34115e78af7b284-0.tsv
+++ b/combinations/mulled-v2-5f9af68cbba5a65e63088a597dd671d52ac290ed:f8e81b227aa8d33d64a1d8c9a34115e78af7b284-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-scater=1.20.0,r-scales=1.1.1,r-workflowscriptscommon=0.0.7,r-optparse=1.6.6,r-ggpubr=0.4.0,bioconductor-loomexperiment=1.10.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5f9af68cbba5a65e63088a597dd671d52ac290ed:f8e81b227aa8d33d64a1d8c9a34115e78af7b284

**Packages**:
- bioconductor-scater=1.20.0
- r-scales=1.1.1
- r-workflowscriptscommon=0.0.7
- r-optparse=1.6.6
- r-ggpubr=0.4.0
- bioconductor-loomexperiment=1.10.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scater-plot-dist-scatter.xml

Generated with Planemo.