### PR TITLE
Update bwa, prinseq-plus-plus combo

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -271,6 +271,6 @@ svdb=2.6.1,samtools=1.15.1
 r-base=4.1.2,changeo=1.2.0,r-alakazam=1.2.0,phylip=3.697,r-optparse=1.7.1
 ont-fast5-api=0.4.1,r-tailfindr=1.3.0
 gatk4=4.2.6.1,samtools=1.15.1,sambamba=0.8.2,bcftools=1.15.1,perl=5.32.1,r-base=4.1.2
-bwa=0.7.17,prinseq-plus-plus=1.2.4,perl=5.26
+bwa=0.7.17,prinseq-plus-plus=1.2.4,perl=5.26,boost-cpp=1.74
 levenshtein=0.20.1
 pysam=0.19.1,edlib=1.3.9,tqdm=4.64.0


### PR DESCRIPTION
https://github.com/BioContainers/multi-package-containers/pull/2268
- https://github.com/BioContainers/multi-package-containers/edit/master/combinations/hash.tsv#L274
- mulled container fails when calling prinseq++ with error
- googling suggested that this needs boost-cpp=1.74