### PR TITLE
Rebuild StringTie 1.1.0

### DIFF
--- a/combinations/stringtie:1.1.0-1.tsv
+++ b/combinations/stringtie:1.1.0-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+stringtie=1.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	1


### PR DESCRIPTION
A bit silly for such an old version but the image that exists is completely broken (no bash, no libz, etc.).