### PR TITLE
Add container mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:f58d91a3028db2aa341f22010ef285923d40eefe.

### DIFF
--- a/combinations/mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:f58d91a3028db2aa341f22010ef285923d40eefe-0.tsv
+++ b/combinations/mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:f58d91a3028db2aa341f22010ef285923d40eefe-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.3.1,python=3.11,bioconductor-lineagespot=1.4.0,r-getopt=1.20.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:f58d91a3028db2aa341f22010ef285923d40eefe

**Packages**:
- r-base=4.3.1
- python=3.11
- bioconductor-lineagespot=1.4.0
- r-getopt=1.20.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lineagespot_wrapper.xml

Generated with Planemo.