### PR TITLE
Add container mulled-v2-283013c53e9be2db71ac5442e35da355c979ca0e:db712fd85ab78376a65a1bfaa62f945d34b00413.

### DIFF
--- a/combinations/mulled-v2-283013c53e9be2db71ac5442e35da355c979ca0e:db712fd85ab78376a65a1bfaa62f945d34b00413-0.tsv
+++ b/combinations/mulled-v2-283013c53e9be2db71ac5442e35da355c979ca0e:db712fd85ab78376a65a1bfaa62f945d34b00413-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.6.0,xarray=2022.3.0,matplotlib=3.5.2,python=3,cftime=1.6.1,dask=2022.7.0,pandas=1.4.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-283013c53e9be2db71ac5442e35da355c979ca0e:db712fd85ab78376a65a1bfaa62f945d34b00413

**Packages**:
- netcdf4=1.6.0
- xarray=2022.3.0
- matplotlib=3.5.2
- python=3
- cftime=1.6.1
- dask=2022.7.0
- pandas=1.4.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- timeseries_plot.xml

Generated with Planemo.