### PR TITLE
Add container mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:04842a4c570550c67fec3f957a1aae3bd0771965.

### DIFF
--- a/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:04842a4c570550c67fec3f957a1aae3bd0771965-0.tsv
+++ b/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:04842a4c570550c67fec3f957a1aae3bd0771965-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pangolin-data=1.12,csvtk=0.23.0,minimap2=2.24,scorpio=0.3.17,usher=0.5.6,pangolin=4.1.2,constellations=0.1.10,grep=3.4,ucsc-fatovcf=426,gofasta=1.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:04842a4c570550c67fec3f957a1aae3bd0771965

**Packages**:
- pangolin-data=1.12
- csvtk=0.23.0
- minimap2=2.24
- scorpio=0.3.17
- usher=0.5.6
- pangolin=4.1.2
- constellations=0.1.10
- grep=3.4
- ucsc-fatovcf=426
- gofasta=1.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.