### PR TITLE
Add container mulled-v2-aaf75b349de6d380ac6d4a206d51c2d696678b2a:f3c6faf275e70708a7635731117f172a7eafdd14.

### DIFF
--- a/combinations/mulled-v2-aaf75b349de6d380ac6d4a206d51c2d696678b2a:f3c6faf275e70708a7635731117f172a7eafdd14-0.tsv
+++ b/combinations/mulled-v2-aaf75b349de6d380ac6d4a206d51c2d696678b2a:f3c6faf275e70708a7635731117f172a7eafdd14-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+delly=0.9.1,bcftools=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-aaf75b349de6d380ac6d4a206d51c2d696678b2a:f3c6faf275e70708a7635731117f172a7eafdd14

**Packages**:
- delly=0.9.1
- bcftools=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- merge.xml
- call.xml
- lr.xml
- cnv.xml
- filter.xml
- classify.xml

Generated with Planemo.