### PR TITLE
Add container mulled-v2-a636e47be55ce15a83643a889cb203191490feb6:0312d894f3be621c405ed691e164afc64ff04fb8.

### DIFF
--- a/combinations/mulled-v2-a636e47be55ce15a83643a889cb203191490feb6:0312d894f3be621c405ed691e164afc64ff04fb8-0.tsv
+++ b/combinations/mulled-v2-a636e47be55ce15a83643a889cb203191490feb6:0312d894f3be621c405ed691e164afc64ff04fb8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-crisprvariants=1.20.0,bioconductor-sangerseqr=1.28.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a636e47be55ce15a83643a889cb203191490feb6:0312d894f3be621c405ed691e164afc64ff04fb8

**Packages**:
- bioconductor-crisprvariants=1.20.0
- bioconductor-sangerseqr=1.28.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ab1fastq.xml

Generated with Planemo.