### PR TITLE
Add container mdtraj:1.9.7.

### DIFF
--- a/combinations/mdtraj:1.9.7-0.tsv
+++ b/combinations/mdtraj:1.9.7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mdtraj=1.9.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mdtraj:1.9.7

**Packages**:
- mdtraj=1.9.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- md_slicer.xml
- md_converter.xml
- traj_select_and_merge.xml

Generated with Planemo.