### PR TITLE
Add container mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee2a45131f83aa237e4dd4025fec23aa7e4405f.

### DIFF
--- a/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee2a45131f83aa237e4dd4025fec23aa7e4405f-0.tsv
+++ b/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee2a45131f83aa237e4dd4025fec23aa7e4405f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mlst=2.23.0,staramr=0.10.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee2a45131f83aa237e4dd4025fec23aa7e4405f

**Packages**:
- mlst=2.23.0
- staramr=0.10.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- staramr_search.xml

Generated with Planemo.