### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0acaeb6d6362d2b6ff3dc80676056404135cc1ae.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0acaeb6d6362d2b6ff3dc80676056404135cc1ae-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0acaeb6d6362d2b6ff3dc80676056404135cc1ae-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+yak=0.1,hifiasm=0.19.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0acaeb6d6362d2b6ff3dc80676056404135cc1ae

**Packages**:
- yak=0.1
- hifiasm=0.19.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.