### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:2f6959a062d42fc31b3c9f09e4f4d860a8309993.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:2f6959a062d42fc31b3c9f09e4f4d860a8309993-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:2f6959a062d42fc31b3c9f09e4f4d860a8309993-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+p7zip=16.02,ca-certificates=2021.10.8,ncbi-datasets-cli=13.21.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:2f6959a062d42fc31b3c9f09e4f4d860a8309993

**Packages**:
- p7zip=16.02
- ca-certificates=2021.10.8
- ncbi-datasets-cli=13.21.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.