### PR TITLE
Add new mulled container for new AmpliconArchitect version

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -237,3 +237,4 @@ pysam=0.19.0,samtools=1.15.1
 mirtop=0.4.25,samtools=1.15.1,r-base=4.1.1,r-data.table=1.14.2
 rsem=1.3.3,star=2.7.10a
 star=2.7.10a,samtools=1.15.1,gawk=5.1.0
+python=2.7,pysam=0.15.2,flask=1.1.2,cython=0.29.14,numpy=1.16.6,scipy=1.2.1,matplotlib=2.2.5,mosek::mosek=8.0.60,future=0.18.2


### PR DESCRIPTION
A new version of AmpliconArchitect (https://github.com/jluebeck/AmpliconArchitect) needs an additional dependency: future.
