### PR TITLE
add r-base to container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -310,7 +310,7 @@ bbmap=38.98,fastp=0.23.2
 bcftools=1.15.1,samtools=1.15.1,python=3.8.3
 p7zip=16.02
 pandas=1.4.3
-r-seqinr=4.2_16,bioconductor-biostrings=2.62.0,bioconductor-shortread=1.52.0
+r-base=4.1.3,r-seqinr=4.2_16,bioconductor-biostrings=2.62.0,bioconductor-shortread=1.52.0
 diamond=2.0.15,seqtk=1.3
 vsearch=2.21.1,cd-hit=4.8.1,seqtk=1.3,bbmap=38.98
 r-plotly=4.10.0,r-knitr=1.39,r-cowplot=1.1.1,r-scales=1.2.0,bioconductor-ggtree=3.2.0,r-devtools=2.4.4,r-biocmanager=1.30.18,r-rmarkdown=2.14,r-kableextra=1.3.4,r-vegan=2.6_2,r-tidyverse=1.3.2


### PR DESCRIPTION
Add r-base to solve the error `Rscript: not found` when using the Docker container https://github.com/nf-core/crisprseq/actions/runs/3657114935/jobs/6180335688