### PR TITLE
Bump chromap version 0.2.0 in mulled container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -154,6 +154,7 @@ r-base=4.1.0,r-rmarkdown=2.9,r-yaml=2.2.1
 r-mass=7.3_54,r-zoo=1.8_9,r-gplots=3.1.1,ghostscript
 chromap=0.1,samtools=1.13
 chromap=0.1.5,samtools=1.14
+chromap=0.2.0,samtools=1.14
 bbmap=38.92,samtools=1.13
 bbmap=38.92,samtools=1.13,pigz=2.6
 r-optparse=1.6.6,r-tidyverse=1.3.1,r-data.table=1.14.0,r-dtplyr=1.1.0,bioconductor-biostrings=2.58.0,bioconductor-treeio=1.14.3,r-ape=5.4_1,bioconductor-ggtree=2.4.1


### PR DESCRIPTION
nf-core chipseq needs this version to solve some issues we found in the previous version available in the mulled containers. 