### PR TITLE
Add container mulled-v2-7844a8fea2cd7edb4e7860d89ae581b657866797:6d6e57cd220d23fc23e2bb6b929d72230d4b5e16.

### DIFF
--- a/combinations/mulled-v2-7844a8fea2cd7edb4e7860d89ae581b657866797:6d6e57cd220d23fc23e2bb6b929d72230d4b5e16-0.tsv
+++ b/combinations/mulled-v2-7844a8fea2cd7edb4e7860d89ae581b657866797:6d6e57cd220d23fc23e2bb6b929d72230d4b5e16-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=1.2.4,numpy=1.20.2,scipy=1.6.2,scikit-image=0.18.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7844a8fea2cd7edb4e7860d89ae581b657866797:6d6e57cd220d23fc23e2bb6b929d72230d4b5e16

**Packages**:
- pandas=1.2.4
- numpy=1.20.2
- scipy=1.6.2
- scikit-image=0.18.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- landmark_registration.xml

Generated with Planemo.