### PR TITLE
Add container mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:51cc61a3f0efdb533187e9ad84a6cc9d83c57b59. **Hash**: mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:51cc61a3f0efdb533187e9ad84a6cc9d83c57b59

### DIFF
--- a/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:51cc61a3f0efdb533187e9ad84a6cc9d83c57b59-0.tsv
+++ b/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:51cc61a3f0efdb533187e9ad84a6cc9d83c57b59-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+proteinortho=6.1.2,ucsc-blat=377,diamond=2.0.15,last=1418,blast=2.13.0	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
**Packages**:
- proteinortho=6.1.2
- ucsc-blat=377
- diamond=2.0.15
- last=1418
- blast=2.13.0
Base Image:bioconda/extended-base-image:latest

**For** :
- proteinortho_summary.xml
- proteinortho.xml
- proteinortho_grab_proteins.xml

Generated with Planemo.