### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:6e7adab07229e340ac51c77a2f9f806cf7e0444b.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:6e7adab07229e340ac51c77a2f9f806cf7e0444b-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:6e7adab07229e340ac51c77a2f9f806cf7e0444b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+nextclade=1.3.0,coreutils=8.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:6e7adab07229e340ac51c77a2f9f806cf7e0444b

**Packages**:
- nextclade=1.3.0
- coreutils=8.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.