### PR TITLE
Add container mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:b1bc70d1180ee21fe9b53f79a2e0e1f5f0db5385.

### DIFF
--- a/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:b1bc70d1180ee21fe9b53f79a2e0e1f5f0db5385-0.tsv
+++ b/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:b1bc70d1180ee21fe9b53f79a2e0e1f5f0db5385-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+last=1256,proteinortho=6.0.31,blat=36,blast=2.12.0,diamond=2.0.9	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:b1bc70d1180ee21fe9b53f79a2e0e1f5f0db5385

**Packages**:
- last=1256
- proteinortho=6.0.31
- blat=36
- blast=2.12.0
- diamond=2.0.9
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho.xml
- proteinortho_summary.xml
- proteinortho_grab_proteins.xml

Generated with Planemo.