### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c6e9d5034596b28e1d480d19592b3a94b05b2646.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c6e9d5034596b28e1d480d19592b3a94b05b2646-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c6e9d5034596b28e1d480d19592b3a94b05b2646-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.31,nextclade=1.5.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c6e9d5034596b28e1d480d19592b3a94b05b2646

**Packages**:
- coreutils=8.31
- nextclade=1.5.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.