### PR TITLE
Add container mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:6fd142ad831858be89ffd21721af33b240f5f08d.

### DIFF
--- a/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:6fd142ad831858be89ffd21721af33b240f5f08d-0.tsv
+++ b/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:6fd142ad831858be89ffd21721af33b240f5f08d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rmarkdown=2.11,r-seurat=4.0.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:6fd142ad831858be89ffd21721af33b240f5f08d

**Packages**:
- r-rmarkdown=2.11
- r-seurat=4.0.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.