### PR TITLE
Add container mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:1c41af5aaa7b7102ba85bc2ba59fd5e550300a0d.

### DIFF
--- a/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:1c41af5aaa7b7102ba85bc2ba59fd5e550300a0d-0.tsv
+++ b/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:1c41af5aaa7b7102ba85bc2ba59fd5e550300a0d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.12,freebayes=1.3.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:1c41af5aaa7b7102ba85bc2ba59fd5e550300a0d

**Packages**:
- samtools=1.12
- freebayes=1.3.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- leftalign.xml

Generated with Planemo.