### PR TITLE
Add container mulled-v2-94ba6e43747abfe912028168132d77a1722d16d1:a85ef95c399cb66b66b3a88b10d26ca74db245ee.

### DIFF
--- a/combinations/mulled-v2-94ba6e43747abfe912028168132d77a1722d16d1:a85ef95c399cb66b66b3a88b10d26ca74db245ee-0.tsv
+++ b/combinations/mulled-v2-94ba6e43747abfe912028168132d77a1722d16d1:a85ef95c399cb66b66b3a88b10d26ca74db245ee-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-org.at.tair.db=3.17.0,bioconductor-org.gg.eg.db=3.17.0,bioconductor-org.mm.eg.db=3.17.0,bioconductor-org.rn.eg.db=3.17.0,bioconductor-org.hs.eg.db=3.17.0,bioconductor-org.dr.eg.db=3.17.0,bioconductor-org.bt.eg.db=3.17.0,bioconductor-org.dm.eg.db=3.17.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-94ba6e43747abfe912028168132d77a1722d16d1:a85ef95c399cb66b66b3a88b10d26ca74db245ee

**Packages**:
- bioconductor-org.at.tair.db=3.17.0
- bioconductor-org.gg.eg.db=3.17.0
- bioconductor-org.mm.eg.db=3.17.0
- bioconductor-org.rn.eg.db=3.17.0
- bioconductor-org.hs.eg.db=3.17.0
- bioconductor-org.dr.eg.db=3.17.0
- bioconductor-org.bt.eg.db=3.17.0
- bioconductor-org.dm.eg.db=3.17.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- annotateMyIDs.xml

Generated with Planemo.