### PR TITLE
Add container mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:03227845b95c4410fad3b083e7c78106f2420ca3.

### DIFF
--- a/combinations/mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:03227845b95c4410fad3b083e7c78106f2420ca3-0.tsv
+++ b/combinations/mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:03227845b95c4410fad3b083e7c78106f2420ca3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,pysam=0.16.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:03227845b95c4410fad3b083e7c78106f2420ca3

**Packages**:
- samtools=1.9
- pysam=0.16.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fromHicupToJuicebox.xml

Generated with Planemo.