### PR TITLE
Add container mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:e09b5b2b77378ececf70567ace3c822323a61fe5.

### DIFF
--- a/combinations/mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:e09b5b2b77378ececf70567ace3c822323a61fe5-0.tsv
+++ b/combinations/mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:e09b5b2b77378ececf70567ace3c822323a61fe5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggplot2=3.3.6,pysam=0.19.1,r-optparse=1.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:e09b5b2b77378ececf70567ace3c822323a61fe5

**Packages**:
- r-ggplot2=3.3.6
- pysam=0.19.1
- r-optparse=1.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mapping_quality_stats.xml

Generated with Planemo.