### PR TITLE
Add multi-package container for shm_csr tool on ARGalaxy

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -162,3 +162,4 @@ r-recetox-aplcms=0.9.3,r-base=4.1.0,r-arrow=4.0.1,r-dplyr=1.0.7	quay.io/bioconda
 samblaster=0.1.26,samtools=1.14
 circularmapper=1.93.5,bwa=0.7.17
 r-optparse=1.7.1,r-upsetr=1.4.0,bedtools=2.30.0
+python=3.7.1,changeo=0.4.4,biopython=1.72,xlrd=1.2.0,r-ggplot2=3.0.0,r-reshape2=1.4.3,r-scales=0.5.0,r-seqinr=3.4_5,r-data.table=1.11.4,unzip=6.0,bash=4.4.18,tar=1.34,file=5.39


### PR DESCRIPTION
This container is quite difficult to solve without strict channel priority. But with it, it solves in 15 seconds.

This is needed for the Somatic Hypermutation pipeline in ARGalaxy. Previously this did not have a proper container to run in. (Only conda).