### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:c27ab2d9cb85c764c3869210c2696a7235d9dce8.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:c27ab2d9cb85c764c3869210c2696a7235d9dce8-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:c27ab2d9cb85c764c3869210c2696a7235d9dce8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sra-tools=3.0.5,pigz=2.6,samtools=1.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:c27ab2d9cb85c764c3869210c2696a7235d9dce8

**Packages**:
- sra-tools=3.0.5
- pigz=2.6
- samtools=1.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fastq_dump.xml
- sam_dump.xml
- fasterq_dump.xml

Generated with Planemo.