### PR TITLE
Add gmp for pandoc

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -405,6 +405,6 @@ bismark=0.24.0,seqkit=2.4.0,pigz=2.6,csvtk=0.25.0
 bbmap=39.01,samtools=1.17,seqkit=2.4.0,pigz=2.6,csvtk=0.25.0
 r-argparse=2.1.3,r-data.table=1.14.2,r-circlize=0.4.15,r-randomcolor=1.1.0.1,bioconductor-complexheatmap=2.10.0 
 bwa-mem2=2.2.1,samtools=1.16.1,staden_io_lib=1.14.14
-r-nacho=2.0.4,r-tidyverse=2.0.0,r-ggplot2=3.4.2,r-rlang=1.1.1,r-tidylog=1.0.2,r-fs=1.6.2,bioconductor-complexheatmap=2.14.0,r-circlize=0.4.15,r-yaml=2.3.7,r-ragg=1.2.5,r-rcolorbrewer=1.1_3,r-pheatmap=1.0.12,pandoc=2.19.2
+r-nacho=2.0.4,r-tidyverse=2.0.0,r-ggplot2=3.4.2,r-rlang=1.1.1,r-tidylog=1.0.2,r-fs=1.6.2,bioconductor-complexheatmap=2.14.0,r-circlize=0.4.15,r-yaml=2.3.7,r-ragg=1.2.5,r-rcolorbrewer=1.1_3,r-pheatmap=1.0.12,pandoc=2.19.2,gmp=6.2.1
 bismark=0.24.1,seqkit=2.4.0,pigz=2.6,csvtk=0.25.0
 numpy=1.23.5,bacphlip=0.9.6,hmmer=3.3.2


### PR DESCRIPTION
Sorry, that we have to change this one again. Apparently, we also need to explicitly add `gmp` for `pandoc`. 