### PR TITLE
Add container mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:9d9a4d9aab75e7569ccec35bdeab1d59e8a3e151.

### DIFF
--- a/combinations/mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:9d9a4d9aab75e7569ccec35bdeab1d59e8a3e151-0.tsv
+++ b/combinations/mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:9d9a4d9aab75e7569ccec35bdeab1d59e8a3e151-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.18.1,ray-core=1.6.0,superdsm=0.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:9d9a4d9aab75e7569ccec35bdeab1d59e8a3e151

**Packages**:
- scikit-image=0.18.1
- ray-core=1.6.0
- superdsm=0.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- superdsm.xml

Generated with Planemo.