### PR TITLE
Add container mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:c168327051891d62ea3d00531005121b89fddf0f.

### DIFF
--- a/combinations/mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:c168327051891d62ea3d00531005121b89fddf0f-0.tsv
+++ b/combinations/mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:c168327051891d62ea3d00531005121b89fddf0f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pymuonsuite=0.3.0,zip=3.0,euphonic=1.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a9199b8872af4a9ac13b9c55fb21874fc1324189:c168327051891d62ea3d00531005121b89fddf0f

**Packages**:
- pymuonsuite=0.3.0
- zip=3.0
- euphonic=1.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pm_nq.xml

Generated with Planemo.