### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb08b6ef61eff051bc66639545df1af6df47c0f7.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb08b6ef61eff051bc66639545df1af6df47c0f7-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb08b6ef61eff051bc66639545df1af6df47c0f7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fonts-conda-ecosystem=1,busco=5.4.5,tar=1.34	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:bb08b6ef61eff051bc66639545df1af6df47c0f7

**Packages**:
- fonts-conda-ecosystem=1
- busco=5.4.5
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.