### PR TITLE
Add container mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:7b1ad5dbd0ee31d66967a1f20b4d8cd630dcec00.

### DIFF
--- a/combinations/mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:7b1ad5dbd0ee31d66967a1f20b4d8cd630dcec00-0.tsv
+++ b/combinations/mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:7b1ad5dbd0ee31d66967a1f20b4d8cd630dcec00-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.15.1,gawk=5.0.1,bcftools=1.15.1,htslib=1.15.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:7b1ad5dbd0ee31d66967a1f20b4d8cd630dcec00

**Packages**:
- samtools=1.15.1
- gawk=5.0.1
- bcftools=1.15.1
- htslib=1.15.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_consensus.xml
- bcftools_norm.xml

Generated with Planemo.