### PR TITLE
Add container mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:879ddaebc016378f34d1b42b2f9c0fbfb5835004.

### DIFF
--- a/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:879ddaebc016378f34d1b42b2f9c0fbfb5835004-0.tsv
+++ b/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:879ddaebc016378f34d1b42b2f9c0fbfb5835004-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freebayes=1.3.6,parallel=20211222,gawk=5.1.0,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:879ddaebc016378f34d1b42b2f9c0fbfb5835004

**Packages**:
- freebayes=1.3.6
- parallel=20211222
- gawk=5.1.0
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freebayes.xml

Generated with Planemo.