### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:59aa403f8dce2d188091dacbd50d6b54ab0d8212.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:59aa403f8dce2d188091dacbd50d6b54ab0d8212-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:59aa403f8dce2d188091dacbd50d6b54ab0d8212-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+nextclade=1.9.0,coreutils=8.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:59aa403f8dce2d188091dacbd50d6b54ab0d8212

**Packages**:
- nextclade=1.9.0
- coreutils=8.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.