### PR TITLE
Add container mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:2027566aa4b8d3c6cc97c4bde29583018ac7b404.

### DIFF
--- a/combinations/mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:2027566aa4b8d3c6cc97c4bde29583018ac7b404-0.tsv
+++ b/combinations/mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:2027566aa4b8d3c6cc97c4bde29583018ac7b404-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-gplots=3.1.1,bioconductor-limma=3.50.1,r-getopt=1.20.3,bioconductor-edger=3.36.0,r-scales=1.1.1,bioconductor-glimma=2.4.0,r-rjson=0.2.21,r-statmod=1.4.36	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3d571fed05a48eb8af17dbc6c8ed632143702ac1:2027566aa4b8d3c6cc97c4bde29583018ac7b404

**Packages**:
- r-gplots=3.1.1
- bioconductor-limma=3.50.1
- r-getopt=1.20.3
- bioconductor-edger=3.36.0
- r-scales=1.1.1
- bioconductor-glimma=2.4.0
- r-rjson=0.2.21
- r-statmod=1.4.36
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- limma_voom.xml

Generated with Planemo.