### PR TITLE
add sqlite to tidyverse

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -204,3 +204,4 @@ samtools=1.14.0,bedtools=2.30.0,ucsc-facount=377,python=3.8
 gatk4=4.2.0.0,r-base=4.1,r-ggplot2=3.3.5,datamash=1.1.0
 pyliftover=0.4,pandas=1.1.5
 circle-map=1.1.4,biopython=1.77
+r-tidyverse=1.3.1,r-rsqlite=2.1.1


### PR DESCRIPTION
Hello

I'd like to import data from sqlite3 databases and work with them in the tidyverse.

r-tidyverse already is already present in a few different containers in `hash.tsv`. I added a new one, but could it be better to modify an existing one?

For example the image hosted at https://depot.galaxyproject.org/singularity/r-tidyverse:1.2.1 contains sqlite3 and the tidyverse but not rsqlite, which is needed to interface the two.

Thanks :smile: 