### PR TITLE
Add container mulled-v2-b99184dc2d32592dd62a87fa4a796c61585788e6:07602ea99d759e160674ea07c369efffcc80577a.

### DIFF
--- a/combinations/mulled-v2-b99184dc2d32592dd62a87fa4a796c61585788e6:07602ea99d759e160674ea07c369efffcc80577a-0.tsv
+++ b/combinations/mulled-v2-b99184dc2d32592dd62a87fa4a796c61585788e6:07602ea99d759e160674ea07c369efffcc80577a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcftools=1.15.1,htslib=1.15.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b99184dc2d32592dd62a87fa4a796c61585788e6:07602ea99d759e160674ea07c369efffcc80577a

**Packages**:
- bcftools=1.15.1
- htslib=1.15.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_plugin_frameshifts.xml
- bcftools_plugin_missing2ref.xml
- bcftools_plugin_fill_tags.xml
- bcftools_plugin_tag2tag.xml
- bcftools_isec.xml
- bcftools_annotate.xml
- bcftools_concat.xml
- bcftools_convert_from_vcf.xml
- bcftools_plugin_fixploidy.xml
- bcftools_roh.xml
- bcftools_call.xml
- bcftools_plugin_mendelian.xml
- bcftools_plugin_dosage.xml
- bcftools_plugin_setgt.xml
- bcftools_view.xml
- bcftools_plugin_impute_info.xml
- bcftools_query_list_samples.xml
- bcftools_plugin_color_chrs.xml
- bcftools_gtcheck.xml
- bcftools_merge.xml
- bcftools_reheader.xml
- bcftools_query.xml
- bcftools_plugin_fill_an_ac.xml
- bcftools_plugin_split_vep.xml
- bcftools_filter.xml

Generated with Planemo.