### PR TITLE
Add container mulled-v2-e4c44467785957646902e79427b4c556ebfd0752:e07d728e708771087bae53d3269ebbc12faf2ff1.

### DIFF
--- a/combinations/mulled-v2-e4c44467785957646902e79427b4c556ebfd0752:e07d728e708771087bae53d3269ebbc12faf2ff1-0.tsv
+++ b/combinations/mulled-v2-e4c44467785957646902e79427b4c556ebfd0752:e07d728e708771087bae53d3269ebbc12faf2ff1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+srst2=0.2.0,samtools=0.1.18	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e4c44467785957646902e79427b4c556ebfd0752:e07d728e708771087bae53d3269ebbc12faf2ff1

**Packages**:
- srst2=0.2.0
- samtools=0.1.18
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- srst2.xml

Generated with Planemo.