### PR TITLE
Add container mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:7b207509e653a9298fb39401ab9e6c5f6f447534.

### DIFF
--- a/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:7b207509e653a9298fb39401ab9e6c5f6f447534-0.tsv
+++ b/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:7b207509e653a9298fb39401ab9e6c5f6f447534-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gmp=6.2.1,pandoc=3.1.3,cojac=0.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:7b207509e653a9298fb39401ab9e6c5f6f447534

**Packages**:
- gmp=6.2.1
- pandoc=3.1.3
- cojac=0.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_pubmut.xml

Generated with Planemo.