### PR TITLE
Add container mulled-v2-8e5b1b2eba0e91a13c5b4f79a3efba43b8656ca7:ee0f7a93ecbdff50167e6b585601cf193a69f2ba.

### DIFF
--- a/combinations/mulled-v2-8e5b1b2eba0e91a13c5b4f79a3efba43b8656ca7:ee0f7a93ecbdff50167e6b585601cf193a69f2ba-0.tsv
+++ b/combinations/mulled-v2-8e5b1b2eba0e91a13c5b4f79a3efba43b8656ca7:ee0f7a93ecbdff50167e6b585601cf193a69f2ba-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-seurat=4.3.0.1,r-data.table=1.14.2,r-rmarkdown=2.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e5b1b2eba0e91a13c5b4f79a3efba43b8656ca7:ee0f7a93ecbdff50167e6b585601cf193a69f2ba

**Packages**:
- r-seurat=4.3.0.1
- r-data.table=1.14.2
- r-rmarkdown=2.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seurat.xml

Generated with Planemo.