### PR TITLE
Add container mulled-v2-e26ee6da54e864218a775232cf0c4f68bce1f2ec:0ce51db549d4c542d8696560b38ac4db64601b3f.

### DIFF
--- a/combinations/mulled-v2-e26ee6da54e864218a775232cf0c4f68bce1f2ec:0ce51db549d4c542d8696560b38ac4db64601b3f-0.tsv
+++ b/combinations/mulled-v2-e26ee6da54e864218a775232cf0c4f68bce1f2ec:0ce51db549d4c542d8696560b38ac4db64601b3f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-latticeextra=0.6_29=r40hc72bb7e_1,sambamba=0.8.1=h41abebc_0,pysam=0.17.0=py37h45aed0b_0,r-gridextra=2.3=r40hc72bb7e_1003,r-optparse=1.7.1=r40hc72bb7e_0,r-reshape2=1.4.4=r40h03ef668_1,icu=68.1=h58526e2_0,numpy=1.21.3=py37h31617e3_0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e26ee6da54e864218a775232cf0c4f68bce1f2ec:0ce51db549d4c542d8696560b38ac4db64601b3f

**Packages**:
- r-latticeextra=0.6_29=r40hc72bb7e_1
- sambamba=0.8.1=h41abebc_0
- pysam=0.17.0=py37h45aed0b_0
- r-gridextra=2.3=r40hc72bb7e_1003
- r-optparse=1.7.1=r40hc72bb7e_0
- r-reshape2=1.4.4=r40h03ef668_1
- icu=68.1=h58526e2_0
- numpy=1.21.3=py37h31617e3_0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- small_rna_maps.xml

Generated with Planemo.