### PR TITLE
Add container mulled-v2-2b916ff704d137d674df9216f5715253338e7f18:b7d1106000b720c73e2d1304f5f38c3468c6d309.

### DIFF
--- a/combinations/mulled-v2-2b916ff704d137d674df9216f5715253338e7f18:b7d1106000b720c73e2d1304f5f38c3468c6d309-0.tsv
+++ b/combinations/mulled-v2-2b916ff704d137d674df9216f5715253338e7f18:b7d1106000b720c73e2d1304f5f38c3468c6d309-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+prodigal=2.6.3,infernal=1.1.4,integron_finder=2.0.2,hmmer=3.3.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b916ff704d137d674df9216f5715253338e7f18:b7d1106000b720c73e2d1304f5f38c3468c6d309

**Packages**:
- prodigal=2.6.3
- infernal=1.1.4
- integron_finder=2.0.2
- hmmer=3.3.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- integron_finder.xml

Generated with Planemo.