### PR TITLE
New multipackage container containing python packages for PrepareAA s…

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -392,3 +392,4 @@ bioconductor-clusterprofiler=4.6.0,bioconductor-org.hs.eg.db=3.16.0
 xopen=1.1.0,pysam=0.16.0
 bioconductor-purecn=2.4.0,bioconductor-txdb.hsapiens.ucsc.hg38.knowngene=3.16.0,bioconductor-org.hs.eg.db=3.16.0,bioconductor-txdb.hsapiens.ucsc.hg19.knowngene=3.2.2
 python=3.6.13,pandas=1.1.5,numpy=1.19.5,jinja2==2.11.3,pyyaml=5.3,fire=0.3
+python=2.7,pysam=0.15.2,flask=1.1.2,cython=0.29.14,numpy=1.16.6,scipy=1.2.1,matplotlib=2.2.5,mosek::mosek=8.0.60,future=0.18.2,intervaltree=3.0.2


### PR DESCRIPTION
See title. PrepareAA (https://github.com/jluebeck/AmpliconSuite-pipeline/tree/45cb915702df56d72fa337c93107adb8bb4fe1b8) uses additional python packages for its scripts in the newest version. 

Having a conda package for it is sadly not possible as it requires licenses to run, which are free for academic use.  Therefore, a multi package container is the only option atm to use it with singularity and docker