### PR TITLE
Add container mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:60f9afb38f763d3b23f9e22f3ebf8a38d6de3c05.

### DIFF
--- a/combinations/mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:60f9afb38f763d3b23f9e22f3ebf8a38d6de3c05-0.tsv
+++ b/combinations/mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:60f9afb38f763d3b23f9e22f3ebf8a38d6de3c05-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-learn=1.0.2,cnvkit=0.9.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:60f9afb38f763d3b23f9e22f3ebf8a38d6de3c05

**Packages**:
- scikit-learn=1.0.2
- cnvkit=0.9.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- reference.xml
- access.xml
- autobin.xml
- heatmap.xml
- target.xml
- diagram.xml
- segment.xml
- scatter.xml
- batch.xml
- call.xml
- antitarget.xml
- fix.xml

Generated with Planemo.