### PR TITLE
Add container mulled-v2-ca258a039fcd88610bc4e297b13703e8be53f5ca:d638c4f85566099ea0c74bc8fddc6f531fe56753.

### DIFF
--- a/combinations/mulled-v2-ca258a039fcd88610bc4e297b13703e8be53f5ca:d638c4f85566099ea0c74bc8fddc6f531fe56753-0.tsv
+++ b/combinations/mulled-v2-ca258a039fcd88610bc4e297b13703e8be53f5ca:d638c4f85566099ea0c74bc8fddc6f531fe56753-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.9,pyyaml=6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ca258a039fcd88610bc4e297b13703e8be53f5ca:d638c4f85566099ea0c74bc8fddc6f531fe56753

**Packages**:
- python=3.9
- pyyaml=6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- load_annotations.xml
- install_packaged_annotation_data.xml

Generated with Planemo.