### PR TITLE
Add container mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:43d9227d3d9c70d1e0bd78d95edf330537eb276e.

### DIFF
--- a/combinations/mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:43d9227d3d9c70d1e0bd78d95edf330537eb276e-0.tsv
+++ b/combinations/mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:43d9227d3d9c70d1e0bd78d95edf330537eb276e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.7.1,bioconductor-scater=1.22.0,r-workflowscriptscommon=0.0.7,bioconductor-loomexperiment=1.12.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e60309dbdc217d86bba918def11fe36aadeee7f:43d9227d3d9c70d1e0bd78d95edf330537eb276e

**Packages**:
- r-optparse=1.7.1
- bioconductor-scater=1.22.0
- r-workflowscriptscommon=0.0.7
- bioconductor-loomexperiment=1.12.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scater-plot-pca.xml
- scater-create-qcmetric-ready-sce.xml

Generated with Planemo.