### PR TITLE
Add container mulled-v2-cc702e9aea4a48a16a0f2d80c7c4c1d217c574a8:9e7e37ba628b92148a09ca315f8e1f2518920047.

### DIFF
--- a/combinations/mulled-v2-cc702e9aea4a48a16a0f2d80c7c4c1d217c574a8:9e7e37ba628b92148a09ca315f8e1f2518920047-0.tsv
+++ b/combinations/mulled-v2-cc702e9aea4a48a16a0f2d80c7c4c1d217c574a8:9e7e37ba628b92148a09ca315f8e1f2518920047-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+segmetrics=0.11.3,scikit-image=0.18.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cc702e9aea4a48a16a0f2d80c7c4c1d217c574a8:9e7e37ba628b92148a09ca315f8e1f2518920047

**Packages**:
- segmetrics=0.11.3
- scikit-image=0.18.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- segmetrics.xml

Generated with Planemo.