### PR TITLE
Add container mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:ef568af8775dbbcbee71f51a6a3b20a9f3a59e00.

### DIFF
--- a/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:ef568af8775dbbcbee71f51a6a3b20a9f3a59e00-0.tsv
+++ b/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:ef568af8775dbbcbee71f51a6a3b20a9f3a59e00-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.5.3,bcftools=1.15.1,tectonic=0.12.0,samtools=1.15.1,htslib=1.15.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:ef568af8775dbbcbee71f51a6a3b20a9f3a59e00

**Packages**:
- matplotlib=3.5.3
- bcftools=1.15.1
- tectonic=0.12.0
- samtools=1.15.1
- htslib=1.15.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_stats.xml

Generated with Planemo.