### PR TITLE
Add container mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:7e1a0812b13a1c047cdfec229bbd1b6cc00e9bc8.

### DIFF
--- a/combinations/mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:7e1a0812b13a1c047cdfec229bbd1b6cc00e9bc8-0.tsv
+++ b/combinations/mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:7e1a0812b13a1c047cdfec229bbd1b6cc00e9bc8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ggplot2=3.4.0,r-base=4.1.1,r-svglite=2.1.0,r-reshape2=1.4.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-72c5c15fef8e7277f5a39f6ecb577229550271a7:7e1a0812b13a1c047cdfec229bbd1b6cc00e9bc8

**Packages**:
- r-ggplot2=3.4.0
- r-base=4.1.1
- r-svglite=2.1.0
- r-reshape2=1.4.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ggplot_histogram.xml
- ggplot_violin.xml

Generated with Planemo.