### PR TITLE
Add container mulled-v2-58f2574ebdaab51f07f50801a686e17cdc14fcf0:537924fe788181888d2476f600451520fdfd33ea.

### DIFF
--- a/combinations/mulled-v2-58f2574ebdaab51f07f50801a686e17cdc14fcf0:537924fe788181888d2476f600451520fdfd33ea-0.tsv
+++ b/combinations/mulled-v2-58f2574ebdaab51f07f50801a686e17cdc14fcf0:537924fe788181888d2476f600451520fdfd33ea-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+htslib=1.16,coreutils=9.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-58f2574ebdaab51f07f50801a686e17cdc14fcf0:537924fe788181888d2476f600451520fdfd33ea

**Packages**:
- htslib=1.16
- coreutils=9.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- interval_to_bgzip_converter.xml

Generated with Planemo.