### PR TITLE
Add container mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:5b51379e60303022cf38e03790719b891c5e674a.

### DIFF
--- a/combinations/mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:5b51379e60303022cf38e03790719b891c5e674a-0.tsv
+++ b/combinations/mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:5b51379e60303022cf38e03790719b891c5e674a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+getorganelle=1.7.7.0,biopython=1.79	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:5b51379e60303022cf38e03790719b891c5e674a

**Packages**:
- getorganelle=1.7.7.0
- biopython=1.79
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- get_annotated_regions_from_gb.xml

Generated with Planemo.