### PR TITLE
Add container mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:8cf8fcd5038c6e400dce82809a4f5348110b8259.

### DIFF
--- a/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:8cf8fcd5038c6e400dce82809a4f5348110b8259-0.tsv
+++ b/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:8cf8fcd5038c6e400dce82809a4f5348110b8259-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8,requests=2.27.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:8cf8fcd5038c6e400dce82809a4f5348110b8259

**Packages**:
- python=3.8
- requests=2.27.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bakta_build_database.xml

Generated with Planemo.