### PR TITLE
Add container mulled-v2-86a5a6ee20dfb9c3d0e84ae7f79f39e4e6550a39:4e8946fac3bd3954a6ccaf266edfd4cc0a046ec6.

### DIFF
--- a/combinations/mulled-v2-86a5a6ee20dfb9c3d0e84ae7f79f39e4e6550a39:4e8946fac3bd3954a6ccaf266edfd4cc0a046ec6-0.tsv
+++ b/combinations/mulled-v2-86a5a6ee20dfb9c3d0e84ae7f79f39e4e6550a39:4e8946fac3bd3954a6ccaf266edfd4cc0a046ec6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+lightgbm=3.3.5,galaxy-ml=0.10.0,python=3.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-86a5a6ee20dfb9c3d0e84ae7f79f39e4e6550a39:4e8946fac3bd3954a6ccaf266edfd4cc0a046ec6

**Packages**:
- lightgbm=3.3.5
- galaxy-ml=0.10.0
- python=3.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lightgbm.xml

Generated with Planemo.