### PR TITLE
Add container mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:84c6b1411207e6e7dd1faacf51b19352be1fc948.

### DIFF
--- a/combinations/mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:84c6b1411207e6e7dd1faacf51b19352be1fc948-0.tsv
+++ b/combinations/mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:84c6b1411207e6e7dd1faacf51b19352be1fc948-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ribotaper=1.3.1a,ghostscript=9.54.0,coreutils=9.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:84c6b1411207e6e7dd1faacf51b19352be1fc948

**Packages**:
- ribotaper=1.3.1a
- ghostscript=9.54.0
- coreutils=9.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ribotaper_part3_main.xml
- ribotaper_part2_create_metaplots.xml
- ribotaper_part1_create_annotation_files.xml

Generated with Planemo.