### PR TITLE
Add container mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:28452dc9072da838c55355be8eee26cbb6bdac88.

### DIFF
--- a/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:28452dc9072da838c55355be8eee26cbb6bdac88-0.tsv
+++ b/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:28452dc9072da838c55355be8eee26cbb6bdac88-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+last=1257,proteinortho=6.0.32,diamond=2.0.9,blat=36,blast=2.12.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:28452dc9072da838c55355be8eee26cbb6bdac88

**Packages**:
- last=1257
- proteinortho=6.0.32
- diamond=2.0.9
- blat=36
- blast=2.12.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho_summary.xml
- proteinortho.xml
- proteinortho_grab_proteins.xml

Generated with Planemo.