### PR TITLE
Add container mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:f00c8145f4b788d5ee49b4ba6eec2ee479298f7e.

### DIFF
--- a/combinations/mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:f00c8145f4b788d5ee49b4ba6eec2ee479298f7e-0.tsv
+++ b/combinations/mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:f00c8145f4b788d5ee49b4ba6eec2ee479298f7e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+umi_tools=1.1.2,samtools=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:f00c8145f4b788d5ee49b4ba6eec2ee479298f7e

**Packages**:
- umi_tools=1.1.2
- samtools=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_group.xml
- umi-tools_dedup.xml

Generated with Planemo.