### PR TITLE
Add container with rmats and pairadise

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -296,3 +296,4 @@ pretextmap=0.1.9,samtools=1.16.1
 r-base=4.2.1
 r-seqinr=4.2_16,r-optparse=1.7.3,bioconductor-rsamtools=2.10.0,r-dplyr=1.0.10,r-plyr=1.8.7,r-stringr=1.4.1,bioconductor-shortread=1.52.0,bioconductor-genomicalignments=1.30.0,r-data.table=1.14.4,bioconductor-biomart=2.50.0,r-plotly=4.10.0,bioconductor-decipher=2.22.0,bioconductor-biostrings=2.62.0,r-parallelly=1.32.1,r-jsonlite=1.8.2
 ucsc-gtftogenepred=377,ucsc-genepredtobed=377,bedtools=2.27.0
+rmats=4.1.2,bioconductor-pairadise=1.6.0


### PR DESCRIPTION
Add container with rmats and pairadise r-package which is required for rmats paired stats model - being implemented as part of nf-core/rnasplice workflow.