### PR TITLE
Add container mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:22b310ccf52b87dd9a17b08cc95d86af5c99dabb.

### DIFF
--- a/combinations/mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:22b310ccf52b87dd9a17b08cc95d86af5c99dabb-0.tsv
+++ b/combinations/mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:22b310ccf52b87dd9a17b08cc95d86af5c99dabb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.4.3,htslib=1.10,bcftools=1.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:22b310ccf52b87dd9a17b08cc95d86af5c99dabb

**Packages**:
- matplotlib=3.4.3
- htslib=1.10
- bcftools=1.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_cnv.xml

Generated with Planemo.