### PR TITLE
Add container mulled-v2-f17d140b78b935a3e14582a84d43135017e9422b:e517e1477094793a8e534dd3e6bd84746d33bc3a.

### DIFF
--- a/combinations/mulled-v2-f17d140b78b935a3e14582a84d43135017e9422b:e517e1477094793a8e534dd3e6bd84746d33bc3a-0.tsv
+++ b/combinations/mulled-v2-f17d140b78b935a3e14582a84d43135017e9422b:e517e1477094793a8e534dd3e6bd84746d33bc3a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.7.1,r-data.table=1.14.2,bioconductor-rtracklayer=1.54.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f17d140b78b935a3e14582a84d43135017e9422b:e517e1477094793a8e534dd3e6bd84746d33bc3a

**Packages**:
- r-optparse=1.7.1
- r-data.table=1.14.2
- bioconductor-rtracklayer=1.54.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- get_length_and_gc_content.xml

Generated with Planemo.