### PR TITLE
Add container mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07.

### DIFF
--- a/combinations/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07-0.tsv
+++ b/combinations/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.13,bwa-mem2=2.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:c5b8c4b7735290369693e2b63cfc1ea0732fde07

**Packages**:
- samtools=1.13
- bwa-mem2=2.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bwa-mem2.xml

Generated with Planemo.