### PR TITLE
Add container humann:3.6.0.

### DIFF
--- a/combinations/humann:3.6.0-0.tsv
+++ b/combinations/humann:3.6.0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+humann=3.6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: humann:3.6.0

**Packages**:
- humann=3.6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- humann_barplot.xml
- humann_associate.xml
- humann_split_table.xml
- humann_renorm_table.xml
- humann_rename_table.xml
- humann_reduce_table.xml
- humann.xml
- humann_rna_dna_norm.xml
- humann_unpack_pathways.xml
- humann_join_tables.xml
- humann_strain_profiler.xml
- humann_split_stratified_table.xml
- humann_regroup_table.xml
- data_manager_humann_download.xml

Generated with Planemo.