### PR TITLE
Add container mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:73585c71af93a1f54d7c49f0c36f37d638946b1e.

### DIFF
--- a/combinations/mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:73585c71af93a1f54d7c49f0c36f37d638946b1e-0.tsv
+++ b/combinations/mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:73585c71af93a1f54d7c49f0c36f37d638946b1e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kallisto=0.48.0,samtools=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:73585c71af93a1f54d7c49f0c36f37d638946b1e

**Packages**:
- kallisto=0.48.0
- samtools=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kallisto_pseudo.xml
- kallisto_quant.xml

Generated with Planemo.