### PR TITLE
Add container mulled-v2-59f626fc21ed823aae2a42e936d849c617df2e11:3b8f1f4ecca0ff4596f2d09011a9ea899e798bf2.

### DIFF
--- a/combinations/mulled-v2-59f626fc21ed823aae2a42e936d849c617df2e11:3b8f1f4ecca0ff4596f2d09011a9ea899e798bf2-0.tsv
+++ b/combinations/mulled-v2-59f626fc21ed823aae2a42e936d849c617df2e11:3b8f1f4ecca0ff4596f2d09011a9ea899e798bf2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+stacks=2.55,python=3.7,findutils=4.6.0,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-59f626fc21ed823aae2a42e936d849c617df2e11:3b8f1f4ecca0ff4596f2d09011a9ea899e798bf2

**Packages**:
- stacks=2.55
- python=3.7
- findutils=4.6.0
- samtools=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stacks_gstacks.xml
- stacks_tsv2bam.xml

Generated with Planemo.