### PR TITLE
Add container mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:e3bc54570927dc255f0e580cba1789b64690d611.

### DIFF
--- a/combinations/mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:e3bc54570927dc255f0e580cba1789b64690d611-0.tsv
+++ b/combinations/mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:e3bc54570927dc255f0e580cba1789b64690d611-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.12,samtools=1.16.1,python=3.7,star=2.7.10b	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:e3bc54570927dc255f0e580cba1789b64690d611

**Packages**:
- gzip=1.12
- samtools=1.16.1
- python=3.7
- star=2.7.10b
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rna_star_index_builder.xml

Generated with Planemo.