### PR TITLE
Add container mulled-v2-e55777ce93e8830ae3af21342ba29604ecff7116:499d90913edb810078c759bb32adc4458a451c4f.

### DIFF
--- a/combinations/mulled-v2-e55777ce93e8830ae3af21342ba29604ecff7116:499d90913edb810078c759bb32adc4458a451c4f-0.tsv
+++ b/combinations/mulled-v2-e55777ce93e8830ae3af21342ba29604ecff7116:499d90913edb810078c759bb32adc4458a451c4f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+smoove=0.2.8,svtyper=0.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e55777ce93e8830ae3af21342ba29604ecff7116:499d90913edb810078c759bb32adc4458a451c4f

**Packages**:
- smoove=0.2.8
- svtyper=0.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lumpy_smoove.xml

Generated with Planemo.