### PR TITLE
Add container mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:7c8371a0022ba2fbb2a0fc5ff38efb1b3d0b0688.

### DIFF
--- a/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:7c8371a0022ba2fbb2a0fc5ff38efb1b3d0b0688-0.tsv
+++ b/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:7c8371a0022ba2fbb2a0fc5ff38efb1b3d0b0688-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scorpio=0.3.17,grep=3.4,pangolin-data=1.17,ucsc-fatovcf=426,gofasta=1.1.0,pangolin=4.2,constellations=0.1.10,usher=0.6.2,minimap2=2.24,csvtk=0.25.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:7c8371a0022ba2fbb2a0fc5ff38efb1b3d0b0688

**Packages**:
- scorpio=0.3.17
- grep=3.4
- pangolin-data=1.17
- ucsc-fatovcf=426
- gofasta=1.1.0
- pangolin=4.2
- constellations=0.1.10
- usher=0.6.2
- minimap2=2.24
- csvtk=0.25.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.