### PR TITLE
Add container mulled-v2-74fb92a516e1351a0d862b5a82851a388617fca6:ece820afc8d64dd226ddf93e2f56fe6b20c0cf0f.

### DIFF
--- a/combinations/mulled-v2-74fb92a516e1351a0d862b5a82851a388617fca6:ece820afc8d64dd226ddf93e2f56fe6b20c0cf0f-0.tsv
+++ b/combinations/mulled-v2-74fb92a516e1351a0d862b5a82851a388617fca6:ece820afc8d64dd226ddf93e2f56fe6b20c0cf0f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-argparse=2.2.1,bioconductor-isoformswitchanalyzer=1.20.0,r-dplyr=1.0.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-74fb92a516e1351a0d862b5a82851a388617fca6:ece820afc8d64dd226ddf93e2f56fe6b20c0cf0f

**Packages**:
- r-argparse=2.2.1
- bioconductor-isoformswitchanalyzer=1.20.0
- r-dplyr=1.0.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- isoformswitchanalyzer.xml

Generated with Planemo.