### PR TITLE
Add container mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:8b608626cc6d310d13cc0e041a3301f294a72cac.

### DIFF
--- a/combinations/mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:8b608626cc6d310d13cc0e041a3301f294a72cac-0.tsv
+++ b/combinations/mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:8b608626cc6d310d13cc0e041a3301f294a72cac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+superdsm=0.1.3,scikit-image=0.18.1,ray-core=1.6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2fb6df5a6c7c52bcbd88a7af7a53b8f1ce830ed9:8b608626cc6d310d13cc0e041a3301f294a72cac

**Packages**:
- superdsm=0.1.3
- scikit-image=0.18.1
- ray-core=1.6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- superdsm.xml

Generated with Planemo.