### PR TITLE
Add container mulled-v2-2c7d95051c0f3f40a6bb7545f5baf25d27c8969d:5fa21ef1edb2098ec1fac92adf838eaf62d2a118.

### DIFF
--- a/combinations/mulled-v2-2c7d95051c0f3f40a6bb7545f5baf25d27c8969d:5fa21ef1edb2098ec1fac92adf838eaf62d2a118-0.tsv
+++ b/combinations/mulled-v2-2c7d95051c0f3f40a6bb7545f5baf25d27c8969d:5fa21ef1edb2098ec1fac92adf838eaf62d2a118-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+concoct=1.1.0,samtools=1.15.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2c7d95051c0f3f40a6bb7545f5baf25d27c8969d:5fa21ef1edb2098ec1fac92adf838eaf62d2a118

**Packages**:
- concoct=1.1.0
- samtools=1.15.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- concoct_coverage_table.xml

Generated with Planemo.