### PR TITLE
Add container mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:6936a6cc1b5c3c676ffda21ec5891b07f4b629d4.

### DIFF
--- a/combinations/mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:6936a6cc1b5c3c676ffda21ec5891b07f4b629d4-0.tsv
+++ b/combinations/mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:6936a6cc1b5c3c676ffda21ec5891b07f4b629d4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-deseq2=1.40.2,bioconductor-rhdf5=2.44.0,r-pheatmap=1.0.12,r-gplots=3.1.3,r-ggrepel=0.9.3,bioconductor-genomicfeatures=1.52.1,r-getopt=1.20.3,r-rjson=0.2.21,bioconductor-tximport=1.28.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-05fd88b9ac812a9149da2f2d881d62f01cc49835:6936a6cc1b5c3c676ffda21ec5891b07f4b629d4

**Packages**:
- bioconductor-deseq2=1.40.2
- bioconductor-rhdf5=2.44.0
- r-pheatmap=1.0.12
- r-gplots=3.1.3
- r-ggrepel=0.9.3
- bioconductor-genomicfeatures=1.52.1
- r-getopt=1.20.3
- r-rjson=0.2.21
- bioconductor-tximport=1.28.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deseq2.xml

Generated with Planemo.