### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:9f578e46d1430e4cc8561c4918ebc47726e52d07.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:9f578e46d1430e4cc8561c4918ebc47726e52d07-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:9f578e46d1430e4cc8561c4918ebc47726e52d07-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.31,nextclade=1.4.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:9f578e46d1430e4cc8561c4918ebc47726e52d07

**Packages**:
- coreutils=8.31
- nextclade=1.4.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.