### PR TITLE
mulled container for hifiasm and samtools

### DIFF
--- a/combinations/quay.io_biocontainers_mulled-v2-9f30340fa6bf2d4e604e5c30bc65d5554fb4a3cf_3522be1df8657efefe10f84f598f545deef1cd09.tsv
+++ b/combinations/quay.io_biocontainers_mulled-v2-9f30340fa6bf2d4e604e5c30bc65d5554fb4a3cf_3522be1df8657efefe10f84f598f545deef1cd09.tsv
@@ -1,0 +1,1 @@
+bioconda::hifiasm=0.16.1,bioconda::samtools=1.15


### PR DESCRIPTION
Commit changes contain a definition of the mulled container for hifiasm=0.16.1 and samtools=1.15