### PR TITLE
Bump chromap version 0.2.1 and samtools 1.15

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -156,6 +156,7 @@ r-mass=7.3_54,r-zoo=1.8_9,r-gplots=3.1.1,ghostscript
 chromap=0.1,samtools=1.13
 chromap=0.1.5,samtools=1.14
 chromap=0.2.0,samtools=1.14
+chromap=0.2.1,samtools=1.15
 bbmap=38.92,samtools=1.13
 bbmap=38.92,samtools=1.13,pigz=2.6
 r-optparse=1.6.6,r-tidyverse=1.3.1,r-data.table=1.14.0,r-dtplyr=1.1.0,bioconductor-biostrings=2.58.0,bioconductor-treeio=1.14.3,r-ape=5.4_1,bioconductor-ggtree=2.4.1


### PR DESCRIPTION
Bump chromap 0.2.1 and samtools 1.15 for  nf-core/chipseq