### PR TITLE
Add container mulled-v2-d06ddf0327bc580784d87b349a635b5fc6d1dfdb:2b74db8f123b62f925b2a8cac2f5fcce87bd055f.

### DIFF
--- a/combinations/mulled-v2-d06ddf0327bc580784d87b349a635b5fc6d1dfdb:2b74db8f123b62f925b2a8cac2f5fcce87bd055f-0.tsv
+++ b/combinations/mulled-v2-d06ddf0327bc580784d87b349a635b5fc6d1dfdb:2b74db8f123b62f925b2a8cac2f5fcce87bd055f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.21.4,biopython=1.79	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d06ddf0327bc580784d87b349a635b5fc6d1dfdb:2b74db8f123b62f925b2a8cac2f5fcce87bd055f

**Packages**:
- numpy=1.21.4
- biopython=1.79
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fasta-stats.xml

Generated with Planemo.