### PR TITLE
Add container mulled-v2-9f807c0a006153cd3ff533fea11003254ad0148d:da9fb86f1c0ec300df4062a7610b481c6cf1abc7.

### DIFF
--- a/combinations/mulled-v2-9f807c0a006153cd3ff533fea11003254ad0148d:da9fb86f1c0ec300df4062a7610b481c6cf1abc7-0.tsv
+++ b/combinations/mulled-v2-9f807c0a006153cd3ff533fea11003254ad0148d:da9fb86f1c0ec300df4062a7610b481c6cf1abc7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bedtools=2.30.0,quast=5.2.0,bwa=0.7.17	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9f807c0a006153cd3ff533fea11003254ad0148d:da9fb86f1c0ec300df4062a7610b481c6cf1abc7

**Packages**:
- bedtools=2.30.0
- quast=5.2.0
- bwa=0.7.17
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- quast.xml

Generated with Planemo.