### PR TITLE
Add container mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:821bebb5fe8c66b22338eb47bcff8ea99c4068a5.

### DIFF
--- a/combinations/mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:821bebb5fe8c66b22338eb47bcff8ea99c4068a5-0.tsv
+++ b/combinations/mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:821bebb5fe8c66b22338eb47bcff8ea99c4068a5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xarray=0.20.2,shapely=1.7.1,python=3,netcdf4=1.5.6,geopandas=0.9.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cc5df71afeb4645d30b58307edc58b5156be4748:821bebb5fe8c66b22338eb47bcff8ea99c4068a5

**Packages**:
- xarray=0.20.2
- shapely=1.7.1
- python=3
- netcdf4=1.5.6
- geopandas=0.9.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_select.xml
- xarray_coords_info.xml
- xarray_metadata_info.xml

Generated with Planemo.