### PR TITLE
Added tools for mulled containers used by `scnanoseq`

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -329,6 +329,10 @@ r-base=3.6.3,r-argparser=0.6,r-dplyr=1.0.5,r-ggplot2=3.3.3,r-ggpubr=0.4.0,r-gplo
 rxdock=2013.1.1_148c5bd1,python=3.9,parallel=20211022
 r-base=3.6.3,python=2.7.15,r-argparser=0.6,r-dplyr=1.0.5
 conda-forge::r-base,conda-forge::r-seurat=4.1.1,conda-forge::r-ggplot2,conda-forge::r-optparse
+bioconductor-bambu=3.0.5,r-optparse
+r-tidyverse=1.3.1,r-optparse
+editdistance=0.6.0,pysam=0.19.1,pygtrie=2.5.0,biopython=1.79
+regex=2022.1.18,biopython=1.79
 bbmap=39.01,samtools=1.16.1,pigz=2.6
 vcf2maf=1.6.21,ensembl-vep=107.0,samtools=1.15.1,bcftools=1.15.1
 circtools,r-base


### PR DESCRIPTION
This PR adds tools for 4 mulled containers needed by the `scnanoseq` nf-core pipeline which is under development:

```
bioconductor-bambu=3.0.5,r-optparse
r-tidyverse=1.3.1,r-optparse
editdistance=0.6.0,pysam=0.19.1,pygtrie=2.5.0,biopython=1.79
regex=2022.1.18,biopython=1.79
```