### PR TITLE
Rebuild mulled container used by diamond 2.0.8

### DIFF
--- a/combinations/mulled-v2-a123a99e3ea11391d796d7c1acc76f35aa2b2df2:a82d30120d016d343cbbd273504b76c589f6dfa4-1.tsv
+++ b/combinations/mulled-v2-a123a99e3ea11391d796d7c1acc76f35aa2b2df2:a82d30120d016d343cbbd273504b76c589f6dfa4-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.7,diamond=2.0.8	quay.io/bioconda/base-glibc-busybox-bash:latest	1


### PR DESCRIPTION
The -0 version has the resolver issue from bioconda/bioconda-recipes#11583 and works in Singularity with `--no-mount=tmp`. I believe this rebuild is all that's necessary for a fix but someone correct me if I'm wrong?