### PR TITLE
Add container mulled-v2-4b1d834250c2fc21cf5defb541c597d4a325388b:7d34747875d7c2bb9746b40ac21e28cf14b97cc7.

### DIFF
--- a/combinations/mulled-v2-4b1d834250c2fc21cf5defb541c597d4a325388b:7d34747875d7c2bb9746b40ac21e28cf14b97cc7-0.tsv
+++ b/combinations/mulled-v2-4b1d834250c2fc21cf5defb541c597d4a325388b:7d34747875d7c2bb9746b40ac21e28cf14b97cc7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+malt=0.53,python=3.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4b1d834250c2fc21cf5defb541c597d4a325388b:7d34747875d7c2bb9746b40ac21e28cf14b97cc7

**Packages**:
- malt=0.53
- python=3.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- malt_index_builder.xml

Generated with Planemo.