### PR TITLE
Add container mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:f8319960eaa84b4f7f317126a4c1471f6a82cead.

### DIFF
--- a/combinations/mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:f8319960eaa84b4f7f317126a4c1471f6a82cead-0.tsv
+++ b/combinations/mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:f8319960eaa84b4f7f317126a4c1471f6a82cead-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.14,gawk=5.1.0,python-bioext=0.20.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-96feb22db3a5d1663e446b95a13d8781e5ff3123:f8319960eaa84b4f7f317126a4c1471f6a82cead

**Packages**:
- samtools=1.14
- gawk=5.1.0
- python-bioext=0.20.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bealign.xml

Generated with Planemo.