### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:7f553ccd74a6a0f7a7502bf9a987c3e59347987d.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:7f553ccd74a6a0f7a7502bf9a987c3e59347987d-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:7f553ccd74a6a0f7a7502bf9a987c3e59347987d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasta3=36.3.8,mafft=7.489	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:7f553ccd74a6a0f7a7502bf9a987c3e59347987d

**Packages**:
- fasta3=36.3.8
- mafft=7.489
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mafft-add.xml
- mafft.xml

Generated with Planemo.