### PR TITLE
Add container mulled-v2-54b0a0985f878d1addb1c7f4f63ca366f3ff5ba3:9ecdab37e3b5dabe4cb2e74fd708bd28ab09c95f.

### DIFF
--- a/combinations/mulled-v2-54b0a0985f878d1addb1c7f4f63ca366f3ff5ba3:9ecdab37e3b5dabe4cb2e74fd708bd28ab09c95f-0.tsv
+++ b/combinations/mulled-v2-54b0a0985f878d1addb1c7f4f63ca366f3ff5ba3:9ecdab37e3b5dabe4cb2e74fd708bd28ab09c95f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-tximport=1.22.0,bioconductor-genomicfeatures=1.46.1,r-getopt=1.20.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-54b0a0985f878d1addb1c7f4f63ca366f3ff5ba3:9ecdab37e3b5dabe4cb2e74fd708bd28ab09c95f

**Packages**:
- bioconductor-tximport=1.22.0
- bioconductor-genomicfeatures=1.46.1
- r-getopt=1.20.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tximport.xml

Generated with Planemo.