### PR TITLE
Add container mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:b1373788e7892dcce835f05cfea5646aaef20469.

### DIFF
--- a/combinations/mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:b1373788e7892dcce835f05cfea5646aaef20469-0.tsv
+++ b/combinations/mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:b1373788e7892dcce835f05cfea5646aaef20469-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xarray=0.20.2,dask=2021.12.0,cmcrameri=1.2,python=3,matplotlib=3.4.2,netcdf4=1.5.6,cartopy=0.19.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:b1373788e7892dcce835f05cfea5646aaef20469

**Packages**:
- xarray=0.20.2
- dask=2021.12.0
- cmcrameri=1.2
- python=3
- matplotlib=3.4.2
- netcdf4=1.5.6
- cartopy=0.19.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_mapplot.xml

Generated with Planemo.