### PR TITLE
Add container mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:65d6c86ec47b2e78c579ceaa8397df99729c3b79.

### DIFF
--- a/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:65d6c86ec47b2e78c579ceaa8397df99729c3b79-0.tsv
+++ b/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:65d6c86ec47b2e78c579ceaa8397df99729c3b79-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie2=2.4.5,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:65d6c86ec47b2e78c579ceaa8397df99729c3b79

**Packages**:
- bowtie2=2.4.5
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bowtie2_wrapper.xml

Generated with Planemo.