### PR TITLE
Add container mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:973245282fa32ba4b0dff7584d3925191bba05cb.

### DIFF
--- a/combinations/mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:973245282fa32ba4b0dff7584d3925191bba05cb-0.tsv
+++ b/combinations/mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:973245282fa32ba4b0dff7584d3925191bba05cb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.6.0,cartopy=0.20.3,cmcrameri=1.4,xarray=2022.3.0,matplotlib=3.5.2,python=3,dask=2022.7.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b6e0aa4719eccbb640c59e7f6037f8c82ca3dc7f:973245282fa32ba4b0dff7584d3925191bba05cb

**Packages**:
- netcdf4=1.6.0
- cartopy=0.20.3
- cmcrameri=1.4
- xarray=2022.3.0
- matplotlib=3.5.2
- python=3
- dask=2022.7.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_mapplot.xml

Generated with Planemo.