### PR TITLE
Add container mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:37a458ff34650b8a579f26dcd3a8814ea455dd59.

### DIFF
--- a/combinations/mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:37a458ff34650b8a579f26dcd3a8814ea455dd59-0.tsv
+++ b/combinations/mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:37a458ff34650b8a579f26dcd3a8814ea455dd59-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-edger=3.36.0,r-rjson=0.2.20,bioconductor-limma=3.50.0,r-getopt=1.20.3,r-statmod=1.4.36,r-scales=1.1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9c87747efa8cda7e1443d2bbc042981e5013079d:37a458ff34650b8a579f26dcd3a8814ea455dd59

**Packages**:
- bioconductor-edger=3.36.0
- r-rjson=0.2.20
- bioconductor-limma=3.50.0
- r-getopt=1.20.3
- r-statmod=1.4.36
- r-scales=1.1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- edger.xml

Generated with Planemo.