### PR TITLE
Add container mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:71330a98cfc2d7558a2722d0633dfc0200e07058.

### DIFF
--- a/combinations/mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:71330a98cfc2d7558a2722d0633dfc0200e07058-0.tsv
+++ b/combinations/mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:71330a98cfc2d7558a2722d0633dfc0200e07058-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.15.1,unicycler=0.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:71330a98cfc2d7558a2722d0633dfc0200e07058

**Packages**:
- samtools=1.15.1
- unicycler=0.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- unicycler.xml

Generated with Planemo.