### PR TITLE
Add container mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:611c5ed00120482fe681399c9f103740803fdcb2.

### DIFF
--- a/combinations/mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:611c5ed00120482fe681399c9f103740803fdcb2-0.tsv
+++ b/combinations/mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:611c5ed00120482fe681399c9f103740803fdcb2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcftools=1.15.1,htslib=1.15.1,python=3.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:611c5ed00120482fe681399c9f103740803fdcb2

**Packages**:
- bcftools=1.15.1
- htslib=1.15.1
- python=3.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_plugin_counts.xml

Generated with Planemo.