### PR TITLE
Add container mulled-v2-d35d986df816cc29c117288b7cd6a8b3edf56ec6:a7390cdef6f09f80cdf865bb2912a31a13b362e3.

### DIFF
--- a/combinations/mulled-v2-d35d986df816cc29c117288b7cd6a8b3edf56ec6:a7390cdef6f09f80cdf865bb2912a31a13b362e3-0.tsv
+++ b/combinations/mulled-v2-d35d986df816cc29c117288b7cd6a8b3edf56ec6:a7390cdef6f09f80cdf865bb2912a31a13b362e3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.4,macs2=2.2.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d35d986df816cc29c117288b7cd6a8b3edf56ec6:a7390cdef6f09f80cdf865bb2912a31a13b362e3

**Packages**:
- r-base=3.4
- macs2=2.2.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- macs2_bdgcmp.xml
- macs2_callpeak.xml
- macs2_randsample.xml
- macs2_bdgpeakcall.xml
- macs2_filterdup.xml
- macs2_refinepeak.xml
- macs2_predictd.xml

Generated with Planemo.