### PR TITLE
Add container mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:f6274226323f3401fb1dc15e6dd0cc17f7697bc0.

### DIFF
--- a/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:f6274226323f3401fb1dc15e6dd0cc17f7697bc0-0.tsv
+++ b/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:f6274226323f3401fb1dc15e6dd0cc17f7697bc0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,deeptools=3.5.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:f6274226323f3401fb1dc15e6dd0cc17f7697bc0

**Packages**:
- samtools=1.9
- deeptools=3.5.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- alignmentSieve.xml
- correctGCBias.xml
- bamCompare.xml
- computeMatrixOperations.xml
- plotHeatmap.xml
- plotProfiler.xml
- computeMatrix.xml
- plotCoverage.xml
- plotCorrelation.xml
- multiBamSummary.xml
- bamCoverage.xml
- plotPCA.xml
- computeGCBias.xml
- plotFingerprint.xml
- plotEnrichment.xml
- bigwigAverage.xml
- bamPEFragmentSize.xml
- estimateReadFiltering.xml
- multiBigwigSummary.xml
- bigwigCompare.xml

Generated with Planemo.