### PR TITLE
Add container mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:a6dde613718a5f85e5ef41ee86a7c1052f45890e.

### DIFF
--- a/combinations/mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:a6dde613718a5f85e5ef41ee86a7c1052f45890e-0.tsv
+++ b/combinations/mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:a6dde613718a5f85e5ef41ee86a7c1052f45890e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-statmod=1.4.36,r-getopt=1.20.3,r-scales=1.1.1,r-gplots=3.1.1,bioconductor-edger=3.36.0,bioconductor-glimma=2.4.0,bioconductor-limma=3.50.0,r-rjson=0.2.20	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:a6dde613718a5f85e5ef41ee86a7c1052f45890e

**Packages**:
- r-statmod=1.4.36
- r-getopt=1.20.3
- r-scales=1.1.1
- r-gplots=3.1.1
- bioconductor-edger=3.36.0
- bioconductor-glimma=2.4.0
- bioconductor-limma=3.50.0
- r-rjson=0.2.20
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- limma_voom.xml

Generated with Planemo.