### PR TITLE
Add container mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:786f9dbe8f20add922e642af6162efd689739471.

### DIFF
--- a/combinations/mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:786f9dbe8f20add922e642af6162efd689739471-0.tsv
+++ b/combinations/mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:786f9dbe8f20add922e642af6162efd689739471-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scorpio=0.3.16,csvtk=0.23.0,pangolin=3.1.19	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:786f9dbe8f20add922e642af6162efd689739471

**Packages**:
- scorpio=0.3.16
- csvtk=0.23.0
- pangolin=3.1.19
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.