### PR TITLE
Rebuild plant_tribes_kaks_analysis:1.0.3

### DIFF
--- a/combinations/plant_tribes_kaks_analysis:1.0.3-2.tsv
+++ b/combinations/plant_tribes_kaks_analysis:1.0.3-2.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+plant_tribes_kaks_analysis=1.0.3	quay.io/bioconda/base-glibc-busybox-bash:latest	2


### PR DESCRIPTION
The previous build was built without strict channel priority and contains an old version of ruby from bioconda linked against `libjemalloc.so.1`, which is not provided by the newer `jemalloc` version installed at build time.