### PR TITLE
Add container mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:8a16228faab8c1e928bf89d98f736a5e84b014ef.

### DIFF
--- a/combinations/mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:8a16228faab8c1e928bf89d98f736a5e84b014ef-0.tsv
+++ b/combinations/mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:8a16228faab8c1e928bf89d98f736a5e84b014ef-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+interproscan=5.54-87.0,hmmer=3.1b2,requests=2.26.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:8a16228faab8c1e928bf89d98f736a5e84b014ef

**Packages**:
- interproscan=5.54-87.0
- hmmer=3.1b2
- requests=2.26.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- interproscan.xml

Generated with Planemo.