### PR TITLE
Add container mulled-v2-7fa676f38ece084ab37bdeb69ba98357a795dca1:969d229324abcd04db4366ae2bc82d26fe229e68.

### DIFF
--- a/combinations/mulled-v2-7fa676f38ece084ab37bdeb69ba98357a795dca1:969d229324abcd04db4366ae2bc82d26fe229e68-0.tsv
+++ b/combinations/mulled-v2-7fa676f38ece084ab37bdeb69ba98357a795dca1:969d229324abcd04db4366ae2bc82d26fe229e68-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-org.gg.eg.db=3.16.0,bioconductor-org.dm.eg.db=3.16.0,bioconductor-org.hs.eg.db=3.16.0,bioconductor-org.mm.eg.db=3.16.0,bioconductor-org.dr.eg.db=3.16.0,bioconductor-org.rn.eg.db=3.16.0,bioconductor-org.at.tair.db=3.16.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7fa676f38ece084ab37bdeb69ba98357a795dca1:969d229324abcd04db4366ae2bc82d26fe229e68

**Packages**:
- bioconductor-org.gg.eg.db=3.16.0
- bioconductor-org.dm.eg.db=3.16.0
- bioconductor-org.hs.eg.db=3.16.0
- bioconductor-org.mm.eg.db=3.16.0
- bioconductor-org.dr.eg.db=3.16.0
- bioconductor-org.rn.eg.db=3.16.0
- bioconductor-org.at.tair.db=3.16.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- annotateMyIDs.xml

Generated with Planemo.