### PR TITLE
Add container mulled-v2-a7d17b945df7581dda6073e3758b93293ce59c18:772222a182224e8027220a014d40def63b721a7b.

### DIFF
--- a/combinations/mulled-v2-a7d17b945df7581dda6073e3758b93293ce59c18:772222a182224e8027220a014d40def63b721a7b-0.tsv
+++ b/combinations/mulled-v2-a7d17b945df7581dda6073e3758b93293ce59c18:772222a182224e8027220a014d40def63b721a7b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+king=2.2.4,r-igraph=1.2.2,r-kinship2=1.6.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a7d17b945df7581dda6073e3758b93293ce59c18:772222a182224e8027220a014d40def63b721a7b

**Packages**:
- king=2.2.4
- r-igraph=1.2.2
- r-kinship2=1.6.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- king.xml

Generated with Planemo.