### PR TITLE
Add container mulled-v2-b172376c9e7d5fd725d5ae553a5c3fe63fc8e8a4:e7ffc9427e5626ab246fc62fe088afc6bcbed99a.

### DIFF
--- a/combinations/mulled-v2-b172376c9e7d5fd725d5ae553a5c3fe63fc8e8a4:e7ffc9427e5626ab246fc62fe088afc6bcbed99a-0.tsv
+++ b/combinations/mulled-v2-b172376c9e7d5fd725d5ae553a5c3fe63fc8e8a4:e7ffc9427e5626ab246fc62fe088afc6bcbed99a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+interproscan=5.52-86.0,requests=2.26.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b172376c9e7d5fd725d5ae553a5c3fe63fc8e8a4:e7ffc9427e5626ab246fc62fe088afc6bcbed99a

**Packages**:
- interproscan=5.52-86.0
- requests=2.26.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- interproscan.xml

Generated with Planemo.