### PR TITLE
bbmap,samtools,pigz

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -150,3 +150,4 @@ r-base=4.1.0,r-rmarkdown=2.9,r-yaml=2.2.1
 r-mass=7.3_54,r-zoo=1.8_9,r-gplots=3.1.1,ghostscript
 chromap=0.1,samtools=1.13
 bbmap=38.92,samtools=1.13
+bbmap=38.92,samtools=1.13,pigz=2.6


### PR DESCRIPTION
Sorry about this, pigz should have been in yesterday's PR, but hadn't seen that pigz is needed for a flag.

I chose to add as another line/container, I'm fine with deleting the `bbmap=38.92,samtools=1.13` line.