### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:5c55a92be570dbabb346ef451e444162265132e7.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:5c55a92be570dbabb346ef451e444162265132e7-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:5c55a92be570dbabb346ef451e444162265132e7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasta3=36.3.8,mafft=7.505	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:5c55a92be570dbabb346ef451e444162265132e7

**Packages**:
- fasta3=36.3.8
- mafft=7.505
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mafft-add.xml
- mafft.xml

Generated with Planemo.