### PR TITLE
Add container parse_mito_blast:1.0.2.

### DIFF
--- a/combinations/parse_mito_blast:1.0.2-0.tsv
+++ b/combinations/parse_mito_blast:1.0.2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+parse_mito_blast=1.0.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: parse_mito_blast:1.0.2

**Packages**:
- parse_mito_blast=1.0.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- parse_mito_blast.xml

Generated with Planemo.