### PR TITLE
Add container mulled-v2-8149bc80edf5dd3ae616ce7e218af52915c09714:bffe614b9c49b2ac98b52c47f88f52c96b240633.

### DIFF
--- a/combinations/mulled-v2-8149bc80edf5dd3ae616ce7e218af52915c09714:bffe614b9c49b2ac98b52c47f88f52c96b240633-0.tsv
+++ b/combinations/mulled-v2-8149bc80edf5dd3ae616ce7e218af52915c09714:bffe614b9c49b2ac98b52c47f88f52c96b240633-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.7.1,bioconductor-ancombc=1.4.0,r-data.table=1.14.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8149bc80edf5dd3ae616ce7e218af52915c09714:bffe614b9c49b2ac98b52c47f88f52c96b240633

**Packages**:
- r-optparse=1.7.1
- bioconductor-ancombc=1.4.0
- r-data.table=1.14.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ancombc.xml

Generated with Planemo.