### PR TITLE
Add container mulled-v2-8448e564f661806bf1f0d06f059b5f477b7c0b1d:44db661ec765a422a8b90da67af0513f81167fc1.

### DIFF
--- a/combinations/mulled-v2-8448e564f661806bf1f0d06f059b5f477b7c0b1d:44db661ec765a422a8b90da67af0513f81167fc1-0.tsv
+++ b/combinations/mulled-v2-8448e564f661806bf1f0d06f059b5f477b7c0b1d:44db661ec765a422a8b90da67af0513f81167fc1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.23.4,r-latticeextra=0.6_30,r-optparse=1.7.3,r-gridextra=2.3,pysam=0.18.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8448e564f661806bf1f0d06f059b5f477b7c0b1d:44db661ec765a422a8b90da67af0513f81167fc1

**Packages**:
- numpy=1.23.4
- r-latticeextra=0.6_30
- r-optparse=1.7.3
- r-gridextra=2.3
- pysam=0.18.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- signature.xml

Generated with Planemo.