### PR TITLE
Add container mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:1f11faba9d0f56a01cc9c02c16d514332d06631b.

### DIFF
--- a/combinations/mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:1f11faba9d0f56a01cc9c02c16d514332d06631b-0.tsv
+++ b/combinations/mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:1f11faba9d0f56a01cc9c02c16d514332d06631b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-getopt=1.20.3,r-rjson=0.2.21,bioconductor-dexseq=1.44	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:1f11faba9d0f56a01cc9c02c16d514332d06631b

**Packages**:
- r-getopt=1.20.3
- r-rjson=0.2.21
- bioconductor-dexseq=1.44
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plotdexseq.xml
- dexseq.xml
- dexseq_count.xml

Generated with Planemo.