### PR TITLE
Add container mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ae453618cde8e164d9645b6a9d8c83fbc3bc8884.

### DIFF
--- a/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ae453618cde8e164d9645b6a9d8c83fbc3bc8884-0.tsv
+++ b/combinations/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ae453618cde8e164d9645b6a9d8c83fbc3bc8884-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pretextmap=0.1.8,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:ae453618cde8e164d9645b6a9d8c83fbc3bc8884

**Packages**:
- pretextmap=0.1.8
- samtools=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pretext_map.xml

Generated with Planemo.