### PR TITLE
Add container mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:98edaf83ba4c6b627270aa5447704b3aa1e44d0d.

### DIFF
--- a/combinations/mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:98edaf83ba4c6b627270aa5447704b3aa1e44d0d-0.tsv
+++ b/combinations/mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:98edaf83ba4c6b627270aa5447704b3aa1e44d0d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.10.6,ncbi-amrfinderplus=3.10.45,pandas=1.5.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:98edaf83ba4c6b627270aa5447704b3aa1e44d0d

**Packages**:
- python=3.10.6
- ncbi-amrfinderplus=3.10.45
- pandas=1.5.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_build_amrfinderplus.xml

Generated with Planemo.