### PR TITLE
Add container mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:86abc2edd3c0a724d6332b6f33098225026bf916.

### DIFF
--- a/combinations/mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:86abc2edd3c0a724d6332b6f33098225026bf916-0.tsv
+++ b/combinations/mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:86abc2edd3c0a724d6332b6f33098225026bf916-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freebayes=1.3.5=py39hba5d119_3,samtools=1.6=hb116620_7,sambamba=0.8.1=h41abebc_0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:86abc2edd3c0a724d6332b6f33098225026bf916

**Packages**:
- freebayes=1.3.5=py39hba5d119_3
- samtools=1.6=hb116620_7
- sambamba=0.8.1=h41abebc_0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- artbio_bam_cleaning.xml

Generated with Planemo.