### PR TITLE
Add container mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:528ec11e1efc11d27a160aad3e65f143cae9ca8d.

### DIFF
--- a/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:528ec11e1efc11d27a160aad3e65f143cae9ca8d-0.tsv
+++ b/combinations/mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:528ec11e1efc11d27a160aad3e65f143cae9ca8d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rmarkdown=2.18,r-seurat=4.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e130ecd2c6e47cf1d1e8de7f0c8b6446e279444:528ec11e1efc11d27a160aad3e65f143cae9ca8d

**Packages**:
- r-rmarkdown=2.18
- r-seurat=4.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.