### PR TITLE
bump vardict again

### DIFF
--- a/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:05404be5589f67ec741a7d5090cc16d5b0174b6a-0.tsv
+++ b/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:05404be5589f67ec741a7d5090cc16d5b0174b6a-0.tsv
@@ -1,2 +1,2 @@
 #targets	base_image	image_build
-gawk=5.1.0,vardict-java=1.8.2,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	1
+gawk=5.1.0,vardict-java=1.8.2,samtools=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	2


### PR DESCRIPTION
the container still contained an old R that suffered from missing
`libreadline.so.6`

xref https://github.com/bioconda/bioconda-recipes/pull/30857