### PR TITLE
Add container mulled-v2-4e5bab508d50d8a5ce9922ef9d1166663893a590:70786904046a08547c136f61b3f310acf2f46712.

### DIFF
--- a/combinations/mulled-v2-4e5bab508d50d8a5ce9922ef9d1166663893a590:70786904046a08547c136f61b3f310acf2f46712-0.tsv
+++ b/combinations/mulled-v2-4e5bab508d50d8a5ce9922ef9d1166663893a590:70786904046a08547c136f61b3f310acf2f46712-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-tidyr=1.2.1,r-stringr=1.4.1,r-magrittr=2.0.3,r-rmarkdown=2.18,r-flextable=0.8.3,r-tidyverse=1.3.2,r-officer=0.5.1,r-gmp=0.6_8,r-ggplot2=3.4.0,r-dplyr=1.0.10,r-tibble=3.1.8,r-officedown=0.2.4,r-knitr=1.40	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4e5bab508d50d8a5ce9922ef9d1166663893a590:70786904046a08547c136f61b3f310acf2f46712

**Packages**:
- r-tidyr=1.2.1
- r-stringr=1.4.1
- r-magrittr=2.0.3
- r-rmarkdown=2.18
- r-flextable=0.8.3
- r-tidyverse=1.3.2
- r-officer=0.5.1
- r-gmp=0.6_8
- r-ggplot2=3.4.0
- r-dplyr=1.0.10
- r-tibble=3.1.8
- r-officedown=0.2.4
- r-knitr=1.40
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cb_ivr.xml

Generated with Planemo.