### PR TITLE
Add container mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:05bc19c8b87c51b59349f9151e8741a6c19e5b2e.

### DIFF
--- a/combinations/mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:05bc19c8b87c51b59349f9151e8741a6c19e5b2e-0.tsv
+++ b/combinations/mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:05bc19c8b87c51b59349f9151e8741a6c19e5b2e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+infernal=1.1.4,infernal,coreutils=8.32	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f2523559880abe1637e3e1ea67a33632c6dcc2f2:05bc19c8b87c51b59349f9151e8741a6c19e5b2e

**Packages**:
- infernal=1.1.4
- infernal
- coreutils=8.32
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cmsearch.xml
- cmstat.xml
- cmalign.xml
- cmpress.xml
- cmbuild.xml
- cmscan.xml

Generated with Planemo.