### PR TITLE
Add container mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:80948538a8bdca8b6531966deccf2b5302e3d649.

### DIFF
--- a/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:80948538a8bdca8b6531966deccf2b5302e3d649-0.tsv
+++ b/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:80948538a8bdca8b6531966deccf2b5302e3d649-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+subread=2.0.3,samtools=1.16.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:80948538a8bdca8b6531966deccf2b5302e3d649

**Packages**:
- subread=2.0.3
- samtools=1.16.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- featurecounts.xml

Generated with Planemo.