### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4b6fdbbad724e4227cdabe492018c98e67b49192.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4b6fdbbad724e4227cdabe492018c98e67b49192-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4b6fdbbad724e4227cdabe492018c98e67b49192-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=14.3,p7zip=16.02,ca-certificates=2022.9.24	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:4b6fdbbad724e4227cdabe492018c98e67b49192

**Packages**:
- ncbi-datasets-cli=14.3
- p7zip=16.02
- ca-certificates=2022.9.24
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml

Generated with Planemo.