### PR TITLE
Add container mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:96a4a122d96d1e54cc88ea2d99553214e34b1d6b.

### DIFF
--- a/combinations/mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:96a4a122d96d1e54cc88ea2d99553214e34b1d6b-0.tsv
+++ b/combinations/mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:96a4a122d96d1e54cc88ea2d99553214e34b1d6b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.32,infernal,infernal=1.1.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:96a4a122d96d1e54cc88ea2d99553214e34b1d6b

**Packages**:
- coreutils=8.32
- infernal
- infernal=1.1.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cmsearch.xml
- cmstat.xml
- cmalign.xml
- cmpress.xml
- cmbuild.xml
- cmscan.xml

Generated with Planemo.