### PR TITLE
Add container biom-format:2.1.10.

### DIFF
--- a/combinations/biom-format:2.1.10-0.tsv
+++ b/combinations/biom-format:2.1.10-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biom-format=2.1.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: biom-format:2.1.10

**Packages**:
- biom-format=2.1.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- biom_add_metadata.xml
- biom_from_uc.xml
- biom_normalize_table.xml
- biom_convert.xml
- biom_summarize_table.xml
- biom_subset_table.xml

Generated with Planemo.