### PR TITLE
Add container mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:6ad9f3fdcba8cf5180031c800c8d0b373a0ac081.

### DIFF
--- a/combinations/mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:6ad9f3fdcba8cf5180031c800c8d0b373a0ac081-0.tsv
+++ b/combinations/mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:6ad9f3fdcba8cf5180031c800c8d0b373a0ac081-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+spades=3.15.3,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:6ad9f3fdcba8cf5180031c800c8d0b373a0ac081

**Packages**:
- spades=3.15.3
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rnaspades.xml
- spades.xml
- metaspades.xml
- biosyntheticspades.xml
- rnaviralspades.xml
- metaplasmidspades.xml
- coronaspades.xml
- plasmidspades.xml
- metaviralspades.xml

Generated with Planemo.