### PR TITLE
Add container interproscan:5.55-88.0.

### DIFF
--- a/combinations/interproscan:5.55-88.0-0.tsv
+++ b/combinations/interproscan:5.55-88.0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+interproscan=5.55-88.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: interproscan:5.55-88.0

**Packages**:
- interproscan=5.55-88.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- interproscan.xml

Generated with Planemo.