### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:9ffe093e2066f0414c33beedb69c1ca243903e46.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:9ffe093e2066f0414c33beedb69c1ca243903e46-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:9ffe093e2066f0414c33beedb69c1ca243903e46-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.16.1,sra-tools=3.0.0,pigz=2.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:9ffe093e2066f0414c33beedb69c1ca243903e46

**Packages**:
- samtools=1.16.1
- sra-tools=3.0.0
- pigz=2.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fastq_dump.xml
- fasterq_dump.xml
- sam_dump.xml

Generated with Planemo.