### PR TITLE
Include multicontainer for fred2 (2.0.7), mhcflurry (2.0.1), and python (2.7.18)

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -159,4 +159,3 @@ megahit=1.2.9,pigz=2.6
 sra-tools=2.11.0,pigz=2.6
 biopython=1.78,blast=2.9.0,pysam=0.17.0
 r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1,r-dplyr=1.0.7	quay.io/bioconda/base-glibc-debian-bash:latest	0
-fred2=2.0.7,mhcflurry=2.0.1,mhcnuggets=2.3.2

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -160,3 +160,5 @@ sra-tools=2.11.0,pigz=2.6
 biopython=1.78,blast=2.9.0,pysam=0.17.0
 r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1,r-dplyr=1.0.7	quay.io/bioconda/base-glibc-debian-bash:latest	0
 samblaster=0.1.26,samtools=1.14
+fred2=2.0.7,mhcflurry=2.0.1,mhcnuggets=2.3.2
+fred2=2.0.7,mhcflurry=1.4.3

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -160,5 +160,4 @@ sra-tools=2.11.0,pigz=2.6
 biopython=1.78,blast=2.9.0,pysam=0.17.0
 r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1,r-dplyr=1.0.7	quay.io/bioconda/base-glibc-debian-bash:latest	0
 samblaster=0.1.26,samtools=1.14
-fred2=2.0.7,mhcflurry=2.0.1,mhcnuggets=2.3.2,python=2.7.18
 fred2=2.0.7,mhcflurry=1.4.3,python=2.7.18

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -159,3 +159,4 @@ megahit=1.2.9,pigz=2.6
 sra-tools=2.11.0,pigz=2.6
 biopython=1.78,blast=2.9.0,pysam=0.17.0
 r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1,r-dplyr=1.0.7	quay.io/bioconda/base-glibc-debian-bash:latest	0
+fred2=2.0.7,mhcflurry=2.0.1,mhcnuggets=2.3.2

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -160,5 +160,5 @@ sra-tools=2.11.0,pigz=2.6
 biopython=1.78,blast=2.9.0,pysam=0.17.0
 r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1,r-dplyr=1.0.7	quay.io/bioconda/base-glibc-debian-bash:latest	0
 samblaster=0.1.26,samtools=1.14
-fred2=2.0.7,mhcflurry=2.0.1,mhcnuggets=2.3.2
-fred2=2.0.7,mhcflurry=1.4.3
+fred2=2.0.7,mhcflurry=2.0.1,mhcnuggets=2.3.2,python=2.7.18
+fred2=2.0.7,mhcflurry=1.4.3,python=2.7.18


### PR DESCRIPTION
Include target: multi-package container fred2 (2.0.7), mhcflurry (2.0.1), and mhcnuggets (2.3.2)