### PR TITLE
Add container mulled-v2-258922dd32ede57ed7115a4d4c28f2094cb21eec:4913fcfa10f2f2aff7ece136756af6fe46e6be0d.

### DIFF
--- a/combinations/mulled-v2-258922dd32ede57ed7115a4d4c28f2094cb21eec:4913fcfa10f2f2aff7ece136756af6fe46e6be0d-0.tsv
+++ b/combinations/mulled-v2-258922dd32ede57ed7115a4d4c28f2094cb21eec:4913fcfa10f2f2aff7ece136756af6fe46e6be0d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gmp=6.2.1,samtools=1.16.1,bowtie2=2.4.5,hicup=0.9.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-258922dd32ede57ed7115a4d4c28f2094cb21eec:4913fcfa10f2f2aff7ece136756af6fe46e6be0d

**Packages**:
- gmp=6.2.1
- samtools=1.16.1
- bowtie2=2.4.5
- hicup=0.9.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hicup_filter.xml
- hicup_digester.xml
- hicup2juicer.xml
- hicup_deduplicator.xml
- hicup_mapper.xml
- hicup_truncater.xml
- hicup_hicup.xml

Generated with Planemo.