### PR TITLE
Bump pysam 0.19.0 and samtools 1.15.1 versions

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -230,3 +230,4 @@ biopython=1.78,pandas=1.3.5,matplotlib=3.5.1,typer=0.4.1,xlsxwriter=1.4.3
 python=3.7,mash=2.0
 python=3.7,pandas=1.3.5,tabulate=0.8.9,mash=2.0
 bamtools=2.5.2,samtools=1.15.1
+pysam=0.19.0,samtools=1.15.1


### PR DESCRIPTION
Bump samtools version 1.15.1 and pysam 0.19.0 for nf-core/chipseq