### PR TITLE
Add container mulled-v2-66666558450b9a1fbe038dbecf7379ea9f340bab:2369805b20057e0c2d5b59dd2566678cef96e607.

### DIFF
--- a/combinations/mulled-v2-66666558450b9a1fbe038dbecf7379ea9f340bab:2369805b20057e0c2d5b59dd2566678cef96e607-0.tsv
+++ b/combinations/mulled-v2-66666558450b9a1fbe038dbecf7379ea9f340bab:2369805b20057e0c2d5b59dd2566678cef96e607-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+targetscan=7.0.2,viennarna=2.2.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-66666558450b9a1fbe038dbecf7379ea9f340bab:2369805b20057e0c2d5b59dd2566678cef96e607

**Packages**:
- targetscan=7.0.2
- viennarna=2.2.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- targetscan.xml

Generated with Planemo.