### PR TITLE
Add cadd+conda combo

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -385,3 +385,4 @@ bedtools=2.30.0,biopython=1.79,circos=0.69.8,coreutils=9.1,gawk=5.1.0,numpy=1.23
 python=3.6,bowtie2=2.3.4,samtools=1.3.1,biopython=1.79,pysam=0.19.1,diamond=0.9.29,pandas=0.20
 star=2.7.10b,samtools=1.16.1,gawk=5.1.0
 r-vcfr=1.14.0,r-mongolite=2.7.1,r-jsonlite=1.8.4,r-optparse=1.7.3,r-tidyverse=2.0.0
+cadd-scripts=1.6,conda=4.14.0


### PR DESCRIPTION
CADD needs conda to be in path to run, without it both docker and singularity images are unusable. Hence, the need for this mulled container. 