### PR TITLE
Add container mulled-v2-1db50f99443206288f90b902e1044e9932611944:758cce59db6fc1127bfffd00686c6783b7a5e06d.

### DIFF
--- a/combinations/mulled-v2-1db50f99443206288f90b902e1044e9932611944:758cce59db6fc1127bfffd00686c6783b7a5e06d-0.tsv
+++ b/combinations/mulled-v2-1db50f99443206288f90b902e1044e9932611944:758cce59db6fc1127bfffd00686c6783b7a5e06d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.16.1,graphviz=3.0.0,vpolo=0.2.0,salmon=1.9.0,pandas=1.5.2,scipy=1.9.3,seqtk=1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1db50f99443206288f90b902e1044e9932611944:758cce59db6fc1127bfffd00686c6783b7a5e06d

**Packages**:
- samtools=1.16.1
- graphviz=3.0.0
- vpolo=0.2.0
- salmon=1.9.0
- pandas=1.5.2
- scipy=1.9.3
- seqtk=1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- salmonquant.xml
- alevin.xml
- salmonquantmerge.xml

Generated with Planemo.