### PR TITLE
Add container mulled-v2-e31d506b11ec9b8231b63a7d36798b05447fa6df:5e6621ffccafff642a87d90fa4e096eb78cd88ea.

### DIFF
--- a/combinations/mulled-v2-e31d506b11ec9b8231b63a7d36798b05447fa6df:5e6621ffccafff642a87d90fa4e096eb78cd88ea-0.tsv
+++ b/combinations/mulled-v2-e31d506b11ec9b8231b63a7d36798b05447fa6df:5e6621ffccafff642a87d90fa4e096eb78cd88ea-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bzip2=1.0.8,lastz=1.04.15	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e31d506b11ec9b8231b63a7d36798b05447fa6df:5e6621ffccafff642a87d90fa4e096eb78cd88ea

**Packages**:
- bzip2=1.0.8
- lastz=1.04.15
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lastz_d.xml

Generated with Planemo.