### PR TITLE
Add container mulled-v2-a31b665dad5b6b3c2243f62528d99a64a09a9422:0ce8c4f273f0606d5fcf9e79ed75741b22fa07e0.

### DIFF
--- a/combinations/mulled-v2-a31b665dad5b6b3c2243f62528d99a64a09a9422:0ce8c4f273f0606d5fcf9e79ed75741b22fa07e0-0.tsv
+++ b/combinations/mulled-v2-a31b665dad5b6b3c2243f62528d99a64a09a9422:0ce8c4f273f0606d5fcf9e79ed75741b22fa07e0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pymuonsuite=0.2.1,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a31b665dad5b6b3c2243f62528d99a64a09a9422:0ce8c4f273f0606d5fcf9e79ed75741b22fa07e0

**Packages**:
- pymuonsuite=0.2.1
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pm_muairss_write.xml
- pm_uep_opt_write.xml

Generated with Planemo.