### PR TITLE
Add container mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:2fec61e42c338a5137282bf2704b8fbceea13701.

### DIFF
--- a/combinations/mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:2fec61e42c338a5137282bf2704b8fbceea13701-0.tsv
+++ b/combinations/mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:2fec61e42c338a5137282bf2704b8fbceea13701-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.16.0.1,openpyxl=3.0.9,pandas=1.3.0,biopython=1.79	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:2fec61e42c338a5137282bf2704b8fbceea13701

**Packages**:
- pysam=0.16.0.1
- openpyxl=3.0.9
- pandas=1.3.0
- biopython=1.79
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_add_zero_coverage.xml

Generated with Planemo.