### PR TITLE
Add container mulled-v2-fdd016122f200fdc6dc30f6ea2fd0000e8067dff:f9531f6ac1f44332eff70b5912d7d5f3ebe8df38.

### DIFF
--- a/combinations/mulled-v2-fdd016122f200fdc6dc30f6ea2fd0000e8067dff:f9531f6ac1f44332eff70b5912d7d5f3ebe8df38-0.tsv
+++ b/combinations/mulled-v2-fdd016122f200fdc6dc30f6ea2fd0000e8067dff:f9531f6ac1f44332eff70b5912d7d5f3ebe8df38-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-sleuth=0.30.1,r-tidyverse=2.0.0,r-argparse=2.2.1,r-annotables=0.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fdd016122f200fdc6dc30f6ea2fd0000e8067dff:f9531f6ac1f44332eff70b5912d7d5f3ebe8df38

**Packages**:
- r-sleuth=0.30.1
- r-tidyverse=2.0.0
- r-argparse=2.2.1
- r-annotables=0.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sleuth.xml

Generated with Planemo.