### PR TITLE
Add container mulled-v2-c4e658267db06cfc91d5b54f9eb8448b39f0f9d6:84ab5c14a3872ca8b6edccbd36bd3c092e656bcf.

### DIFF
--- a/combinations/mulled-v2-c4e658267db06cfc91d5b54f9eb8448b39f0f9d6:84ab5c14a3872ca8b6edccbd36bd3c092e656bcf-0.tsv
+++ b/combinations/mulled-v2-c4e658267db06cfc91d5b54f9eb8448b39f0f9d6:84ab5c14a3872ca8b6edccbd36bd3c092e656bcf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.1.3,r-optparse=1.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c4e658267db06cfc91d5b54f9eb8448b39f0f9d6:84ab5c14a3872ca8b6edccbd36bd3c092e656bcf

**Packages**:
- r-base=4.1.3
- r-optparse=1.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- MS2snoop.xml

Generated with Planemo.