### PR TITLE
Add container mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:e292900a5ccb65f879af393340758539ef14f345.

### DIFF
--- a/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:e292900a5ccb65f879af393340758539ef14f345-0.tsv
+++ b/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:e292900a5ccb65f879af393340758539ef14f345-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.16.1,bowtie2=2.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:e292900a5ccb65f879af393340758539ef14f345

**Packages**:
- samtools=1.16.1
- bowtie2=2.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bowtie2_wrapper.xml

Generated with Planemo.