### PR TITLE
Add container mulled-v2-67d5623205db59bcde7552abda364cb149725e95:b9661f1dfcb6e14808d338b64658ced1389d0522.

### DIFF
--- a/combinations/mulled-v2-67d5623205db59bcde7552abda364cb149725e95:b9661f1dfcb6e14808d338b64658ced1389d0522-0.tsv
+++ b/combinations/mulled-v2-67d5623205db59bcde7552abda364cb149725e95:b9661f1dfcb6e14808d338b64658ced1389d0522-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-getopt=1.20.3,ribowaltz=1.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-67d5623205db59bcde7552abda364cb149725e95:b9661f1dfcb6e14808d338b64658ced1389d0522

**Packages**:
- r-getopt=1.20.3
- ribowaltz=1.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ribowaltz_plot.xml
- ribowaltz.xml

Generated with Planemo.