### PR TITLE
Add container mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:0aba14790d322fae5d56ce22ca3a8832591f4228.

### DIFF
--- a/combinations/mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:0aba14790d322fae5d56ce22ca3a8832591f4228-0.tsv
+++ b/combinations/mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:0aba14790d322fae5d56ce22ca3a8832591f4228-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bbmap=39.01,samtools=1.16.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:0aba14790d322fae5d56ce22ca3a8832591f4228

**Packages**:
- bbmap=39.01
- samtools=1.16.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bbmerge.xml
- bbduk.xml
- bbmap.xml
- tadpole.xml
- callvariants.xml

Generated with Planemo.