### PR TITLE
Add container mulled-v2-8164d39688a7d09e655a207d9302604653235c22:a24aa5c7cb85507b4e55aa20014c5fb5ad16ae2c.

### DIFF
--- a/combinations/mulled-v2-8164d39688a7d09e655a207d9302604653235c22:a24aa5c7cb85507b4e55aa20014c5fb5ad16ae2c-0.tsv
+++ b/combinations/mulled-v2-8164d39688a7d09e655a207d9302604653235c22:a24aa5c7cb85507b4e55aa20014c5fb5ad16ae2c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kleborate=2.3.0,kaptive=2.0.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8164d39688a7d09e655a207d9302604653235c22:a24aa5c7cb85507b4e55aa20014c5fb5ad16ae2c

**Packages**:
- kleborate=2.3.0
- kaptive=2.0.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kleborate.xml

Generated with Planemo.