### PR TITLE
Add container mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:951e914d3ad608df43a6513769e60ae8de57d13e.

### DIFF
--- a/combinations/mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:951e914d3ad608df43a6513769e60ae8de57d13e-0.tsv
+++ b/combinations/mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:951e914d3ad608df43a6513769e60ae8de57d13e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.14,python=3.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1a35167f7a491c7086c13835aaa74b39f1f43979:951e914d3ad608df43a6513769e60ae8de57d13e

**Packages**:
- samtools=1.14
- python=3.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_sam_fasta_index_builder.xml

Generated with Planemo.