### PR TITLE
Add container mulled-v2-557d564058ddc35a247887bebc5197cae96f3347:c450539e24dfe6a08369d2b75448daa8b7c6ac98.

### DIFF
--- a/combinations/mulled-v2-557d564058ddc35a247887bebc5197cae96f3347:c450539e24dfe6a08369d2b75448daa8b7c6ac98-0.tsv
+++ b/combinations/mulled-v2-557d564058ddc35a247887bebc5197cae96f3347:c450539e24dfe6a08369d2b75448daa8b7c6ac98-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+quast=5.0.2,circos=0.69.8	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-557d564058ddc35a247887bebc5197cae96f3347:c450539e24dfe6a08369d2b75448daa8b7c6ac98

**Packages**:
- quast=5.0.2
- circos=0.69.8
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- quast.xml

Generated with Planemo.