### PR TITLE
Add container mulled-v2-dbf158d5d75e5bcc5740c9a658e55c43d146f76c:01fdf8e6c43aadd8f430adb67228daf9e38b0d30.

### DIFF
--- a/combinations/mulled-v2-dbf158d5d75e5bcc5740c9a658e55c43d146f76c:01fdf8e6c43aadd8f430adb67228daf9e38b0d30-0.tsv
+++ b/combinations/mulled-v2-dbf158d5d75e5bcc5740c9a658e55c43d146f76c:01fdf8e6c43aadd8f430adb67228daf9e38b0d30-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.32,trinity=2.9.1,rsync=3.2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dbf158d5d75e5bcc5740c9a658e55c43d146f76c:01fdf8e6c43aadd8f430adb67228daf9e38b0d30

**Packages**:
- coreutils=8.32
- trinity=2.9.1
- rsync=3.2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- trinity.xml

Generated with Planemo.