### PR TITLE
Add container mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:b867545cda89fb1c1306f33027739fb256e0fc48.

### DIFF
--- a/combinations/mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:b867545cda89fb1c1306f33027739fb256e0fc48-0.tsv
+++ b/combinations/mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:b867545cda89fb1c1306f33027739fb256e0fc48-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-scater=1.20.0,r-optparse=1.6.6,r-workflowscriptscommon=0.0.7,bioconductor-loomexperiment=1.10.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:b867545cda89fb1c1306f33027739fb256e0fc48

**Packages**:
- bioconductor-scater=1.20.0
- r-optparse=1.6.6
- r-workflowscriptscommon=0.0.7
- bioconductor-loomexperiment=1.10.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scater-create-qcmetric-ready-sce.xml
- scater-plot-pca.xml

Generated with Planemo.