### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:5873389808dc832b2497311f05e5575f7c74736c.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:5873389808dc832b2497311f05e5575f7c74736c-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:5873389808dc832b2497311f05e5575f7c74736c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2022.6.15,ncbi-datasets-cli=13.35.0,p7zip=16.02	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:5873389808dc832b2497311f05e5575f7c74736c

**Packages**:
- ca-certificates=2022.6.15
- ncbi-datasets-cli=13.35.0
- p7zip=16.02
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.