### PR TITLE
Add container mulled-v2-9b02bd279180dfb6eb4bdeb5093497aa615430f0:2560952d817283a3284a2e1815a1043043c17fe4.

### DIFF
--- a/combinations/mulled-v2-9b02bd279180dfb6eb4bdeb5093497aa615430f0:2560952d817283a3284a2e1815a1043043c17fe4-0.tsv
+++ b/combinations/mulled-v2-9b02bd279180dfb6eb4bdeb5093497aa615430f0:2560952d817283a3284a2e1815a1043043c17fe4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-svglite=2.0.0,r-reshape2=1.4.4,r-cowplot=1.1.1,r-egg=0.4.5,r-ggdendro=0.1.22,r-dplyr=1.0.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9b02bd279180dfb6eb4bdeb5093497aa615430f0:2560952d817283a3284a2e1815a1043043c17fe4

**Packages**:
- r-svglite=2.0.0
- r-reshape2=1.4.4
- r-cowplot=1.1.1
- r-egg=0.4.5
- r-ggdendro=0.1.22
- r-dplyr=1.0.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ggplot2_heatmap.xml

Generated with Planemo.