### PR TITLE
Add container mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:e6ed8b7baef01ea0160d7d9fc7002fbd7dafcd96.

### DIFF
--- a/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:e6ed8b7baef01ea0160d7d9fc7002fbd7dafcd96-0.tsv
+++ b/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:e6ed8b7baef01ea0160d7d9fc7002fbd7dafcd96-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.15.1,tectonic=0.8.0,bcftools=1.15.1,htslib=1.15.1,matplotlib=3.5.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:e6ed8b7baef01ea0160d7d9fc7002fbd7dafcd96

**Packages**:
- samtools=1.15.1
- tectonic=0.8.0
- bcftools=1.15.1
- htslib=1.15.1
- matplotlib=3.5.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_stats.xml

Generated with Planemo.