### PR TITLE
Add container mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:008f90aac08a991b04d8049dee75f33d8f9ec181.

### DIFF
--- a/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:008f90aac08a991b04d8049dee75f33d8f9ec181-0.tsv
+++ b/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:008f90aac08a991b04d8049dee75f33d8f9ec181-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+minimap2=2.23,samtools=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:008f90aac08a991b04d8049dee75f33d8f9ec181

**Packages**:
- minimap2=2.23
- samtools=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- minimap2.xml

Generated with Planemo.