### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:df247d9c739d2bbcb045598045bcea69e6f5f8bb.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:df247d9c739d2bbcb045598045bcea69e6f5f8bb-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:df247d9c739d2bbcb045598045bcea69e6f5f8bb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+yak=0.1,hifiasm=0.16.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:df247d9c739d2bbcb045598045bcea69e6f5f8bb

**Packages**:
- yak=0.1
- hifiasm=0.16.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.