### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:c4345de14d1a68e8e8398a77a3ff20562f4b3dab.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:c4345de14d1a68e8e8398a77a3ff20562f4b3dab-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:c4345de14d1a68e8e8398a77a3ff20562f4b3dab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+yak=0.1,hifiasm=0.18.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:c4345de14d1a68e8e8398a77a3ff20562f4b3dab

**Packages**:
- yak=0.1
- hifiasm=0.18.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.