### PR TITLE
Add container mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:d13ddfd2ca1392eb218a6ad377a31776ec95e494.

### DIFF
--- a/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:d13ddfd2ca1392eb218a6ad377a31776ec95e494-0.tsv
+++ b/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:d13ddfd2ca1392eb218a6ad377a31776ec95e494-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcftools=1.10,samtools=1.10,tectonic=0.8.0,htslib=1.10,matplotlib=3.4.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:d13ddfd2ca1392eb218a6ad377a31776ec95e494

**Packages**:
- bcftools=1.10
- samtools=1.10
- tectonic=0.8.0
- htslib=1.10
- matplotlib=3.4.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_stats.xml

Generated with Planemo.