### PR TITLE
Add container mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:40128b496751b037e2bd85f6789e83d4ff8a4837.

### DIFF
--- a/combinations/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:40128b496751b037e2bd85f6789e83d4ff8a4837-0.tsv
+++ b/combinations/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:40128b496751b037e2bd85f6789e83d4ff8a4837-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.14,bowtie=1.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:40128b496751b037e2bd85f6789e83d4ff8a4837

**Packages**:
- samtools=1.14
- bowtie=1.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sRbowtie.xml

Generated with Planemo.