### PR TITLE
mulled prinseq-plus-plus and bwa

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -208,3 +208,4 @@ circle-map=1.1.4,biopython=1.77
 r-tidyverse=1.3.1,r-rsqlite=2.1.1
 scikit-optimize=0.9.0,matplotlib=3.5.0,pandas=1.3.5
 r-ampir=1.1.0	bgruening/busybox-bash:0.1	0
+bwa=0.7.17-r1188 prinseq-plus-plus=1.2.4


### PR DESCRIPTION
Requesting mulled container with bwa=0.7.17-r1188 and prinseq-plus-plus=1.2.4
https://anaconda.org/bioconda/prinseq-plus-plus