### PR TITLE
Add container mulled-v2-f395c32258c413438e4e76bb2de5778c96486df0:1a968c65cb05d516385de9b2bfb013915c9ddb1b.

### DIFF
--- a/combinations/mulled-v2-f395c32258c413438e4e76bb2de5778c96486df0:1a968c65cb05d516385de9b2bfb013915c9ddb1b-0.tsv
+++ b/combinations/mulled-v2-f395c32258c413438e4e76bb2de5778c96486df0:1a968c65cb05d516385de9b2bfb013915c9ddb1b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hmmer=3.3.2,pfam_scan=1.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f395c32258c413438e4e76bb2de5778c96486df0:1a968c65cb05d516385de9b2bfb013915c9ddb1b

**Packages**:
- hmmer=3.3.2
- pfam_scan=1.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pfamscan.xml

Generated with Planemo.