### PR TITLE
Add container mulled-v2-a1815becb0eb93979f460c7a36cdd5abbf9659ec:2900bec866c4d6c4f9259ecc6c80959ca1472313.

### DIFF
--- a/combinations/mulled-v2-a1815becb0eb93979f460c7a36cdd5abbf9659ec:2900bec866c4d6c4f9259ecc6c80959ca1472313-0.tsv
+++ b/combinations/mulled-v2-a1815becb0eb93979f460c7a36cdd5abbf9659ec:2900bec866c4d6c4f9259ecc6c80959ca1472313-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+chemfp=1.6.1,matplotlib=2.2.5,scipy=1.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a1815becb0eb93979f460c7a36cdd5abbf9659ec:2900bec866c4d6c4f9259ecc6c80959ca1472313

**Packages**:
- chemfp=1.6.1
- matplotlib=2.2.5
- scipy=1.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nxn_clustering.xml

Generated with Planemo.