### PR TITLE
Add container mulled-v2-43ae9088764289ae4b59805a3dddde08ecdefbf7:b9c5f79fedb78a7cd86a13c454cfa9ac97542f89.

### DIFF
--- a/combinations/mulled-v2-43ae9088764289ae4b59805a3dddde08ecdefbf7:b9c5f79fedb78a7cd86a13c454cfa9ac97542f89-0.tsv
+++ b/combinations/mulled-v2-43ae9088764289ae4b59805a3dddde08ecdefbf7:b9c5f79fedb78a7cd86a13c454cfa9ac97542f89-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+smudgeplot=0.2.5,kmer-jellyfish=2.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-43ae9088764289ae4b59805a3dddde08ecdefbf7:b9c5f79fedb78a7cd86a13c454cfa9ac97542f89

**Packages**:
- smudgeplot=0.2.5
- kmer-jellyfish=2.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- smudgeplot.xml

Generated with Planemo.