### PR TITLE
Add container mulled-v2-979fea4b700da20aa00e22deb22f7a863b211c22:a56c24f198a170c53588e1355862c9f54efbd9c8.

### DIFF
--- a/combinations/mulled-v2-979fea4b700da20aa00e22deb22f7a863b211c22:a56c24f198a170c53588e1355862c9f54efbd9c8-0.tsv
+++ b/combinations/mulled-v2-979fea4b700da20aa00e22deb22f7a863b211c22:a56c24f198a170c53588e1355862c9f54efbd9c8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tabix=0.2.5,h5py=2.7.0,cooler=0.7.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-979fea4b700da20aa00e22deb22f7a863b211c22:a56c24f198a170c53588e1355862c9f54efbd9c8

**Packages**:
- tabix=0.2.5
- h5py=2.7.0
- cooler=0.7.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooler_getMatrix.xml
- cooler_cload_tabix.xml
- cooler_makebins.xml
- cooler_csort_tabix.xml
- cooler_balance.xml

Generated with Planemo.