### PR TITLE
Add container mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:f69ccb328f427733c6a3ba80809cac9717724909.

### DIFF
--- a/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:f69ccb328f427733c6a3ba80809cac9717724909-0.tsv
+++ b/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:f69ccb328f427733c6a3ba80809cac9717724909-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+usher=0.6.2,pangolin=4.1.3,minimap2=2.24,csvtk=0.25.0,ucsc-fatovcf=426,constellations=0.1.10,gofasta=1.1.0,grep=3.4,pangolin-data=1.17,scorpio=0.3.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:f69ccb328f427733c6a3ba80809cac9717724909

**Packages**:
- usher=0.6.2
- pangolin=4.1.3
- minimap2=2.24
- csvtk=0.25.0
- ucsc-fatovcf=426
- constellations=0.1.10
- gofasta=1.1.0
- grep=3.4
- pangolin-data=1.17
- scorpio=0.3.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.