### PR TITLE
Add container mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:d59c9046e6b3407711bdd7cef448c4bc6fd00001.

### DIFF
--- a/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:d59c9046e6b3407711bdd7cef448c4bc6fd00001-0.tsv
+++ b/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:d59c9046e6b3407711bdd7cef448c4bc6fd00001-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.13,stringtie=2.1.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:d59c9046e6b3407711bdd7cef448c4bc6fd00001

**Packages**:
- samtools=1.13
- stringtie=2.1.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stringtie.xml
- stringtie_merge.xml

Generated with Planemo.