### PR TITLE
Add container mulled-v2-51b93a907f88b30bc80ed7a707079071037aea00:006d67500af163e99c11dd7d19d63e09f597416b.

### DIFF
--- a/combinations/mulled-v2-51b93a907f88b30bc80ed7a707079071037aea00:006d67500af163e99c11dd7d19d63e09f597416b-0.tsv
+++ b/combinations/mulled-v2-51b93a907f88b30bc80ed7a707079071037aea00:006d67500af163e99c11dd7d19d63e09f597416b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+galaxy-ml=0.10.0,python=3.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-51b93a907f88b30bc80ed7a707079071037aea00:006d67500af163e99c11dd7d19d63e09f597416b

**Packages**:
- galaxy-ml=0.10.0
- python=3.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- model_validation.xml
- search_model_validation.xml
- nn_classifier.xml
- fitted_model_eval.xml
- numeric_clustering.xml
- train_test_split.xml
- train_test_eval.xml
- keras_model_config.xml
- sample_generator.xml
- ml_visualization_ex.xml
- sparse.xml
- discriminant.xml
- pre_process.xml
- generalized_linear.xml
- svm.xml
- keras_batch_models.xml
- keras_train_and_eval.xml
- keras_model_builder.xml
- stacking_ensembles.xml
- model_prediction.xml
- label_encoder.xml
- ensemble.xml
- estimator_attributes.xml
- pca.xml
- regression_metrics.xml
- feature_selection.xml
- pipeline.xml
- association_rules.xml
- clf_metrics.xml
- to_categorical.xml
- pairwise_metrics.xml
- simple_model_fit.xml

Generated with Planemo.