### PR TITLE
Add container mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:62f986384c7d44b66318d1ad77a926b50f711949.

### DIFF
--- a/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:62f986384c7d44b66318d1ad77a926b50f711949-0.tsv
+++ b/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:62f986384c7d44b66318d1ad77a926b50f711949-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ucsc-blat=377,proteinortho=6.2.3,last=1422,blast=2.13.0,diamond=2.1.4	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:62f986384c7d44b66318d1ad77a926b50f711949

**Packages**:
- ucsc-blat=377
- proteinortho=6.2.3
- last=1422
- blast=2.13.0
- diamond=2.1.4
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho_summary.xml
- proteinortho_grab_proteins.xml
- proteinortho.xml

Generated with Planemo.