### PR TITLE
Add container mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:937bc1dc64f7fd41c363f9eff970a1b9d120d5ac.

### DIFF
--- a/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:937bc1dc64f7fd41c363f9eff970a1b9d120d5ac-0.tsv
+++ b/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:937bc1dc64f7fd41c363f9eff970a1b9d120d5ac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+icescreen=1.0.3,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:937bc1dc64f7fd41c363f9eff970a1b9d120d5ac

**Packages**:
- icescreen=1.0.3
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- icescreen.xml

Generated with Planemo.