### PR TITLE
Add container mulled-v2-32b6c8acd34a14e720bbe477eceb2889d962080a:b48f1f516af8b20465c1d227499f07e5a5d64956.

### DIFF
--- a/combinations/mulled-v2-32b6c8acd34a14e720bbe477eceb2889d962080a:b48f1f516af8b20465c1d227499f07e5a5d64956-0.tsv
+++ b/combinations/mulled-v2-32b6c8acd34a14e720bbe477eceb2889d962080a:b48f1f516af8b20465c1d227499f07e5a5d64956-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.6.0,python=3.10,pandas=1.4.3,xarray=2022.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-32b6c8acd34a14e720bbe477eceb2889d962080a:b48f1f516af8b20465c1d227499f07e5a5d64956

**Packages**:
- netcdf4=1.6.0
- python=3.10
- pandas=1.4.3
- xarray=2022.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_coords_info.xml
- xarray_metadata_info.xml

Generated with Planemo.