### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:3328ff6c7b96b5ad8fb09f266ca9dd5daab866b0.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:3328ff6c7b96b5ad8fb09f266ca9dd5daab866b0-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:3328ff6c7b96b5ad8fb09f266ca9dd5daab866b0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mosdepth=0.3.4,gzip=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:3328ff6c7b96b5ad8fb09f266ca9dd5daab866b0

**Packages**:
- mosdepth=0.3.4
- gzip=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.