### PR TITLE
Add container mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:e2c6477f5df0e9ec64324f6743eb08654a5bcd01.

### DIFF
--- a/combinations/mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:e2c6477f5df0e9ec64324f6743eb08654a5bcd01-0.tsv
+++ b/combinations/mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:e2c6477f5df0e9ec64324f6743eb08654a5bcd01-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.72,circos=0.69.8,circos-tools=0.23,grep=3.4,gawk=5.1.0,pybigwig=0.3.18,bcbiogff=0.6.6,python=3.7.12,tar=1.34	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e80261884f165982dbbf2d4738d698db578c42f5:e2c6477f5df0e9ec64324f6743eb08654a5bcd01

**Packages**:
- biopython=1.72
- circos=0.69.8
- circos-tools=0.23
- grep=3.4
- gawk=5.1.0
- pybigwig=0.3.18
- bcbiogff=0.6.6
- python=3.7.12
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- text-from-interval.xml
- gc_skew.xml
- resample.xml
- scatter-from-wiggle.xml
- tiles-from-interval.xml
- stack-histogram.xml
- circos.xml
- tableviewer.xml
- binlinks.xml
- bundlelinks.xml
- alignments-to-links.xml

Generated with Planemo.