### PR TITLE
Add container mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:0bba35a3d4a3832a30878d78eef61805a2e1475a.

### DIFF
--- a/combinations/mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:0bba35a3d4a3832a30878d78eef61805a2e1475a-0.tsv
+++ b/combinations/mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:0bba35a3d4a3832a30878d78eef61805a2e1475a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.15.1,bcftools=1.15.1,htslib=1.15.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:0bba35a3d4a3832a30878d78eef61805a2e1475a

**Packages**:
- samtools=1.15.1
- bcftools=1.15.1
- htslib=1.15.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_mpileup.xml
- bcftools_csq.xml
- bcftools_convert_to_vcf.xml

Generated with Planemo.