### PR TITLE
Add container prot-scriber:0.1.1.

### DIFF
--- a/combinations/prot-scriber:0.1.1-0.tsv
+++ b/combinations/prot-scriber:0.1.1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+prot-scriber=0.1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: prot-scriber:0.1.1

**Packages**:
- prot-scriber=0.1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- prot-scriber.xml

Generated with Planemo.