### PR TITLE
Add container mulled-v2-468c0dfd23d0c52420c4a3bf0b82e4386a4ba151:d5b6fd312fbceb2f03f63a7b35fd66394d765549.

### DIFF
--- a/combinations/mulled-v2-468c0dfd23d0c52420c4a3bf0b82e4386a4ba151:d5b6fd312fbceb2f03f63a7b35fd66394d765549-0.tsv
+++ b/combinations/mulled-v2-468c0dfd23d0c52420c4a3bf0b82e4386a4ba151:d5b6fd312fbceb2f03f63a7b35fd66394d765549-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bzip2=1.0.8,htslib=1.16	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-468c0dfd23d0c52420c4a3bf0b82e4386a4ba151:d5b6fd312fbceb2f03f63a7b35fd66394d765549

**Packages**:
- bzip2=1.0.8
- htslib=1.16
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- uncompressed_to_gz.xml

Generated with Planemo.