### PR TITLE
Add container mulled-v2-75aa0199171ca9e18ab358a9d8270ebe6c913965:15f68184e7d7d5749383f465384845ff1accc7ff.

### DIFF
--- a/combinations/mulled-v2-75aa0199171ca9e18ab358a9d8270ebe6c913965:15f68184e7d7d5749383f465384845ff1accc7ff-0.tsv
+++ b/combinations/mulled-v2-75aa0199171ca9e18ab358a9d8270ebe6c913965:15f68184e7d7d5749383f465384845ff1accc7ff-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-readr=2.1.1,r-ampvis2=2.7.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-75aa0199171ca9e18ab358a9d8270ebe6c913965:15f68184e7d7d5749383f465384845ff1accc7ff

**Packages**:
- r-readr=2.1.1
- r-ampvis2=2.7.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- load.xml
- boxplot.xml
- otu_network.xml
- core.xml
- ordinate.xml
- subset_taxa.xml
- timeseries.xml
- venn.xml
- mergereplicates.xml
- rankabundance.xml
- export_fasta.xml
- rarecurve.xml
- octave.xml
- alpha_diversity.xml
- heatmap.xml
- frequency.xml
- setmetadata.xml
- subset_samples.xml

Generated with Planemo.