### PR TITLE
Add container mulled-v2-1edc99f9b63f6b029f68e7e47056771ce9ac42ba:5122b67c625d81aa95539795dd192e7c9780bdef.

### DIFF
--- a/combinations/mulled-v2-1edc99f9b63f6b029f68e7e47056771ce9ac42ba:5122b67c625d81aa95539795dd192e7c9780bdef-0.tsv
+++ b/combinations/mulled-v2-1edc99f9b63f6b029f68e7e47056771ce9ac42ba:5122b67c625d81aa95539795dd192e7c9780bdef-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.20.2,umap-learn=0.5.2,tifffile=2020.10.1,h5py=3.6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1edc99f9b63f6b029f68e7e47056771ce9ac42ba:5122b67c625d81aa95539795dd192e7c9780bdef

**Packages**:
- numpy=1.20.2
- umap-learn=0.5.2
- tifffile=2020.10.1
- h5py=3.6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- 3d_tensor_feature_dimension_reduction.xml

Generated with Planemo.