### PR TITLE
Add container mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:8c7fd85a44af13beb828cf2b798b6815a86754a6.

### DIFF
--- a/combinations/mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:8c7fd85a44af13beb828cf2b798b6815a86754a6-0.tsv
+++ b/combinations/mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:8c7fd85a44af13beb828cf2b798b6815a86754a6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.6.3,bzip2=1.0.8,samtools=1.14,lastz=1.04.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5877ce745b961ed83ba6de863f852b9cce609b7f:8c7fd85a44af13beb828cf2b798b6815a86754a6

**Packages**:
- r-base=3.6.3
- bzip2=1.0.8
- samtools=1.14
- lastz=1.04.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lastz.xml

Generated with Planemo.