### PR TITLE
Add container mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:243f9312b74a5197b3345e348c6b684354036f9c.

### DIFF
--- a/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:243f9312b74a5197b3345e348c6b684354036f9c-0.tsv
+++ b/combinations/mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:243f9312b74a5197b3345e348c6b684354036f9c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+last=1418,blat=36,diamond=2.0.15,blast=2.13.0,proteinortho=6.1.2	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6d4e828e735ac62c061c5cb349a2c8b1204224de:243f9312b74a5197b3345e348c6b684354036f9c

**Packages**:
- last=1418
- blat=36
- diamond=2.0.15
- blast=2.13.0
- proteinortho=6.1.2
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho.xml
- proteinortho_grab_proteins.xml
- proteinortho_summary.xml

Generated with Planemo.