### PR TITLE
Add container for latest vcf2maf & newer ensembl-vep

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -435,3 +435,4 @@ macs2=2.2.7.1,ucsc-bedgraphtobigwig=377
 r-tidyverse=2.0.0,r-data.table=1.14.8,r-stringdist=0.9.10,r-pryr=0.1.6,bioconductor-shortread=1.58.0,bioconductor-biostrings=2.68.1,r-optparse=1.7.3,r-getopt=1.20.3 
 numpy=1.25.2,pandas=2.0.3,bx-python=0.10.0,gzip=1.12
 macs2=2.2.7.1,ucsc-bedgraphtobigwig=445,bedtools=2.30.0
+vcf2maf-umccr=1.6.21.20230511,ensembl-vep=108.2


### PR DESCRIPTION
Hi there,
Could you please add the latest `vcf2maf` (from `umccr`) and a newer version of `ensembl-vep` into a new mulled container? 