### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7c7abf911e92d7fb831611ffb965f3cf7fe2c01d.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7c7abf911e92d7fb831611ffb965f3cf7fe2c01d-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7c7abf911e92d7fb831611ffb965f3cf7fe2c01d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.10,pigz=2.5,sra-tools=2.11.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7c7abf911e92d7fb831611ffb965f3cf7fe2c01d

**Packages**:
- samtools=1.10
- pigz=2.5
- sra-tools=2.11.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sam_dump.xml

Generated with Planemo.