### PR TITLE
Add container mulled-v2-198682a82f5c55520d925ed88748e9462a8f129d:600261f045c89029043bd46f2409893666963a0b.

### DIFF
--- a/combinations/mulled-v2-198682a82f5c55520d925ed88748e9462a8f129d:600261f045c89029043bd46f2409893666963a0b-0.tsv
+++ b/combinations/mulled-v2-198682a82f5c55520d925ed88748e9462a8f129d:600261f045c89029043bd46f2409893666963a0b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+naltorfs=0.1.2,ucsc-fatotwobit=377	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-198682a82f5c55520d925ed88748e9462a8f129d:600261f045c89029043bd46f2409893666963a0b

**Packages**:
- naltorfs=0.1.2
- ucsc-fatotwobit=377
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- find_nested_alt_orfs.xml

Generated with Planemo.