### PR TITLE
Add container mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:aa4f82a8dea2cad16d9bc291ccad3b38645c5933.

### DIFF
--- a/combinations/mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:aa4f82a8dea2cad16d9bc291ccad3b38645c5933-0.tsv
+++ b/combinations/mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:aa4f82a8dea2cad16d9bc291ccad3b38645c5933-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysam=0.19.1,biopython=1.79,pandas=1.4.2,openpyxl=3.0.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-79e7547817e59d678e317e92cf0d38d73b34c7c9:aa4f82a8dea2cad16d9bc291ccad3b38645c5933

**Packages**:
- pysam=0.19.1
- biopython=1.79
- pandas=1.4.2
- openpyxl=3.0.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vsnp_add_zero_coverage.xml

Generated with Planemo.