### PR TITLE
Add container mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:4701c6e1620807fe8733cb4e937b92e03a65d676.

### DIFF
--- a/combinations/mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:4701c6e1620807fe8733cb4e937b92e03a65d676-0.tsv
+++ b/combinations/mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:4701c6e1620807fe8733cb4e937b92e03a65d676-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+viramp-hub=0.1.0,cojac=0.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:4701c6e1620807fe8733cb4e937b92e03a65d676

**Packages**:
- viramp-hub=0.1.0
- cojac=0.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_mutbamscan.xml

Generated with Planemo.