### PR TITLE
Add container mulled-v2-b8115409e625379de22606d1b3388743f4852f6c:d8ac73ee0d3597c20f6544ad927673d62ea31de0.

### DIFF
--- a/combinations/mulled-v2-b8115409e625379de22606d1b3388743f4852f6c:d8ac73ee0d3597c20f6544ad927673d62ea31de0-0.tsv
+++ b/combinations/mulled-v2-b8115409e625379de22606d1b3388743f4852f6c:d8ac73ee0d3597c20f6544ad927673d62ea31de0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.23.4,sambamba=0.8.2,r-gridextra=2.3,pysam=0.18.0,r-latticeextra=0.6_30,r-reshape2=1.4.4,r-optparse=1.7.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8115409e625379de22606d1b3388743f4852f6c:d8ac73ee0d3597c20f6544ad927673d62ea31de0

**Packages**:
- numpy=1.23.4
- sambamba=0.8.2
- r-gridextra=2.3
- pysam=0.18.0
- r-latticeextra=0.6_30
- r-reshape2=1.4.4
- r-optparse=1.7.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- small_rna_maps.xml

Generated with Planemo.