### PR TITLE
Add mulled for gubbins and snp-sites

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -265,3 +265,4 @@ scanpy=1.9.1,python-igraph,leidenalg
 pysam=0.19.1,pandas=1.4.2
 aria2=1.36.0,pigz=2.6,tar=1.34
 samtools=1.15.1,ultra_bioinformatics=0.0.4.1
+gubbins=3.2.1,snp-sites=2.5.1


### PR DESCRIPTION
Gubbins and snp-sites are commonly used together (e.g. via Snippy), with snp-sites being really quick. This container saves the user time