### PR TITLE
Add container mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:e29049f6b1f5a6238a29af1b0f72ae3651ae5534.

### DIFF
--- a/combinations/mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:e29049f6b1f5a6238a29af1b0f72ae3651ae5534-0.tsv
+++ b/combinations/mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:e29049f6b1f5a6238a29af1b0f72ae3651ae5534-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.79,snpeff=4.3.1t	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:e29049f6b1f5a6238a29af1b0f72ae3651ae5534

**Packages**:
- biopython=1.79
- snpeff=4.3.1t
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snpEff_create_db.xml

Generated with Planemo.