### PR TITLE
Add container mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:ca5b522580b80dfcad59519f746e6ef77c9a856a.

### DIFF
--- a/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:ca5b522580b80dfcad59519f746e6ef77c9a856a-0.tsv
+++ b/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:ca5b522580b80dfcad59519f746e6ef77c9a856a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+abyss=2.3.2,bwa=0.7.17	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:ca5b522580b80dfcad59519f746e6ef77c9a856a

**Packages**:
- abyss=2.3.2
- bwa=0.7.17
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- abyss-pe.xml

Generated with Planemo.