### PR TITLE
Combination for update to scanpy tools IUC galaxy wrappers

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -395,4 +395,4 @@ python=3.6.13,pandas=1.1.5,numpy=1.19.5,jinja2==2.11.3,pyyaml=5.3,fire=0.3
 geojson=3.0.1,numpy=1.24.2,opencv=4.7.0,pandas=2.0.0	bioconda/extended-base-image:latest	0
 anndata=0.9.1,matplotlib=3.7.1,pandas=2.0.0,scanpy=1.9.3
 python=3.9,pandas=1.4.2,seaborn=0.11.2,numpy=1.20.0,bottleneck=1.3.2
-anndata=0.7.5,matplotlib=3.3.4,loompy=2.0.17,leidenalg=0.8.3,scanpy=1.7.1,python=3.8.8,scipy=1.6.1,numpy=1.20.1,h5py=3.1.0,hdf5=1.10.6,pandas=1.2.3
+scanpy=1.7.1,matplotlib=3.6.3,anndata=0.7.5,loompy=2.0.17,leidenalg=0.8.3,pandas=1.5.3

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -394,3 +394,4 @@ bioconductor-purecn=2.4.0,bioconductor-txdb.hsapiens.ucsc.hg38.knowngene=3.16.0,
 python=3.6.13,pandas=1.1.5,numpy=1.19.5,jinja2==2.11.3,pyyaml=5.3,fire=0.3
 geojson=3.0.1,numpy=1.24.2,opencv=4.7.0,pandas=2.0.0	bioconda/extended-base-image:latest	0
 anndata=0.9.1,matplotlib=3.7.1,pandas=2.0.0,scanpy=1.9.3
+anndata=0.7.5,matplotlib=3.6.3,loompy=2.0.17,leidenalg=0.8.3,scanpy=1.7.1

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -394,4 +394,4 @@ bioconductor-purecn=2.4.0,bioconductor-txdb.hsapiens.ucsc.hg38.knowngene=3.16.0,
 python=3.6.13,pandas=1.1.5,numpy=1.19.5,jinja2==2.11.3,pyyaml=5.3,fire=0.3
 geojson=3.0.1,numpy=1.24.2,opencv=4.7.0,pandas=2.0.0	bioconda/extended-base-image:latest	0
 anndata=0.9.1,matplotlib=3.7.1,pandas=2.0.0,scanpy=1.9.3
-anndata=0.7.5,matplotlib=3.6.3,loompy=2.0.17,leidenalg=0.8.3,scanpy=1.7.1
+anndata=0.7.5,matplotlib=3.3.4,loompy=2.0.17,leidenalg=0.8.3,scanpy=1.7.1,python=3.8.8

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -394,4 +394,4 @@ bioconductor-purecn=2.4.0,bioconductor-txdb.hsapiens.ucsc.hg38.knowngene=3.16.0,
 python=3.6.13,pandas=1.1.5,numpy=1.19.5,jinja2==2.11.3,pyyaml=5.3,fire=0.3
 geojson=3.0.1,numpy=1.24.2,opencv=4.7.0,pandas=2.0.0	bioconda/extended-base-image:latest	0
 anndata=0.9.1,matplotlib=3.7.1,pandas=2.0.0,scanpy=1.9.3
-anndata=0.7.5,matplotlib=3.3.4,loompy=2.0.17,leidenalg=0.8.3,scanpy=1.7.1,python=3.8.8
+anndata=0.7.5,matplotlib=3.3.4,loompy=2.0.17,leidenalg=0.8.3,scanpy=1.7.1,python=3.8.8,scipy=1.6.1,numpy=1.20.1,h5py=3.1.0,hdf5=1.10.6,pandas=1.2.3


### PR DESCRIPTION
This aims to add a new container for these minor set of changes in [tools-iuc/scanpy](https://github.com/galaxyproject/tools-iuc/pull/5206).

It should specifically match these [new deps versions](https://github.com/galaxyproject/tools-iuc/blob/327881a8d914311de1ba43fd8171898e008dd0a8/tools/scanpy/macros.xml#L2-L11), which aim to mimic as much as possible the ones in the current mulled container used by the tool, but overcoming an issue with a matplotlib 3.7.