### PR TITLE
Add container mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:9646dd2b170df8a59304bacc3bacbfd7758d71dc.

### DIFF
--- a/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:9646dd2b170df8a59304bacc3bacbfd7758d71dc-0.tsv
+++ b/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:9646dd2b170df8a59304bacc3bacbfd7758d71dc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+abyss=2.3.6,bwa=0.7.17	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:9646dd2b170df8a59304bacc3bacbfd7758d71dc

**Packages**:
- abyss=2.3.6
- bwa=0.7.17
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- abyss-pe.xml

Generated with Planemo.