### PR TITLE
Add container mulled-v2-8d3ab1ea89ee1ff9882fc30fd569fd1073972c0b:52b4bb2eca0c8aa0a6c2d2b698934aa6b279abab.

### DIFF
--- a/combinations/mulled-v2-8d3ab1ea89ee1ff9882fc30fd569fd1073972c0b:52b4bb2eca0c8aa0a6c2d2b698934aa6b279abab-0.tsv
+++ b/combinations/mulled-v2-8d3ab1ea89ee1ff9882fc30fd569fd1073972c0b:52b4bb2eca0c8aa0a6c2d2b698934aa6b279abab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-bio3d=2.4_1,r-lattice=0.20_38	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8d3ab1ea89ee1ff9882fc30fd569fd1073972c0b:52b4bb2eca0c8aa0a6c2d2b698934aa6b279abab

**Packages**:
- r-bio3d=2.4_1
- r-lattice=0.20_38
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- dccm.xml

Generated with Planemo.