### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1e93565f2a1e0c5b15dc527e62dce057b09c250b.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1e93565f2a1e0c5b15dc527e62dce057b09c250b-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1e93565f2a1e0c5b15dc527e62dce057b09c250b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hifiasm=0.19.5,yak=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1e93565f2a1e0c5b15dc527e62dce057b09c250b

**Packages**:
- hifiasm=0.19.5
- yak=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.