### PR TITLE
Add container mulled-v2-229691629e0b12c862d76101f90a597d5c1c81d4:484c804e1d5952c9023891b6f9a19f7f15815145.

### DIFF
--- a/combinations/mulled-v2-229691629e0b12c862d76101f90a597d5c1c81d4:484c804e1d5952c9023891b6f9a19f7f15815145-0.tsv
+++ b/combinations/mulled-v2-229691629e0b12c862d76101f90a597d5c1c81d4:484c804e1d5952c9023891b6f9a19f7f15815145-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hicup=0.8.3,samtools=1.16.1,bowtie2=2.4.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-229691629e0b12c862d76101f90a597d5c1c81d4:484c804e1d5952c9023891b6f9a19f7f15815145

**Packages**:
- hicup=0.8.3
- samtools=1.16.1
- bowtie2=2.4.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hicup_truncater.xml
- hicup_deduplicator.xml
- hicup_filter.xml
- hicup_digester.xml
- hicup_hicup.xml
- hicup_mapper.xml

Generated with Planemo.