### PR TITLE
Add container mulled-v2-a6021cfef9b68c3407b315a94bb7cc491870e691:d44536386d753417447dba1fcdb9d603a567f815.

### DIFF
--- a/combinations/mulled-v2-a6021cfef9b68c3407b315a94bb7cc491870e691:d44536386d753417447dba1fcdb9d603a567f815-0.tsv
+++ b/combinations/mulled-v2-a6021cfef9b68c3407b315a94bb7cc491870e691:d44536386d753417447dba1fcdb9d603a567f815-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-scater=1.20.0,r-robustbase=0.93_8,r-workflowscriptscommon=0.0.7,r-optparse=1.6.6,bioconductor-loomexperiment=1.10.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a6021cfef9b68c3407b315a94bb7cc491870e691:d44536386d753417447dba1fcdb9d603a567f815

**Packages**:
- bioconductor-scater=1.20.0
- r-robustbase=0.93_8
- r-workflowscriptscommon=0.0.7
- r-optparse=1.6.6
- bioconductor-loomexperiment=1.10.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scater-filter.xml

Generated with Planemo.