### PR TITLE
Add container mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:b586990207ad150815b0bba9469f3b10f1ded05e.

### DIFF
--- a/combinations/mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:b586990207ad150815b0bba9469f3b10f1ded05e-0.tsv
+++ b/combinations/mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:b586990207ad150815b0bba9469f3b10f1ded05e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+euphonic=1.0.0,zip=3.0,pymuonsuite=0.2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:b586990207ad150815b0bba9469f3b10f1ded05e

**Packages**:
- euphonic=1.0.0
- zip=3.0
- pymuonsuite=0.2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pm_nq.xml

Generated with Planemo.