### PR TITLE
Add container mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:f471ba33d45697daad10614c5bd25a67693f67f1.

### DIFF
--- a/combinations/mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:f471ba33d45697daad10614c5bd25a67693f67f1-0.tsv
+++ b/combinations/mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:f471ba33d45697daad10614c5bd25a67693f67f1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.4.1,bamtools=2.5.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:f471ba33d45697daad10614c5bd25a67693f67f1

**Packages**:
- samtools=1.4.1
- bamtools=2.5.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bamtools.xml
- bamtools_split_paired.xml
- bamtools_split_tag.xml
- bamtools_split_ref.xml
- bamtools_split.xml
- bamtools_split_mapped.xml
- bamtools-filter.xml

Generated with Planemo.