### PR TITLE
Update hash.tsv

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -381,3 +381,5 @@ python=3.9,biopython=1.79,pandas=1.5.3,pandarallel=1.6.4
 enasearch=0.1.1	quay.io/bioconda/base-glibc-debian-bash:latest	1
 bioconductor-scater=1.26.0,bioconductor-deseq2=1.38.0,bioconductor-limma=3.54.0,r-ashr=2.2_54,r-pheatmap=1.0.12
 rmats=4.1.2,r-pairadise=1.0.0
+vibrant=1.2.1,coreutils=8.30
+

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -382,4 +382,3 @@ enasearch=0.1.1	quay.io/bioconda/base-glibc-debian-bash:latest	1
 bioconductor-scater=1.26.0,bioconductor-deseq2=1.38.0,bioconductor-limma=3.54.0,r-ashr=2.2_54,r-pheatmap=1.0.12
 rmats=4.1.2,r-pairadise=1.0.0
 vibrant=1.2.1,coreutils=8.30
-


### PR DESCRIPTION
I'm doing this because I'm facing a similar issue to bioconda/bioconda-recipes#37865 when trying to use the biocontainers image for VIBRANT. VIBRANT makes a call to `sort -R` which is an invalid option in the version of sort available in that image. So [I'm trying to follow the suggestion given here](https://github.com/bioconda/bioconda-recipes/issues/37865#issuecomment-1312731062).

I built this image locally using mulled and it does seem to solve the issue.