### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:c9a9ae04f25a51d956889125b6bfcf03b312e289.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:c9a9ae04f25a51d956889125b6bfcf03b312e289-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:c9a9ae04f25a51d956889125b6bfcf03b312e289-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+p7zip=16.02,ca-certificates=2021.5.30,ncbi-datasets-cli=12.27.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:c9a9ae04f25a51d956889125b6bfcf03b312e289

**Packages**:
- p7zip=16.02
- ca-certificates=2021.5.30
- ncbi-datasets-cli=12.27.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.