### PR TITLE
Add container mulled-v2-39a169e772faec87a567cec1d74847e55fc94db1:85698bdfd1797c190a04b5cf2063026fdb279a24.

### DIFF
--- a/combinations/mulled-v2-39a169e772faec87a567cec1d74847e55fc94db1:85698bdfd1797c190a04b5cf2063026fdb279a24-0.tsv
+++ b/combinations/mulled-v2-39a169e772faec87a567cec1d74847e55fc94db1:85698bdfd1797c190a04b5cf2063026fdb279a24-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-org.rn.eg.db=3.14.0,bioconductor-org.at.tair.db=3.14.0,bioconductor-org.dm.eg.db=3.14.0,bioconductor-org.dr.eg.db=3.14.0,bioconductor-org.hs.eg.db=3.14.0,bioconductor-org.mm.eg.db=3.14.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-39a169e772faec87a567cec1d74847e55fc94db1:85698bdfd1797c190a04b5cf2063026fdb279a24

**Packages**:
- bioconductor-org.rn.eg.db=3.14.0
- bioconductor-org.at.tair.db=3.14.0
- bioconductor-org.dm.eg.db=3.14.0
- bioconductor-org.dr.eg.db=3.14.0
- bioconductor-org.hs.eg.db=3.14.0
- bioconductor-org.mm.eg.db=3.14.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- annotateMyIDs.xml

Generated with Planemo.