### PR TITLE
Add container mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:9c5efc89686d718e262836409bbf8541c6c5a159.

### DIFF
--- a/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:9c5efc89686d718e262836409bbf8541c6c5a159-0.tsv
+++ b/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:9c5efc89686d718e262836409bbf8541c6c5a159-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sed=4.7,umi_tools=1.1.2,samtools=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:9c5efc89686d718e262836409bbf8541c6c5a159

**Packages**:
- sed=4.7
- umi_tools=1.1.2
- samtools=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_counts.xml

Generated with Planemo.