### PR TITLE
Add container mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:6a34dcafacd7875b1574f85d2af4a0430886be47.

### DIFF
--- a/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:6a34dcafacd7875b1574f85d2af4a0430886be47-0.tsv
+++ b/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:6a34dcafacd7875b1574f85d2af4a0430886be47-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools,vcfanno=0.3.3,tabix	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:6a34dcafacd7875b1574f85d2af4a0430886be47

**Packages**:
- samtools
- vcfanno=0.3.3
- tabix
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vcfanno.xml

Generated with Planemo.