### PR TITLE
Add container mulled-v2-d9c4e631a27f49ad4961fe3fc66175183aab16b2:5ee154e07576d5276f9cb069c56b21b27cbbcb85.

### DIFF
--- a/combinations/mulled-v2-d9c4e631a27f49ad4961fe3fc66175183aab16b2:5ee154e07576d5276f9cb069c56b21b27cbbcb85-0.tsv
+++ b/combinations/mulled-v2-d9c4e631a27f49ad4961fe3fc66175183aab16b2:5ee154e07576d5276f9cb069c56b21b27cbbcb85-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-arrow=8.0.0,r-recetox-waveica=0.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d9c4e631a27f49ad4961fe3fc66175183aab16b2:5ee154e07576d5276f9cb069c56b21b27cbbcb85

**Packages**:
- r-arrow=8.0.0
- r-recetox-waveica=0.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- waveica.xml

Generated with Planemo.