### PR TITLE
Add container mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:628b91e831af1e8c550464bfa4ed7443c425feee.

### DIFF
--- a/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:628b91e831af1e8c550464bfa4ed7443c425feee-0.tsv
+++ b/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:628b91e831af1e8c550464bfa4ed7443c425feee-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.1.0,parallel=20211022,samtools=1.12,freebayes=1.3.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:628b91e831af1e8c550464bfa4ed7443c425feee

**Packages**:
- gawk=5.1.0
- parallel=20211022
- samtools=1.12
- freebayes=1.3.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freebayes.xml

Generated with Planemo.