### PR TITLE
Add container mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:0c8b01750a3618e51dfdc52260ee25e988a0b510.

### DIFF
--- a/combinations/mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:0c8b01750a3618e51dfdc52260ee25e988a0b510-0.tsv
+++ b/combinations/mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:0c8b01750a3618e51dfdc52260ee25e988a0b510-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.16.1,gffcompare=0.12.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:0c8b01750a3618e51dfdc52260ee25e988a0b510

**Packages**:
- samtools=1.16.1
- gffcompare=0.12.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- gffcompare.xml

Generated with Planemo.