### PR TITLE
Add container mulled-v2-e62c45964731bf241efeedb78776ebc093302f62:abe5275d0bfba478e99a721c3e24cad25789f664.

### DIFF
--- a/combinations/mulled-v2-e62c45964731bf241efeedb78776ebc093302f62:abe5275d0bfba478e99a721c3e24cad25789f664-0.tsv
+++ b/combinations/mulled-v2-e62c45964731bf241efeedb78776ebc093302f62:abe5275d0bfba478e99a721c3e24cad25789f664-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pysradb=1.4.2,imagemagick=7.1.0_52,matplotlib=3.6.2,gawk=5.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e62c45964731bf241efeedb78776ebc093302f62:abe5275d0bfba478e99a721c3e24cad25789f664

**Packages**:
- pysradb=1.4.2
- imagemagick=7.1.0_52
- matplotlib=3.6.2
- gawk=5.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pysradb.xml

Generated with Planemo.