### PR TITLE
Add container mulled-v2-1d4f0b52ad65a0bc048811a1ffe1511742124a90:35de3dbc3237af0f7bff3686b8032e161a2a0dda.

### DIFF
--- a/combinations/mulled-v2-1d4f0b52ad65a0bc048811a1ffe1511742124a90:35de3dbc3237af0f7bff3686b8032e161a2a0dda-0.tsv
+++ b/combinations/mulled-v2-1d4f0b52ad65a0bc048811a1ffe1511742124a90:35de3dbc3237af0f7bff3686b8032e161a2a0dda-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-officer=0.4.4,r-magrittr=2.0.3,r-dplyr=1.0.10,r-tidyverse=1.3.2,r-officedown=0.2.4,r-stringr=1.4.1,r-tibble=3.1.8,r-knitr=1.40,r-tidyr=1.2.1,r-ggplot2=3.3.6,r-flextable=0.8.1,r-rmarkdown=2.16	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1d4f0b52ad65a0bc048811a1ffe1511742124a90:35de3dbc3237af0f7bff3686b8032e161a2a0dda

**Packages**:
- r-officer=0.4.4
- r-magrittr=2.0.3
- r-dplyr=1.0.10
- r-tidyverse=1.3.2
- r-officedown=0.2.4
- r-stringr=1.4.1
- r-tibble=3.1.8
- r-knitr=1.40
- r-tidyr=1.2.1
- r-ggplot2=3.3.6
- r-flextable=0.8.1
- r-rmarkdown=2.16
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cb_ivr.xml

Generated with Planemo.