### PR TITLE
Add container mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:6b46240177cc902d7a0d61ab6e288d7c3d791d49.

### DIFF
--- a/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:6b46240177cc902d7a0d61ab6e288d7c3d791d49-0.tsv
+++ b/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:6b46240177cc902d7a0d61ab6e288d7c3d791d49-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+proteinortho=6.1.5,last=1418,ucsc-blat=377,diamond=2.0.15,blast=2.13.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:6b46240177cc902d7a0d61ab6e288d7c3d791d49

**Packages**:
- proteinortho=6.1.5
- last=1418
- ucsc-blat=377
- diamond=2.0.15
- blast=2.13.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho.xml
- proteinortho_summary.xml
- proteinortho_grab_proteins.xml

Generated with Planemo.