### PR TITLE
Add new version of deeptools-samtools mulled container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -249,4 +249,4 @@ pymuonsuite=0.2.1
 muspinsim=1.1.0
 changeo=1.2.0,igblast=1.17.1,wget=1.20.1	quay.io/bioconda/base-glibc-busybox-bash:2.1.0	0
 cnvkit=0.9.9,samtools=1.15.1
-deeptools=3.5.1,samtools=1.15.1	bgruening/busybox-bash:0.1	0
+deeptools=3.5.1,samtools=1.15.1

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -249,3 +249,4 @@ pymuonsuite=0.2.1
 muspinsim=1.1.0
 changeo=1.2.0,igblast=1.17.1,wget=1.20.1	quay.io/bioconda/base-glibc-busybox-bash:2.1.0	0
 cnvkit=0.9.9,samtools=1.15.1
+deeptools=3.5.1,samtools=1.15.1

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -249,4 +249,4 @@ pymuonsuite=0.2.1
 muspinsim=1.1.0
 changeo=1.2.0,igblast=1.17.1,wget=1.20.1	quay.io/bioconda/base-glibc-busybox-bash:2.1.0	0
 cnvkit=0.9.9,samtools=1.15.1
-deeptools=3.5.1,samtools=1.15.1
+deeptools=3.5.1,samtools=1.15.1	bgruening/busybox-bash:0.1	0


### PR DESCRIPTION
Hi,
Could you please add a new mulled container (for `nf-core/sarek`) with the latest versions of `deeptools=3.5.1` and `samtools=1.15.1`? 
If I should add `deeptools` to another container that already has that `samtools` version, please let me know.
Best regards