### PR TITLE
Add container mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:f110cbaacc2dc31c002c0e8e1ae12fc7878310e5.

### DIFF
--- a/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:f110cbaacc2dc31c002c0e8e1ae12fc7878310e5-0.tsv
+++ b/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:f110cbaacc2dc31c002c0e8e1ae12fc7878310e5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-seurat=4.2.0,r-rmarkdown=2.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:f110cbaacc2dc31c002c0e8e1ae12fc7878310e5

**Packages**:
- r-seurat=4.2.0
- r-rmarkdown=2.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.