### PR TITLE
Update hash.tsv

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -191,4 +191,4 @@ changeo=1.2.0,r-base=4.1.2,r-alakazam=1.2.0,igphyml=1.1.3
 bioconductor-biocparallel=1.28.0,bioconductor-csaw=1.28.0,bioconductor-edger=3.36.0,r-base=4.1.2,r-ggplot2=3.3.5,r-optparse=1.7.1
 r-base=4.1.2,r-alakazam=1.2.0,r-shazam=1.1.0,r-kableextra=1.3.4,r-knitr=1.33,r-stringr=1.4.0,r-dplyr=1.0.6
 python=3.9.5,samtools=1.14
-bioconductor-biocparallel=1.28.0,bioconductor-diffbind=3.4.0,bioconductor-csaw=1.28.0,bioconductor-edger=3.36.0,r-base=4.1.2,r-ggplot2=3.3.5,r-optparse=1.7.1
+bioconductor-diffbind=3.4.0,bioconductor-csaw=1.28.0,bioconductor-edger=3.36.0,r-optparse=1.7.1

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -187,3 +187,4 @@ changeo=1.2.0,r-base=4.1.2,r-alakazam=1.2.0,phylip=3.697
 changeo=1.2.0,igblast=1.17.1
 changeo=1.2.0,r-base=4.1.2,r-alakazam=1.2.0,igphyml=1.1.3
 bioconductor-biocparallel=1.28.0,bioconductor-csaw=1.28.0,bioconductor-edger=3.36.0,r-base=4.1.2,r-ggplot2=3.3.5,r-optparse=1.7.1
+bioconductor-biocparallel=1.28.0,bioconductor-diffbind=3.4.0,bioconductor-csaw=1.28.0,bioconductor-edger=3.36.0,r-base=4.1.2,r-ggplot2=3.3.5,r-optparse=1.7.1


### PR DESCRIPTION
A simple `DiffBind` container with dependencies for differential accessibility workflow. `csaw` is necessary when background normalization is desired, and this does not ship with the current [`bioconductor-diffbind`](https://quay.io/repository/biocontainers/bioconductor-diffbind) container available.