### PR TITLE
Add container mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:ccd1195c617e7533a930de3d37c6c7fb803397e2.

### DIFF
--- a/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:ccd1195c617e7533a930de3d37c6c7fb803397e2-0.tsv
+++ b/combinations/mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:ccd1195c617e7533a930de3d37c6c7fb803397e2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.1.0,vardict-java=1.8.3,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cac536d5ab5827c04e8bd8f442b358e5037adb5a:ccd1195c617e7533a930de3d37c6c7fb803397e2

**Packages**:
- gawk=5.1.0
- vardict-java=1.8.3
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vardict.xml

Generated with Planemo.