### PR TITLE
Add container mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:8aa0691a92899ba427e9b8663a9327da4a67fa71.

### DIFF
--- a/combinations/mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:8aa0691a92899ba427e9b8663a9327da4a67fa71-0.tsv
+++ b/combinations/mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:8aa0691a92899ba427e9b8663a9327da4a67fa71-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.2.2,rseqc=5.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:8aa0691a92899ba427e9b8663a9327da4a67fa71

**Packages**:
- r-base=4.2.2
- rseqc=5.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- read_quality.xml
- junction_annotation.xml

Generated with Planemo.