### PR TITLE
Add container mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:48ddd4c9e62a91a00e217e3c540713b859ecc2fc.

### DIFF
--- a/combinations/mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:48ddd4c9e62a91a00e217e3c540713b859ecc2fc-0.tsv
+++ b/combinations/mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:48ddd4c9e62a91a00e217e3c540713b859ecc2fc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ivar=1.4.2,samtools=1.16.1,python=3.11.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-63799f2237acb361cf94ed0b24a3ed6e5b57284b:48ddd4c9e62a91a00e217e3c540713b859ecc2fc

**Packages**:
- ivar=1.4.2
- samtools=1.16.1
- python=3.11.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ivar_removereads.xml
- ivar_variants.xml
- ivar_filtervariants.xml
- ivar_consensus.xml
- ivar_trim.xml

Generated with Planemo.