### PR TITLE
Add container mulled-v2-e3c9cd0074caea4da98a144225544117285c91cd:2c631310a7e524e0efeeea919b1ef6de2575eaab.

### DIFF
--- a/combinations/mulled-v2-e3c9cd0074caea4da98a144225544117285c91cd:2c631310a7e524e0efeeea919b1ef6de2575eaab-0.tsv
+++ b/combinations/mulled-v2-e3c9cd0074caea4da98a144225544117285c91cd:2c631310a7e524e0efeeea919b1ef6de2575eaab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.7,pindel=0.2.5b8,openssl=1.0,python=3.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e3c9cd0074caea4da98a144225544117285c91cd:2c631310a7e524e0efeeea919b1ef6de2575eaab

**Packages**:
- samtools=1.7
- pindel=0.2.5b8
- openssl=1.0
- python=3.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pindelwrapper.xml

Generated with Planemo.