### PR TITLE
Rebuild pangolin-csvtk image

### DIFF
--- a/combinations/mulled-v2-e01b80ba3fde20703457ef41af40b8873b592bc0:cef90f336f638dc9c5260e8cf180db142bd7fc8b-1.tsv
+++ b/combinations/mulled-v2-e01b80ba3fde20703457ef41af40b8873b592bc0:cef90f336f638dc9c5260e8cf180db142bd7fc8b-1.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+csvtk=0.23.0,pangolin=3.1.16	quay.io/bioconda/base-glibc-busybox-bash:latest	1


### PR DESCRIPTION
This should pick up a newer scorpio build that will not fail with
```
pangolearn updated to 2021-11-25
constellations updated to v0.0.29
pango-designation updated to v1.2.110
Job stats:
job                     count    min threads    max threads
--------------------  -------  -------------  -------------
add_failed_seqs             1              1              1
align_to_reference          1              1              1
all                         1              1              1
generate_report             1              1              1
get_constellations          1              1              1
hash_sequence_assign        1              1              1
pangolearn                  1              1              1
scorpio                     1              1              1
total                       8              1              1

Warning: couldn't parse the following string: # nuc:G11287T - ignoring
[Sun Dec 12 17:00:19 2021]
Error in rule get_constellations:
    jobid: 7
    output: /tmp/tmp3gwbt4h9/get_constellations.txt
    shell:
        
        scorpio list         --constellations /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.429.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cAY.4.2.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cP.2.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.617.1.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.617.2+K417N.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cP.3.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.525.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cA.23.1+E484K.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cBA.2.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.617.3.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.621.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.1.529.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cBA.1_probable.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cA.23.1.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cBA.1.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cAY.4.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.617.2.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.351.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.427.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.526.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.1.318.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cAV1.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cP.1.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cC.37.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.1.7+E484K.json /tmp/tmpqvdc3evd/job_working_directory/000/17/working/datadir/constellations/definitions/cB.1.1.7.json         --pangolin > /tmp/tmp3gwbt4h9/get_constellations.txt
        
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)


Exiting because a job execution failed. Look above for error message

```