### PR TITLE
Add container mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:a5985988f9d613f269af08635f7c11089ffde023.

### DIFF
--- a/combinations/mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:a5985988f9d613f269af08635f7c11089ffde023-0.tsv
+++ b/combinations/mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:a5985988f9d613f269af08635f7c11089ffde023-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-stringi,r-tidyr=1.0.2,r-jsonlite=1.6,r-dplyr=0.8.3,r-batch=1.1_5,r-openxlsx=4.0.17,r-ggplot2=3.2.1,r-curl=3.3,r-stringr=1.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:a5985988f9d613f269af08635f7c11089ffde023

**Packages**:
- r-stringi
- r-tidyr=1.0.2
- r-jsonlite=1.6
- r-dplyr=0.8.3
- r-batch=1.1_5
- r-openxlsx=4.0.17
- r-ggplot2=3.2.1
- r-curl=3.3
- r-stringr=1.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- annotationRmn2D_xml.xml

Generated with Planemo.