### PR TITLE
Add container mulled-v2-b0664646864bfdb46c5343b1b2b93fc05adb4b77:39a005770a3e30fb6aa3bf424b57ddf52bae7ece.

### DIFF
--- a/combinations/mulled-v2-b0664646864bfdb46c5343b1b2b93fc05adb4b77:39a005770a3e30fb6aa3bf424b57ddf52bae7ece-0.tsv
+++ b/combinations/mulled-v2-b0664646864bfdb46c5343b1b2b93fc05adb4b77:39a005770a3e30fb6aa3bf424b57ddf52bae7ece-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bc=1.07.1,picard=2.27.4,samtools=1.15.1,bedtools=2.30.0,grep=3.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b0664646864bfdb46c5343b1b2b93fc05adb4b77:39a005770a3e30fb6aa3bf424b57ddf52bae7ece

**Packages**:
- bc=1.07.1
- picard=2.27.4
- samtools=1.15.1
- bedtools=2.30.0
- grep=3.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- TEfinder.xml

Generated with Planemo.