### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4d262800fe6b2912c45dd73073de53f6a339cf8b.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4d262800fe6b2912c45dd73073de53f6a339cf8b-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4d262800fe6b2912c45dd73073de53f6a339cf8b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2021.10.8,p7zip=16.02,ncbi-datasets-cli=13.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4d262800fe6b2912c45dd73073de53f6a339cf8b

**Packages**:
- ca-certificates=2021.10.8
- p7zip=16.02
- ncbi-datasets-cli=13.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.