### PR TITLE
Add container mulled-v2-86fa6d365a399d238d32e15f42ea8185744dd085:f9c22d8f41833ed81f99318d0121add982deae4d.

### DIFF
--- a/combinations/mulled-v2-86fa6d365a399d238d32e15f42ea8185744dd085:f9c22d8f41833ed81f99318d0121add982deae4d-0.tsv
+++ b/combinations/mulled-v2-86fa6d365a399d238d32e15f42ea8185744dd085:f9c22d8f41833ed81f99318d0121add982deae4d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.6,r-base=4.1.0,peakachu=0.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-86fa6d365a399d238d32e15f42ea8185744dd085:f9c22d8f41833ed81f99318d0121add982deae4d

**Packages**:
- python=3.6
- r-base=4.1.0
- peakachu=0.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- peakachu.xml

Generated with Planemo.