### PR TITLE
Add container mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:1f4c57f5765a5043954172f6aec61bbda6d0104d.

### DIFF
--- a/combinations/mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:1f4c57f5765a5043954172f6aec61bbda6d0104d-0.tsv
+++ b/combinations/mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:1f4c57f5765a5043954172f6aec61bbda6d0104d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python-bioext=0.20.1,samtools=1.13,gawk=5.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:1f4c57f5765a5043954172f6aec61bbda6d0104d

**Packages**:
- python-bioext=0.20.1
- samtools=1.13
- gawk=5.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bealign.xml

Generated with Planemo.