### PR TITLE
Add container mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:513d8f67e8ef83ec06ed21a7f73108b3c6156b75.

### DIFF
--- a/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:513d8f67e8ef83ec06ed21a7f73108b3c6156b75-0.tsv
+++ b/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:513d8f67e8ef83ec06ed21a7f73108b3c6156b75-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+icescreen=1.1.0,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:513d8f67e8ef83ec06ed21a7f73108b3c6156b75

**Packages**:
- icescreen=1.1.0
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- icescreen.xml

Generated with Planemo.