### PR TITLE
Add container mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:089b88a49385e9f8363b4570cfba990e0342530c.

### DIFF
--- a/combinations/mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:089b88a49385e9f8363b4570cfba990e0342530c-0.tsv
+++ b/combinations/mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:089b88a49385e9f8363b4570cfba990e0342530c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xlrd=2.0.1,openpyxl=3.0.9,pyvcf=0.6.8,pandas=1.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:089b88a49385e9f8363b4570cfba990e0342530c

**Packages**:
- xlrd=2.0.1
- openpyxl=3.0.9
- pyvcf=0.6.8
- pandas=1.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_get_snps.xml

Generated with Planemo.