### PR TITLE
Add container mulled-v2-4fa3933ce8bc982743c584f3c8076f6e4b978f3d:cd1a385c52bbdacb152d618db28b6ab6bb8d5ddb.

### DIFF
--- a/combinations/mulled-v2-4fa3933ce8bc982743c584f3c8076f6e4b978f3d:cd1a385c52bbdacb152d618db28b6ab6bb8d5ddb-0.tsv
+++ b/combinations/mulled-v2-4fa3933ce8bc982743c584f3c8076f6e4b978f3d:cd1a385c52bbdacb152d618db28b6ab6bb8d5ddb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.20.2,scikit-image=0.18.1,matplotlib=3.3.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4fa3933ce8bc982743c584f3c8076f6e4b978f3d:cd1a385c52bbdacb152d618db28b6ab6bb8d5ddb

**Packages**:
- numpy=1.20.2
- scikit-image=0.18.1
- matplotlib=3.3.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- overlay_segmentation_mask.xml

Generated with Planemo.