### PR TITLE
Add container mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:a8f542d9cc0c047cb466eee9dad2fbb73a84a0f0.

### DIFF
--- a/combinations/mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:a8f542d9cc0c047cb466eee9dad2fbb73a84a0f0-0.tsv
+++ b/combinations/mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:a8f542d9cc0c047cb466eee9dad2fbb73a84a0f0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bzip2=1.0.8,lastz=1.04.15,r-base=3.6.3,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:a8f542d9cc0c047cb466eee9dad2fbb73a84a0f0

**Packages**:
- bzip2=1.0.8
- lastz=1.04.15
- r-base=3.6.3
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lastz.xml

Generated with Planemo.