### PR TITLE
Add container mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:85f090b09e6657823c135bc06adfd3f3edd1fee9.

### DIFF
--- a/combinations/mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:85f090b09e6657823c135bc06adfd3f3edd1fee9-0.tsv
+++ b/combinations/mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:85f090b09e6657823c135bc06adfd3f3edd1fee9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+cooler=0.8.11,htslib=1.16,h5py=3.7.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:85f090b09e6657823c135bc06adfd3f3edd1fee9

**Packages**:
- cooler=0.8.11
- htslib=1.16
- h5py=3.7.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- cooler_csort_tabix.xml
- cooler_cload_tabix.xml
- cooler_balance.xml
- cooler_makebins.xml

Generated with Planemo.