### PR TITLE
Add container mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:ad9c2a20177a81c2ca51d4e7c4a482c2178c42d7.

### DIFF
--- a/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:ad9c2a20177a81c2ca51d4e7c4a482c2178c42d7-0.tsv
+++ b/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:ad9c2a20177a81c2ca51d4e7c4a482c2178c42d7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+minimap2=2.24,scorpio=0.3.17,pangolin-data=1.11,usher=0.5.6,gofasta=1.1.0,constellations=0.1.10,ucsc-fatovcf=426,csvtk=0.23.0,grep=3.4,pangolin=4.1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:ad9c2a20177a81c2ca51d4e7c4a482c2178c42d7

**Packages**:
- minimap2=2.24
- scorpio=0.3.17
- pangolin-data=1.11
- usher=0.5.6
- gofasta=1.1.0
- constellations=0.1.10
- ucsc-fatovcf=426
- csvtk=0.23.0
- grep=3.4
- pangolin=4.1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.