### PR TITLE
packages with latest version 0.16.4 for polars, support iter_rows function

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -368,3 +368,4 @@ coreutils=9.1,gawk=5.1.0,grep=3.4,matplotlib=3.6.2,numpy=1.23.5,pandas=1.5.2,sam
 gffutils=0.11.1,biopython=1.80,pyvcf=0.6.8
 python=3.10,biopython=1.80,openpyxl=3.1.0,pandas=1.5.3,rich=12.6.0,typer=0.7.0,xlsxwriter=3.0.8,numpy=1.24.2,polars=0.15.14,pyarrow=11.0.0
 r-tidyverse=1.3.1,r-data.table=1.14.6,r-caret=6.0_93
+python=3.10,biopython=1.80,openpyxl=3.1.0,pandas=1.5.3,rich=12.6.0,typer=0.7.0,xlsxwriter=3.0.8,numpy=1.24.2,polars=0.16.4,pyarrow=11.0.0


### PR DESCRIPTION
Since release 0.15.18, polars renamed `iterrows` to `iter_rows` and with some enhancement for this function later on. So I open PR to create new containers 

The old containers with PR https://github.com/BioContainers/multi-package-containers/pull/2510 can be deleted if possible

`quay.io/biocontainers/mulled-v2-cfa20dfeb068db79c8620a11753add64c23d013a:3adbf53eacd4a4477db6e6283c1660f65628bef1-0`

Thanks,
Hai