### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3c15954b701f6e52973cafeb7fef76e1f9d46881.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3c15954b701f6e52973cafeb7fef76e1f9d46881-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3c15954b701f6e52973cafeb7fef76e1f9d46881-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.31,nextclade=1.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:3c15954b701f6e52973cafeb7fef76e1f9d46881

**Packages**:
- coreutils=8.31
- nextclade=1.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.