### PR TITLE
Add container mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:3bd6b24373641b82b7cd9f447961b55ec3e08d17.

### DIFF
--- a/combinations/mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:3bd6b24373641b82b7cd9f447961b55ec3e08d17-0.tsv
+++ b/combinations/mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:3bd6b24373641b82b7cd9f447961b55ec3e08d17-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xarray=0.20.2,python=3,dask=2021.12.0,netcdf4=1.5.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:3bd6b24373641b82b7cd9f447961b55ec3e08d17

**Packages**:
- xarray=0.20.2
- python=3
- dask=2021.12.0
- netcdf4=1.5.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_netcdf2netcdf.xml

Generated with Planemo.