### PR TITLE
Switch refseq DM container to fixed base image

### DIFF
--- a/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:12b38eff4eaf9272ff05127c1f88dbea5dfee45e-0.tsv
+++ b/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:12b38eff4eaf9272ff05127c1f88dbea5dfee45e-0.tsv
@@ -1,2 +1,2 @@
 #targets	base_image	image_build
-python=3.7,requests=2.22.0	bgruening/busybox-bash:0.1	0
+python=3.7,requests=2.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	1


### PR DESCRIPTION
This combination ("python=3.7,requests=2.22.0") of packages is used by the RefSeq Data Manager, and the current busybox image cannot download from RefSeq. Switching to the newer base image will fix that.