### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:2adc36b422bb99d5c87cef9b40c0df00e577fbe8.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:2adc36b422bb99d5c87cef9b40c0df00e577fbe8-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:2adc36b422bb99d5c87cef9b40c0df00e577fbe8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=8.31,nextclade=1.7.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:2adc36b422bb99d5c87cef9b40c0df00e577fbe8

**Packages**:
- coreutils=8.31
- nextclade=1.7.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.