### PR TITLE
cooler, ucsc-bedgraphtobigwig

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -1,4 +1,5 @@
 #targets	base_image	image_build
+cooltools=0.5.1,ucsc-bedgraphtobigwig=377
 python=3.9,scipy=1.8.0,numpy=1.22.3,iced=0.5.10,bx-python=0.8.13,pysam=0.19.0
 python=3.9,pandas=1.3.0,seaborn=0.11.0
 bwa=0.7.17,samtools=1.10,samblaster=0.1.24	bgruening/busybox-bash:0.1	1


### PR DESCRIPTION
The cooler python package run with the option `--bigwig` requires the `ucsc-bedgraphtobigwig` to be installed on the same containers.