### PR TITLE
Add container mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:65cba6b1af2ed827ff435c7d46c3f54dc9957ada.

### DIFF
--- a/combinations/mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:65cba6b1af2ed827ff435c7d46c3f54dc9957ada-0.tsv
+++ b/combinations/mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:65cba6b1af2ed827ff435c7d46c3f54dc9957ada-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+spaln=2.4.6,python=3.8,rust-ncbitaxonomy=1.0.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:65cba6b1af2ed827ff435c7d46c3f54dc9957ada

**Packages**:
- spaln=2.4.6
- python=3.8
- rust-ncbitaxonomy=1.0.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- list_spaln_tables.xml

Generated with Planemo.