### PR TITLE
Add `quay.io/biocontainers/mulled-v2-c79b00aa4647c739dbe7e8480789d3ba67988f2e:0` 

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -330,4 +330,4 @@ rxdock=2013.1.1_148c5bd1,python=3.9,parallel=20211022
 r-base=3.6.3,python=2.7.15,r-argparser=0.6,r-dplyr=1.0.5
 bbmap=39.01,samtools=1.16.1,pigz=2.6
 vcf2maf=1.6.21,ensembl-vep=107.0,samtools=1.15.1,bcftools=1.15.1
-circtools,r-base
+r-base,r-aod,r-ggplot2,r-plyr


### PR DESCRIPTION
Hi @bgruening , unfortunately the mulled container I created yesterday did not work. This PR should correct it and remove the corresponding line from `hash.tsv`. 

In the interest of storage, could the redundant container `quay.io/biocontainers/mulled-v2-a50bc751044ad6f42e252f1fa778c96b6b86f4b7:0` be deleted? 

Thanks, 

Barry 