### PR TITLE
Add container mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:d9847b41af5ef58746c86d7114cd010650f3d9a2.

### DIFF
--- a/combinations/mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:d9847b41af5ef58746c86d7114cd010650f3d9a2-0.tsv
+++ b/combinations/mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:d9847b41af5ef58746c86d7114cd010650f3d9a2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.21.1,openpyxl=3.0.9,pandas=1.3.0,biopython=1.79,xlrd=2.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d91be2208450c41a5198d8660b6d9a5b60613b3a:d9847b41af5ef58746c86d7114cd010650f3d9a2

**Packages**:
- numpy=1.21.1
- openpyxl=3.0.9
- pandas=1.3.0
- biopython=1.79
- xlrd=2.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_statistics.xml

Generated with Planemo.