### PR TITLE
Add container mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:12c6c04fa0fddfac3444fc7dcd5dd6eb24638084.

### DIFF
--- a/combinations/mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:12c6c04fa0fddfac3444fc7dcd5dd6eb24638084-0.tsv
+++ b/combinations/mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:12c6c04fa0fddfac3444fc7dcd5dd6eb24638084-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+spades=3.15.5,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e16a4a78516ff3467ed12b12c1a51ab19b83b2d2:12c6c04fa0fddfac3444fc7dcd5dd6eb24638084

**Packages**:
- spades=3.15.5
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rnaviralspades.xml
- metaviralspades.xml
- metaplasmidspades.xml
- metaspades.xml
- coronaspades.xml
- plasmidspades.xml
- spades.xml
- biosyntheticspades.xml
- rnaspades.xml

Generated with Planemo.