### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c598406974ada96242d95a8743840fe950ab7630.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c598406974ada96242d95a8743840fe950ab7630-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c598406974ada96242d95a8743840fe950ab7630-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+nextclade=2.4.0,coreutils=9.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:c598406974ada96242d95a8743840fe950ab7630

**Packages**:
- nextclade=2.4.0
- coreutils=9.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.