### PR TITLE
Add container mulled-v2-1f34cd7d9c6c353be705d31eb9133199a00197b4:78a1b23c209a7a9b00a9ee3ba35206b1430fe141.

### DIFF
--- a/combinations/mulled-v2-1f34cd7d9c6c353be705d31eb9133199a00197b4:78a1b23c209a7a9b00a9ee3ba35206b1430fe141-0.tsv
+++ b/combinations/mulled-v2-1f34cd7d9c6c353be705d31eb9133199a00197b4:78a1b23c209a7a9b00a9ee3ba35206b1430fe141-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.21,unzip=6.0,rasterio=1.2,pyyaml=6.0,tar=1.34,rasterstats=0.16,gdal=3.4.0,fiona=1.8,eodie=1.0.2,python=3.9,shapely=1.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1f34cd7d9c6c353be705d31eb9133199a00197b4:78a1b23c209a7a9b00a9ee3ba35206b1430fe141

**Packages**:
- numpy=1.21
- unzip=6.0
- rasterio=1.2
- pyyaml=6.0
- tar=1.34
- rasterstats=0.16
- gdal=3.4.0
- fiona=1.8
- eodie=1.0.2
- python=3.9
- shapely=1.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- eodie.xml

Generated with Planemo.