### PR TITLE
Add container mulled-v2-5cada6dc649cb78fe4ccd00b84f9dc4ee50dd363:506b314b4875ac1041355eb6ab70f2d7f87c528c.

### DIFF
--- a/combinations/mulled-v2-5cada6dc649cb78fe4ccd00b84f9dc4ee50dd363:506b314b4875ac1041355eb6ab70f2d7f87c528c-0.tsv
+++ b/combinations/mulled-v2-5cada6dc649cb78fe4ccd00b84f9dc4ee50dd363:506b314b4875ac1041355eb6ab70f2d7f87c528c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+funannotate=1.8.9,requests=2.26.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5cada6dc649cb78fe4ccd00b84f9dc4ee50dd363:506b314b4875ac1041355eb6ab70f2d7f87c528c

**Packages**:
- funannotate=1.8.9
- requests=2.26.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- funannotate.xml

Generated with Planemo.