### PR TITLE
Add container mulled-v2-05970d57925829f13c3e11fd4669f36a6e9dbc0b:bd7c7f85083d3287e61f1630d1ae1278ec53b616.

### DIFF
--- a/combinations/mulled-v2-05970d57925829f13c3e11fd4669f36a6e9dbc0b:bd7c7f85083d3287e61f1630d1ae1278ec53b616-0.tsv
+++ b/combinations/mulled-v2-05970d57925829f13c3e11fd4669f36a6e9dbc0b:bd7c7f85083d3287e61f1630d1ae1278ec53b616-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+apollo=4.2.13,rsync=3.2.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-05970d57925829f13c3e11fd4669f36a6e9dbc0b:bd7c7f85083d3287e61f1630d1ae1278ec53b616

**Packages**:
- apollo=4.2.13
- rsync=3.2.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fetch_organism_jbrowse.xml

Generated with Planemo.