### PR TITLE
Add container mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:c6ca220985cebe72473390dda6b8c73b085f2dd5.

### DIFF
--- a/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:c6ca220985cebe72473390dda6b8c73b085f2dd5-0.tsv
+++ b/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:c6ca220985cebe72473390dda6b8c73b085f2dd5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+stringtie=2.1.7,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:c6ca220985cebe72473390dda6b8c73b085f2dd5

**Packages**:
- stringtie=2.1.7
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stringtie.xml
- stringtie_merge.xml

Generated with Planemo.