### PR TITLE
Add container mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:b6524911af823c7c52518f6c886b86916d062940.

### DIFF
--- a/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:b6524911af823c7c52518f6c886b86916d062940-0.tsv
+++ b/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:b6524911af823c7c52518f6c886b86916d062940-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie2=2.4.4,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:b6524911af823c7c52518f6c886b86916d062940

**Packages**:
- bowtie2=2.4.4
- samtools=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bowtie2_wrapper.xml

Generated with Planemo.