### PR TITLE
bwa-mem2, bwakit, samtools

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -3,6 +3,7 @@ python=3.9,pandas=1.3.0,seaborn=0.11.0
 bwa=0.7.17,samtools=1.10,samblaster=0.1.24	bgruening/busybox-bash:0.1	1
 bowtie=1.1.1,picard=2.23.3	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.0,bwakit=0.7.17.dev1,samtools=1.10	bgruening/busybox-bash:0.1	0
+bwa-mem2=2.2.1,bwakit=0.7.17.dev1,samtools=1.15.1	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.0,samtools=1.10	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.1,samtools=1.11	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.2,samtools=1.11	bgruening/busybox-bash:0.1	0

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -3,10 +3,10 @@ python=3.9,pandas=1.3.0,seaborn=0.11.0
 bwa=0.7.17,samtools=1.10,samblaster=0.1.24	bgruening/busybox-bash:0.1	1
 bowtie=1.1.1,picard=2.23.3	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.0,bwakit=0.7.17.dev1,samtools=1.10	bgruening/busybox-bash:0.1	0
-bwa-mem2=2.2.1,bwakit=0.7.17.dev1,samtools=1.15.1	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.0,samtools=1.10	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.1,samtools=1.11	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.2,samtools=1.11	bgruening/busybox-bash:0.1	0
+bwa-mem2=2.2.1,bwakit=0.7.17.dev1,samtools=1.15.1	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.2.1,samtools=1.12	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.2.1,samtools=1.14	bgruening/busybox-bash:0.1	0
 bwa-mem2=2.2.1,samtools=1.15	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
Tools required to provide alt-contig mapping with efficient pipes.  `bwa-postalt.js` to be called directly not via the bwakit scripts as they do not support `bwa-mem2`.