### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:000a1215cdab386a89b5099741d20a3d649f6d86.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:000a1215cdab386a89b5099741d20a3d649f6d86-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:000a1215cdab386a89b5099741d20a3d649f6d86-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=13.24.1,ca-certificates=2021.10.8,p7zip=16.02	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:000a1215cdab386a89b5099741d20a3d649f6d86

**Packages**:
- ncbi-datasets-cli=13.24.1
- ca-certificates=2021.10.8
- p7zip=16.02
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.