### PR TITLE
Add container mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:253af48d0c4a83612bcf32943831f33a47ffafaf.

### DIFF
--- a/combinations/mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:253af48d0c4a83612bcf32943831f33a47ffafaf-0.tsv
+++ b/combinations/mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:253af48d0c4a83612bcf32943831f33a47ffafaf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+euphonic=1.0.0,zip=3.0,pymuonsuite=0.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:253af48d0c4a83612bcf32943831f33a47ffafaf

**Packages**:
- euphonic=1.0.0
- zip=3.0
- pymuonsuite=0.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pm_nq.xml

Generated with Planemo.