### PR TITLE
Add container mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:2d82f21e1e3f4dab5b8aed409c8a7a9e6961a68c.

### DIFF
--- a/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:2d82f21e1e3f4dab5b8aed409c8a7a9e6961a68c-0.tsv
+++ b/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:2d82f21e1e3f4dab5b8aed409c8a7a9e6961a68c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+icescreen=1.0.1,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:2d82f21e1e3f4dab5b8aed409c8a7a9e6961a68c

**Packages**:
- icescreen=1.0.1
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- icescreen.xml

Generated with Planemo.