### PR TITLE
Add container mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:1437f69133e41138dec8d584e9a93fe754b97154.

### DIFF
--- a/combinations/mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:1437f69133e41138dec8d584e9a93fe754b97154-0.tsv
+++ b/combinations/mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:1437f69133e41138dec8d584e9a93fe754b97154-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggplot2=3.3.5,r-base=4.1.1,r-reshape2=1.4.4,r-svglite=2.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:1437f69133e41138dec8d584e9a93fe754b97154

**Packages**:
- r-ggplot2=3.3.5
- r-base=4.1.1
- r-reshape2=1.4.4
- r-svglite=2.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ggplot_histogram.xml
- ggplot_violin.xml

Generated with Planemo.