### PR TITLE
Add container mulled-v2-ec389033376a3033fa570b73c1569fb99993aaf4:7fb9f5a1996d57d6c45b8d0350ed82996a0e1071.

### DIFF
--- a/combinations/mulled-v2-ec389033376a3033fa570b73c1569fb99993aaf4:7fb9f5a1996d57d6c45b8d0350ed82996a0e1071-0.tsv
+++ b/combinations/mulled-v2-ec389033376a3033fa570b73c1569fb99993aaf4:7fb9f5a1996d57d6c45b8d0350ed82996a0e1071-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.79,concoct=1.0.0,pandas=0.19.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ec389033376a3033fa570b73c1569fb99993aaf4:7fb9f5a1996d57d6c45b8d0350ed82996a0e1071

**Packages**:
- biopython=1.79
- concoct=1.0.0
- pandas=0.19.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- extract_fasta_bins.xml
- concoct.xml

Generated with Planemo.