### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:62a96791b744dc8ea17c904c1fa16bd0c01c338d.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:62a96791b744dc8ea17c904c1fa16bd0c01c338d-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:62a96791b744dc8ea17c904c1fa16bd0c01c338d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fonts-conda-ecosystem=1,tar=1.34,busco=5.4.6	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:62a96791b744dc8ea17c904c1fa16bd0c01c338d

**Packages**:
- fonts-conda-ecosystem=1
- tar=1.34
- busco=5.4.6
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.