### PR TITLE
Add container mulled-v2-935ccd02f4e91ba43678ed60a3e7dfa29dc12edb:2a6a68fb4ad9613a78078488d8172b0c3e1e4371.

### DIFF
--- a/combinations/mulled-v2-935ccd02f4e91ba43678ed60a3e7dfa29dc12edb:2a6a68fb4ad9613a78078488d8172b0c3e1e4371-0.tsv
+++ b/combinations/mulled-v2-935ccd02f4e91ba43678ed60a3e7dfa29dc12edb:2a6a68fb4ad9613a78078488d8172b0c3e1e4371-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.2.2,r-viridis=0.6.2,r-gsl=2.1_7.1,r-magrittr=2.0.3,r-dplyr=1.0.10,r-rnaturalearth=0.1.0,r-dggridr=3.0.0,r-sf=1.0_7,r-ggplot2=3.4.0,r-rnaturalearthdata=0.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-935ccd02f4e91ba43678ed60a3e7dfa29dc12edb:2a6a68fb4ad9613a78078488d8172b0c3e1e4371

**Packages**:
- r-base=4.2.2
- r-viridis=0.6.2
- r-gsl=2.1_7.1
- r-magrittr=2.0.3
- r-dplyr=1.0.10
- r-rnaturalearth=0.1.0
- r-dggridr=3.0.0
- r-sf=1.0_7
- r-ggplot2=3.4.0
- r-rnaturalearthdata=0.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- obisindicators.xml

Generated with Planemo.