### PR TITLE
Add container mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:82cdf197a5073d4ab1deb3799732d1b165d5e24c.

### DIFF
--- a/combinations/mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:82cdf197a5073d4ab1deb3799732d1b165d5e24c-0.tsv
+++ b/combinations/mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:82cdf197a5073d4ab1deb3799732d1b165d5e24c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8,rust-ncbitaxonomy=1.0.7,spaln=2.4.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb2bf8de45d41165a1c63a4757c869a19ae3ce0a:82cdf197a5073d4ab1deb3799732d1b165d5e24c

**Packages**:
- python=3.8
- rust-ncbitaxonomy=1.0.7
- spaln=2.4.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- list_spaln_tables.xml

Generated with Planemo.