### PR TITLE
Add container mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:7505b7135dbf615ea0a508a5f565b9f00813d080.

### DIFF
--- a/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:7505b7135dbf615ea0a508a5f565b9f00813d080-0.tsv
+++ b/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:7505b7135dbf615ea0a508a5f565b9f00813d080-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mlst=2.23.0,staramr=0.9.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:7505b7135dbf615ea0a508a5f565b9f00813d080

**Packages**:
- mlst=2.23.0
- staramr=0.9.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- staramr_search.xml

Generated with Planemo.