### PR TITLE
Add container mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:50e031e77bab79c1ebcfc7cfe3efcf29135236c8.

### DIFF
--- a/combinations/mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:50e031e77bab79c1ebcfc7cfe3efcf29135236c8-0.tsv
+++ b/combinations/mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:50e031e77bab79c1ebcfc7cfe3efcf29135236c8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.10.8,ivar=1.3.2,samtools=1.16.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:50e031e77bab79c1ebcfc7cfe3efcf29135236c8

**Packages**:
- python=3.10.8
- ivar=1.3.2
- samtools=1.16.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ivar_variants.xml
- ivar_filtervariants.xml
- ivar_removereads.xml
- ivar_trim.xml
- ivar_consensus.xml

Generated with Planemo.