### PR TITLE
Add Python to Samtools/Bedtools Recipe

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -196,5 +196,5 @@ r-shazam=1.1.0,r-tigger=1.0.0
 bamcmp=2.2	quay.io/bioconda/base-glibc-debian-bash:latest	0
 ascat=3.0.0,cancerit-allelecount=4.3.0
 biscuit=1.0.2.20220113,samtools=1.14,samblaster=0.1.26
-samtools=1.14.0,bedtools=2.30.0,ucsc-facount=377
+samtools=1.14.0,bedtools=2.30.0,ucsc-facount=377,python=3.8
 gatk4=4.2.0.0,r-base=4.1,r-ggplot2=3.3.5,datamash=1.1.0


### PR DESCRIPTION
Add Python3.8 to the recently-added samtools/bedtools/facount recipe.