### PR TITLE
Add container mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:ff89de49297a71ab78ef0d2f8a4a85a3b10bc5de.

### DIFF
--- a/combinations/mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:ff89de49297a71ab78ef0d2f8a4a85a3b10bc5de-0.tsv
+++ b/combinations/mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:ff89de49297a71ab78ef0d2f8a4a85a3b10bc5de-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.12,samtools=1.16.1,star=2.7.10b	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:ff89de49297a71ab78ef0d2f8a4a85a3b10bc5de

**Packages**:
- gzip=1.12
- samtools=1.16.1
- star=2.7.10b
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rg_rnaStarSolo.xml
- rg_rnaStar.xml

Generated with Planemo.