### PR TITLE
Add container mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:4ff0ff0201a5d77e1edab34eeb0fc9c674a92dce.

### DIFF
--- a/combinations/mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:4ff0ff0201a5d77e1edab34eeb0fc9c674a92dce-0.tsv
+++ b/combinations/mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:4ff0ff0201a5d77e1edab34eeb0fc9c674a92dce-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+spades=3.15.4,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:4ff0ff0201a5d77e1edab34eeb0fc9c674a92dce

**Packages**:
- spades=3.15.4
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plasmidspades.xml
- rnaspades.xml
- metaplasmidspades.xml
- biosyntheticspades.xml
- rnaviralspades.xml
- coronaspades.xml
- metaspades.xml
- metaviralspades.xml
- spades.xml

Generated with Planemo.