### PR TITLE
bump rpbasicdesign

### DIFF
--- a/combinations/rpbasicdesign:1.1.0-0.tsv
+++ b/combinations/rpbasicdesign:1.1.0-0.tsv
@@ -1,2 +1,2 @@
 #targets	base_image	image_build
-rpbasicdesign=1.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0
+rpbasicdesign=1.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	1


### PR DESCRIPTION
Is there a way to test the container that will be created here locally before merging?

IUC currently fails with:

```
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.9/site-packages/rpbasicdesign/cli.py", line 14, in <module>
    from rpbasicdesign.Designer import Designer
  File "/usr/local/lib/python3.9/site-packages/rpbasicdesign/Designer.py", line 23, in <module>
    from rptools.rplibs import rpSBML, rpPathway
  File "/usr/local/lib/python3.9/site-packages/rptools/rplibs/__init__.py", line 7, in <module>
    from rptools.rplibs.rpPathway import rpPathway
  File "/usr/local/lib/python3.9/site-packages/rptools/rplibs/rpPathway.py", line 46, in <module>
    from .rpSBML import rpSBML
  File "/usr/local/lib/python3.9/site-packages/rptools/rplibs/rpSBML.py", line 40, in <module>
    import cobra
  File "/usr/local/lib/python3.9/site-packages/cobra/__init__.py", line 5, in <module>
    from cobra.core import (
  File "/usr/local/lib/python3.9/site-packages/cobra/core/__init__.py", line 1, in <module>
    from cobra.core.configuration import Configuration
  File "/usr/local/lib/python3.9/site-packages/cobra/core/configuration.py", line 16, in <module>
    from cobra.util.solver import interface_to_str
  File "/usr/local/lib/python3.9/site-packages/cobra/util/__init__.py", line 4, in <module>
    from cobra.util.util import *
  File "/usr/local/lib/python3.9/site-packages/cobra/util/util.py", line 6, in <module>
    from depinfo import print_dependencies
ImportError: cannot import name 'print_dependencies' from 'depinfo' (/usr/local/lib/python3.9/site-packages/depinfo/__init__.py)
```

I hope that I fixed this here https://github.com/conda-forge/cobra-feedstock/pull/8