### PR TITLE
Add container mulled-v2-9ec096ef22a6eefe20530a955849ddff3197a8dd:7dd3c3500dd11890597c7135d82ed4b1eeabbf53.

### DIFF
--- a/combinations/mulled-v2-9ec096ef22a6eefe20530a955849ddff3197a8dd:7dd3c3500dd11890597c7135d82ed4b1eeabbf53-0.tsv
+++ b/combinations/mulled-v2-9ec096ef22a6eefe20530a955849ddff3197a8dd:7dd3c3500dd11890597c7135d82ed4b1eeabbf53-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.6.0,xarray=2022.3.0,python=3.10,geopandas=0.7.0,shapely=1.8.2,pandas=1.4.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9ec096ef22a6eefe20530a955849ddff3197a8dd:7dd3c3500dd11890597c7135d82ed4b1eeabbf53

**Packages**:
- netcdf4=1.6.0
- xarray=2022.3.0
- python=3.10
- geopandas=0.7.0
- shapely=1.8.2
- pandas=1.4.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_select.xml

Generated with Planemo.