### PR TITLE
Add container mulled-v2-1db50f99443206288f90b902e1044e9932611944:15d91f5dbe07eb894f2e2f01d20c25d30301434b.

### DIFF
--- a/combinations/mulled-v2-1db50f99443206288f90b902e1044e9932611944:15d91f5dbe07eb894f2e2f01d20c25d30301434b-0.tsv
+++ b/combinations/mulled-v2-1db50f99443206288f90b902e1044e9932611944:15d91f5dbe07eb894f2e2f01d20c25d30301434b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=1.5.2,seqtk=1.3,vpolo=0.2.0,salmon=1.10.1,scipy=1.9.3,samtools=1.16.1,graphviz=3.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1db50f99443206288f90b902e1044e9932611944:15d91f5dbe07eb894f2e2f01d20c25d30301434b

**Packages**:
- pandas=1.5.2
- seqtk=1.3
- vpolo=0.2.0
- salmon=1.10.1
- scipy=1.9.3
- samtools=1.16.1
- graphviz=3.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- salmonquant.xml
- alevin.xml
- salmonquantmerge.xml

Generated with Planemo.