### PR TITLE
Add container mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:16f849a3170699ae7aea194257b0cb202b3864a7.

### DIFF
--- a/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:16f849a3170699ae7aea194257b0cb202b3864a7-0.tsv
+++ b/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:16f849a3170699ae7aea194257b0cb202b3864a7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-seurat=4.1.0,r-rmarkdown=2.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:16f849a3170699ae7aea194257b0cb202b3864a7

**Packages**:
- r-seurat=4.1.0
- r-rmarkdown=2.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.