### PR TITLE
Add container mulled-v2-7af695c5fcdfb35509bd54076bbaacc78b299572:5790f8049502d19b0cd336cbadb10d67539c8abf.

### DIFF
--- a/combinations/mulled-v2-7af695c5fcdfb35509bd54076bbaacc78b299572:5790f8049502d19b0cd336cbadb10d67539c8abf-0.tsv
+++ b/combinations/mulled-v2-7af695c5fcdfb35509bd54076bbaacc78b299572:5790f8049502d19b0cd336cbadb10d67539c8abf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.2.2,r-rmarkdown=2.19,r-stringr=1.5.0,r-officer=0.5.0,r-magrittr=2.0.3,r-dplyr=1.0.10,r-tibble=3.1.8,r-ggplot2=3.4,r-knitr=1.41,r-tidyverse=1.3.2,r-tidyr=1.2.1,r-flextable=0.8.3,r-officedown=0.2.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7af695c5fcdfb35509bd54076bbaacc78b299572:5790f8049502d19b0cd336cbadb10d67539c8abf

**Packages**:
- r-base=4.2.2
- r-rmarkdown=2.19
- r-stringr=1.5.0
- r-officer=0.5.0
- r-magrittr=2.0.3
- r-dplyr=1.0.10
- r-tibble=3.1.8
- r-ggplot2=3.4
- r-knitr=1.41
- r-tidyverse=1.3.2
- r-tidyr=1.2.1
- r-flextable=0.8.3
- r-officedown=0.2.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cb_ivr.xml

Generated with Planemo.