### PR TITLE
Add container mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:5274d6751ad58166743df4c3ad258380647c2a87.

### DIFF
--- a/combinations/mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:5274d6751ad58166743df4c3ad258380647c2a87-0.tsv
+++ b/combinations/mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:5274d6751ad58166743df4c3ad258380647c2a87-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyvcf=0.6.8,pandas=1.4.2,openpyxl=3.0.9,xlrd=2.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c38f00eb170c1ac48a5c6e1586ef1361e6b50e26:5274d6751ad58166743df4c3ad258380647c2a87

**Packages**:
- pyvcf=0.6.8
- pandas=1.4.2
- openpyxl=3.0.9
- xlrd=2.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_get_snps.xml

Generated with Planemo.