### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:1795c0bb0d39942b9a02872e0a4bbbe113aea57e.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:1795c0bb0d39942b9a02872e0a4bbbe113aea57e-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:1795c0bb0d39942b9a02872e0a4bbbe113aea57e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+p7zip=16.02,ncbi-datasets-cli=12.32.0,ca-certificates=2021.10.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:1795c0bb0d39942b9a02872e0a4bbbe113aea57e

**Packages**:
- p7zip=16.02
- ncbi-datasets-cli=12.32.0
- ca-certificates=2021.10.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.