### PR TITLE
Add container mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8.

### DIFF
--- a/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0.tsv
+++ b/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+minimap2=2.24,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8

**Packages**:
- minimap2=2.24
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- minimap2.xml

Generated with Planemo.