### PR TITLE
Add container mulled-v2-039542721b6b463b663872ba8b7e9fbc05f01925:1de88053ebf8fb9884758395c4871f642c57750c.

### DIFF
--- a/combinations/mulled-v2-039542721b6b463b663872ba8b7e9fbc05f01925:1de88053ebf8fb9884758395c4871f642c57750c-0.tsv
+++ b/combinations/mulled-v2-039542721b6b463b663872ba8b7e9fbc05f01925:1de88053ebf8fb9884758395c4871f642c57750c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8,grep=2.14,coreutils=8.31,sed=4.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-039542721b6b463b663872ba8b7e9fbc05f01925:1de88053ebf8fb9884758395c4871f642c57750c

**Packages**:
- python=3.8
- grep=2.14
- coreutils=8.31
- sed=4.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sorter.xml

Generated with Planemo.