### PR TITLE
Add container mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:1ecf0e59dd79a6e28a208b1a583d7bd1a836d187.

### DIFF
--- a/combinations/mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:1ecf0e59dd79a6e28a208b1a583d7bd1a836d187-0.tsv
+++ b/combinations/mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:1ecf0e59dd79a6e28a208b1a583d7bd1a836d187-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.1.0,samtools=1.14,vardict-java=1.8.3,python=3.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:1ecf0e59dd79a6e28a208b1a583d7bd1a836d187

**Packages**:
- gawk=5.1.0
- samtools=1.14
- vardict-java=1.8.3
- python=3.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vardict.xml

Generated with Planemo.