### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:a898a0769ac4909b7dbc9a97ee996157e6cdf711.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:a898a0769ac4909b7dbc9a97ee996157e6cdf711-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:a898a0769ac4909b7dbc9a97ee996157e6cdf711-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+nextclade=1.10.1,coreutils=8.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:a898a0769ac4909b7dbc9a97ee996157e6cdf711

**Packages**:
- nextclade=1.10.1
- coreutils=8.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.