### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:10b59f68d38dd07cb8c0047ffcbd842385432c3a.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:10b59f68d38dd07cb8c0047ffcbd842385432c3a-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:10b59f68d38dd07cb8c0047ffcbd842385432c3a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+p7zip=16.02,ncbi-datasets-cli=13.36.0,ca-certificates=2022.6.15	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:10b59f68d38dd07cb8c0047ffcbd842385432c3a

**Packages**:
- p7zip=16.02
- ncbi-datasets-cli=13.36.0
- ca-certificates=2022.6.15
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.