### PR TITLE
Add container mulled-v2-b56b6835a1b13ea0d1cd65f4b1c662d2a588aad8:55df21b47055c450ed7d5f677c7feeda33c825cc.

### DIFF
--- a/combinations/mulled-v2-b56b6835a1b13ea0d1cd65f4b1c662d2a588aad8:55df21b47055c450ed7d5f677c7feeda33c825cc-0.tsv
+++ b/combinations/mulled-v2-b56b6835a1b13ea0d1cd65f4b1c662d2a588aad8:55df21b47055c450ed7d5f677c7feeda33c825cc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.0,meningotype=0.8.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b56b6835a1b13ea0d1cd65f4b1c662d2a588aad8:55df21b47055c450ed7d5f677c7feeda33c825cc

**Packages**:
- coreutils=9.0
- meningotype=0.8.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- meningotype.xml

Generated with Planemo.