### PR TITLE
Add container mulled-v2-8164d39688a7d09e655a207d9302604653235c22:8e5b406ab5b98cee3289bdeb0dbc06cb3377d8e2.

### DIFF
--- a/combinations/mulled-v2-8164d39688a7d09e655a207d9302604653235c22:8e5b406ab5b98cee3289bdeb0dbc06cb3377d8e2-0.tsv
+++ b/combinations/mulled-v2-8164d39688a7d09e655a207d9302604653235c22:8e5b406ab5b98cee3289bdeb0dbc06cb3377d8e2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kleborate=2.2.0,kaptive=2.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8164d39688a7d09e655a207d9302604653235c22:8e5b406ab5b98cee3289bdeb0dbc06cb3377d8e2

**Packages**:
- kleborate=2.2.0
- kaptive=2.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kleborate.xml

Generated with Planemo.