### PR TITLE
Add container mulled-v2-e134e2a561eab6041ffac74b3fdba6a15327ab6b:98ea0d67f97ad4ed581e58d3182515f483a1551f.

### DIFF
--- a/combinations/mulled-v2-e134e2a561eab6041ffac74b3fdba6a15327ab6b:98ea0d67f97ad4ed581e58d3182515f483a1551f-0.tsv
+++ b/combinations/mulled-v2-e134e2a561eab6041ffac74b3fdba6a15327ab6b:98ea0d67f97ad4ed581e58d3182515f483a1551f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.4,gawk=4.1.3,macs2=2.2.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e134e2a561eab6041ffac74b3fdba6a15327ab6b:98ea0d67f97ad4ed581e58d3182515f483a1551f

**Packages**:
- r-base=3.4
- gawk=4.1.3
- macs2=2.2.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- macs2_bdgdiff.xml
- macs2_bdgbroadcall.xml

Generated with Planemo.