### PR TITLE
Add container mulled-v2-f80f46eae48aba130c4d0aa2a5872632cc1020e8:02aed0b22773bc025f9550d9083dcfa7ad9852a2.

### DIFF
--- a/combinations/mulled-v2-f80f46eae48aba130c4d0aa2a5872632cc1020e8:02aed0b22773bc025f9550d9083dcfa7ad9852a2-0.tsv
+++ b/combinations/mulled-v2-f80f46eae48aba130c4d0aa2a5872632cc1020e8:02aed0b22773bc025f9550d9083dcfa7ad9852a2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sambamba=1.0=h98b6b92_0,samtools=1.17=hd87286a_1,pysam=0.21.0=py310h41dec4a_1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f80f46eae48aba130c4d0aa2a5872632cc1020e8:02aed0b22773bc025f9550d9083dcfa7ad9852a2

**Packages**:
- sambamba=1.0=h98b6b92_0
- samtools=1.17=hd87286a_1
- pysam=0.21.0=py310h41dec4a_1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bamparse.xml

Generated with Planemo.