### PR TITLE
Add container mulled-v2-77928ff1e4a1fbe4e221a07b05920c96e68f2aac:6df037f25991cc3390590c11085e7551291a42db.

### DIFF
--- a/combinations/mulled-v2-77928ff1e4a1fbe4e221a07b05920c96e68f2aac:6df037f25991cc3390590c11085e7551291a42db-0.tsv
+++ b/combinations/mulled-v2-77928ff1e4a1fbe4e221a07b05920c96e68f2aac:6df037f25991cc3390590c11085e7551291a42db-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandoc=2.12,cojac=0.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-77928ff1e4a1fbe4e221a07b05920c96e68f2aac:6df037f25991cc3390590c11085e7551291a42db

**Packages**:
- pandoc=2.12
- cojac=0.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_pubmut.xml

Generated with Planemo.