### PR TITLE
Add container mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:3f913c31fa371d96a56cca7778deaab88cdfa9bf.

### DIFF
--- a/combinations/mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:3f913c31fa371d96a56cca7778deaab88cdfa9bf-0.tsv
+++ b/combinations/mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:3f913c31fa371d96a56cca7778deaab88cdfa9bf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+interproscan=5.59-91.0,hmmer=3.1b2,requests=2.26.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-da2a3fcba85e40d72d1dfd9e13144f01f40ad152:3f913c31fa371d96a56cca7778deaab88cdfa9bf

**Packages**:
- interproscan=5.59-91.0
- hmmer=3.1b2
- requests=2.26.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- interproscan.xml

Generated with Planemo.