### PR TITLE
Add container mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:5f0e6a598f7dc34097b0746723ef42c11030d872.

### DIFF
--- a/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:5f0e6a598f7dc34097b0746723ef42c11030d872-0.tsv
+++ b/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:5f0e6a598f7dc34097b0746723ef42c11030d872-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freebayes=1.3.6,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:5f0e6a598f7dc34097b0746723ef42c11030d872

**Packages**:
- freebayes=1.3.6
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- leftalign.xml

Generated with Planemo.