### PR TITLE
Vcf2maf vep

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -258,3 +258,4 @@ r-base=4.1.3,bioconductor-chipseeker=1.30.0,r-magrittr=2.0.3,bioconductor-genomi
 r-base=4.1.3,r-ggplot2=3.3.5,r-magrittr=2.0.3,r-gridextra=2.3,r-rcolorbrewer=1.1_3,r-data.table=1.14.2
 r-base=4.1.3,bioconductor-diffbind=3.4.11,r-sleuth=0.30.0,r-ggplot2=3.3.5,r-magrittr=2.0.3,r-openxlsx=4.2.5
 galaxyxml=0.4.14,bioblend=0.17.0
+vcf2maf=1.6.21,ensembl-vep=106

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -258,4 +258,4 @@ r-base=4.1.3,bioconductor-chipseeker=1.30.0,r-magrittr=2.0.3,bioconductor-genomi
 r-base=4.1.3,r-ggplot2=3.3.5,r-magrittr=2.0.3,r-gridextra=2.3,r-rcolorbrewer=1.1_3,r-data.table=1.14.2
 r-base=4.1.3,bioconductor-diffbind=3.4.11,r-sleuth=0.30.0,r-ggplot2=3.3.5,r-magrittr=2.0.3,r-openxlsx=4.2.5
 galaxyxml=0.4.14,bioblend=0.17.0
-vcf2maf=1.6.21,ensembl-vep=106
+vcf2maf=1.6.21,ensembl-vep=106.1


### PR DESCRIPTION
For full vcf2maf functionality, it requires VEP. This should satifsy most use cases of vcf2maf.