### PR TITLE
Add container mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:269ddf09760200cac2764a642873dfcd130a4863.

### DIFF
--- a/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:269ddf09760200cac2764a642873dfcd130a4863-0.tsv
+++ b/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:269ddf09760200cac2764a642873dfcd130a4863-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+stringtie=2.2.1,samtools=1.16.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:269ddf09760200cac2764a642873dfcd130a4863

**Packages**:
- stringtie=2.2.1
- samtools=1.16.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stringtie.xml
- stringtie_merge.xml

Generated with Planemo.