### PR TITLE
Add container mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:8b03ee02d3fd4c591e25416396609e9d06cdc711.

### DIFF
--- a/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:8b03ee02d3fd4c591e25416396609e9d06cdc711-0.tsv
+++ b/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:8b03ee02d3fd4c591e25416396609e9d06cdc711-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rmarkdown=2.14,r-seurat=4.1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:8b03ee02d3fd4c591e25416396609e9d06cdc711

**Packages**:
- r-rmarkdown=2.14
- r-seurat=4.1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.