### PR TITLE
Add container mulled-v2-949aaaddebd054dc6bded102520daff6f0f93ce6:aa2a3707bfa0550fee316844baba7752eaab7802.

### DIFF
--- a/combinations/mulled-v2-949aaaddebd054dc6bded102520daff6f0f93ce6:aa2a3707bfa0550fee316844baba7752eaab7802-0.tsv
+++ b/combinations/mulled-v2-949aaaddebd054dc6bded102520daff6f0f93ce6:aa2a3707bfa0550fee316844baba7752eaab7802-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xlsxwriter=1.4.4,biopython=1.79,pandas=0.25.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-949aaaddebd054dc6bded102520daff6f0f93ce6:aa2a3707bfa0550fee316844baba7752eaab7802

**Packages**:
- xlsxwriter=1.4.4
- biopython=1.79
- pandas=0.25.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_build_tables.xml

Generated with Planemo.