### PR TITLE
Add container mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:079d8e65465218edc4fb3bbf6d92d3376bfcd65b.

### DIFF
--- a/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:079d8e65465218edc4fb3bbf6d92d3376bfcd65b-0.tsv
+++ b/combinations/mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:079d8e65465218edc4fb3bbf6d92d3376bfcd65b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.0,nextclade=2.7.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36d7254367b6ad6a1b47fbbca41b9e60238df0ac:079d8e65465218edc4fb3bbf6d92d3376bfcd65b

**Packages**:
- coreutils=9.0
- nextclade=2.7.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- nextclade.xml

Generated with Planemo.