### PR TITLE
Add container mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:d3299c12982fc8a19367af10a1973e62175fbaca.

### DIFF
--- a/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:d3299c12982fc8a19367af10a1973e62175fbaca-0.tsv
+++ b/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:d3299c12982fc8a19367af10a1973e62175fbaca-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rmarkdown=2.11,r-seurat=4.0.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:d3299c12982fc8a19367af10a1973e62175fbaca

**Packages**:
- r-rmarkdown=2.11
- r-seurat=4.0.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.