### PR TITLE
Use cname for depot.galaxyproject.org in scp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,9 @@ jobs:
         INVOLUCRO_AUTH: "https://${{ secrets.MY_USER }}:${{ secrets.MY_PASSWORD }}@quay.io/v1/?email=${{ secrets.MY_EMAIL }}"
       run: |
          mkdir -p ~/.ssh
-         ssh-keyscan -t rsa orval.galaxyproject.org >> ~/.ssh/known_hosts
+         ssh-keyscan -t rsa depot.galaxyproject.org >> ~/.ssh/known_hosts
          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
          ssh-add - <<< "${{ secrets.ORVAL_KEY }}"
          mulled-build-files --check-published --namespace $MULLED_NAMESPACE --oauth-token ${{ secrets.QUAY_OAUTH_TOKEN }} push ./combinations
          ls -l singularity_import
-         [ "$(ls -A singularity_import)" ] && echo 'uploading Singularity images' && scp singularity_import/*:* singularity@orval.galaxyproject.org:/srv/nginx/depot.galaxyproject.org/root/singularity/
+         [ "$(ls -A singularity_import)" ] && echo 'uploading Singularity images' && scp singularity_import/*:* singularity@depot.galaxyproject.org:/srv/nginx/depot.galaxyproject.org/root/singularity/


### PR DESCRIPTION
We are migrating depot to a new system, the underlying hostname will change from orval but the depot cname will update to point at the new system.