### PR TITLE
Update epytope version

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -244,7 +244,7 @@ star=2.7.10a,samtools=1.15.1,gawk=5.1.0
 python=2.7,pysam=0.15.2,flask=1.1.2,cython=0.29.14,numpy=1.16.6,scipy=1.2.1,matplotlib=2.2.5,mosek::mosek=8.0.60,future=0.18.2
 dnaio=0.8.1,pysam=0.19.0
 numpy=1.22.3,pandas=1.4.2,seaborn=0.11.2,deeptools=3.5.1,pysam=0.19.0,pyranges=0.0.115,dask=2022.4.1,upsetplot=0.6.0
-epytope=3.0.0,gawk=5.1.0,tcsh=6.20.00
+epytope=3.1.0,gawk=5.1.0,tcsh=6.20.00
 pymuonsuite=0.2.1
 muspinsim=1.1.0
 changeo=1.2.0,igblast=1.17.1,wget=1.20.1	quay.io/bioconda/base-glibc-busybox-bash:2.1.0	0


### PR DESCRIPTION
Hey! We released a new version of epytope 3.0.0 -> 3.1.0 and we now want to use this repository together with others requested in #2179 in the nf-core/epitopeprediction pipeline.

Thanks in advance!

Best
Jonas