### PR TITLE
Add container mulled-v2-0d814cbcd5aa81b280ecadbee9e4aba8d9ab33f7:0fb38379c04f2a8a345a2c8f74b190ea9a51b6f3.

### DIFF
--- a/combinations/mulled-v2-0d814cbcd5aa81b280ecadbee9e4aba8d9ab33f7:0fb38379c04f2a8a345a2c8f74b190ea9a51b6f3-0.tsv
+++ b/combinations/mulled-v2-0d814cbcd5aa81b280ecadbee9e4aba8d9ab33f7:0fb38379c04f2a8a345a2c8f74b190ea9a51b6f3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+zip=3.0,mitos=2.0.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0d814cbcd5aa81b280ecadbee9e4aba8d9ab33f7:0fb38379c04f2a8a345a2c8f74b190ea9a51b6f3

**Packages**:
- zip=3.0
- mitos=2.0.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mitos2.xml

Generated with Planemo.