### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:e01e41d46acce1c1c39cbaa37fbd8a7453695ff3.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:e01e41d46acce1c1c39cbaa37fbd8a7453695ff3-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:e01e41d46acce1c1c39cbaa37fbd8a7453695ff3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+nextclade=1.10.3,coreutils=9.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:e01e41d46acce1c1c39cbaa37fbd8a7453695ff3

**Packages**:
- nextclade=1.10.3
- coreutils=9.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.