### PR TITLE
Add container mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:1d523c8ae029df6c532a7227b4b226e9f17d46d0.

### DIFF
--- a/combinations/mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:1d523c8ae029df6c532a7227b4b226e9f17d46d0-0.tsv
+++ b/combinations/mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:1d523c8ae029df6c532a7227b4b226e9f17d46d0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-kinship2=1.8.5,king=2.2.7,r-igraph=1.3.0,r-e1071=1.7_9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:1d523c8ae029df6c532a7227b4b226e9f17d46d0

**Packages**:
- r-kinship2=1.8.5
- king=2.2.7
- r-igraph=1.3.0
- r-e1071=1.7_9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- king.xml

Generated with Planemo.