### PR TITLE
Add container mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:8f34e0190e73e32bca01d14d0a8c390a5a4be21b.

### DIFF
--- a/combinations/mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:8f34e0190e73e32bca01d14d0a8c390a5a4be21b-0.tsv
+++ b/combinations/mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:8f34e0190e73e32bca01d14d0a8c390a5a4be21b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pangolin=3.1.20,csvtk=0.23.0,scorpio=0.3.16	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce5c92dbea367f40f14a5c3693bcbd45fce7cfea:8f34e0190e73e32bca01d14d0a8c390a5a4be21b

**Packages**:
- pangolin=3.1.20
- csvtk=0.23.0
- scorpio=0.3.16
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.