### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb99455fa93a32b1c4f90c2ac3cbec924e7e6b26.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb99455fa93a32b1c4f90c2ac3cbec924e7e6b26-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb99455fa93a32b1c4f90c2ac3cbec924e7e6b26-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+busco=5.3.1,tar=1.34,fonts-conda-ecosystem=1	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb99455fa93a32b1c4f90c2ac3cbec924e7e6b26

**Packages**:
- busco=5.3.1
- tar=1.34
- fonts-conda-ecosystem=1
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.