### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:476b1ac002397f1b92057d7bc6e3585b96928552.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:476b1ac002397f1b92057d7bc6e3585b96928552-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:476b1ac002397f1b92057d7bc6e3585b96928552-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mafft=7.508,fasta3=36.3.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:476b1ac002397f1b92057d7bc6e3585b96928552

**Packages**:
- mafft=7.508
- fasta3=36.3.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mafft-add.xml
- mafft.xml

Generated with Planemo.