### PR TITLE
Add container mulled-v2-117500fefbe40b2dde3de9d20245e4d0f29aa93d:724d48425eaceadcc3fa8b87ce3154c97afd1186.

### DIFF
--- a/combinations/mulled-v2-117500fefbe40b2dde3de9d20245e4d0f29aa93d:724d48425eaceadcc3fa8b87ce3154c97afd1186-0.tsv
+++ b/combinations/mulled-v2-117500fefbe40b2dde3de9d20245e4d0f29aa93d:724d48425eaceadcc3fa8b87ce3154c97afd1186-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-org.hs.eg.db=3.13.0,r-dplyr=1.0.6,r-optparse=1.6.6,bioconductor-org.dr.eg.db=3.13.0,bioconductor-goseq=@VERSION@,bioconductor-org.dm.eg.db=3.13.0,bioconductor-org.rn.eg.db=3.14.0,r-ggplot2=3.3.3,bioconductor-org.mm.eg.db=3.13.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-117500fefbe40b2dde3de9d20245e4d0f29aa93d:724d48425eaceadcc3fa8b87ce3154c97afd1186

**Packages**:
- bioconductor-org.hs.eg.db=3.13.0
- r-dplyr=1.0.6
- r-optparse=1.6.6
- bioconductor-org.dr.eg.db=3.13.0
- bioconductor-goseq=@VERSION@
- bioconductor-org.dm.eg.db=3.13.0
- bioconductor-org.rn.eg.db=3.14.0
- r-ggplot2=3.3.3
- bioconductor-org.mm.eg.db=3.13.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- goseq.xml

Generated with Planemo.