### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:8774c7de59b25cc482ec66d7df60fe55c3887dfe.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:8774c7de59b25cc482ec66d7df60fe55c3887dfe-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:8774c7de59b25cc482ec66d7df60fe55c3887dfe-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2021.10.8,p7zip=16.02,ncbi-datasets-cli=13.14.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:8774c7de59b25cc482ec66d7df60fe55c3887dfe

**Packages**:
- ca-certificates=2021.10.8
- p7zip=16.02
- ncbi-datasets-cli=13.14.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.