### PR TITLE
Add container mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:06466253b80bbe3a0e1da922aab0882a0810f6a7.

### DIFF
--- a/combinations/mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:06466253b80bbe3a0e1da922aab0882a0810f6a7-0.tsv
+++ b/combinations/mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:06466253b80bbe3a0e1da922aab0882a0810f6a7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.6.0,python=3,dask=2022.7.0,xarray=2022.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f99298c68b39e47bd69944cb98b4f11c7f94bca9:06466253b80bbe3a0e1da922aab0882a0810f6a7

**Packages**:
- netcdf4=1.6.0
- python=3
- dask=2022.7.0
- xarray=2022.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_netcdf2netcdf.xml

Generated with Planemo.