### PR TITLE
Add container mulled-v2-8164d39688a7d09e655a207d9302604653235c22:4b859397bfbe43d5cef48dd34c9ca6952b65b47b.

### DIFF
--- a/combinations/mulled-v2-8164d39688a7d09e655a207d9302604653235c22:4b859397bfbe43d5cef48dd34c9ca6952b65b47b-0.tsv
+++ b/combinations/mulled-v2-8164d39688a7d09e655a207d9302604653235c22:4b859397bfbe43d5cef48dd34c9ca6952b65b47b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kaptive=2.0.6,kleborate=2.3.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8164d39688a7d09e655a207d9302604653235c22:4b859397bfbe43d5cef48dd34c9ca6952b65b47b

**Packages**:
- kaptive=2.0.6
- kleborate=2.3.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kleborate.xml

Generated with Planemo.