### PR TITLE
Add container mulled-v2-f7d31c9d7424063a492fc0e5ecbf89bc757c0107:2b50bdd4d8c1fefc6ec24b0753fad0dcecec843b.

### DIFF
--- a/combinations/mulled-v2-f7d31c9d7424063a492fc0e5ecbf89bc757c0107:2b50bdd4d8c1fefc6ec24b0753fad0dcecec843b-0.tsv
+++ b/combinations/mulled-v2-f7d31c9d7424063a492fc0e5ecbf89bc757c0107:2b50bdd4d8c1fefc6ec24b0753fad0dcecec843b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+file=5.39,bc=1.07.1,findutils=4.6.0,r-ggplot2=3.0.0,font-ttf-ubuntu=0.83,tar=1.34,bash=4.4.18,python=3.7.1,changeo=0.4.4,unzip=6.0,r-data.table=1.11.4,biopython=1.72,xlrd=1.2.0,r-seqinr=3.4_5,r-reshape2=1.4.3,r-scales=0.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
…bdd4d8c1fefc6ec24b0753fad0dcecec843b.

**Hash**: mulled-v2-f7d31c9d7424063a492fc0e5ecbf89bc757c0107:2b50bdd4d8c1fefc6ec24b0753fad0dcecec843b

**Packages**:
- file=5.39
- bc=1.07.1
- findutils=4.6.0
- r-ggplot2=3.0.0
- font-ttf-ubuntu=0.83
- tar=1.34
- bash=4.4.18
- python=3.7.1
- changeo=0.4.4
- unzip=6.0
- r-data.table=1.11.4
- biopython=1.72
- xlrd=1.2.0
- r-seqinr=3.4_5
- r-reshape2=1.4.3
- r-scales=0.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- shm_csr.xml

Generated with Planemo.