### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:0869a87e6e5f7bd1938db1d2302897a42571a668.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:0869a87e6e5f7bd1938db1d2302897a42571a668-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:0869a87e6e5f7bd1938db1d2302897a42571a668-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2022.9.24,p7zip=16.02,ncbi-datasets-cli=14.6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:0869a87e6e5f7bd1938db1d2302897a42571a668

**Packages**:
- ca-certificates=2022.9.24
- p7zip=16.02
- ncbi-datasets-cli=14.6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.