### PR TITLE
Add container mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:15c014e4845b5e357737771e99abbcf4754104f2.

### DIFF
--- a/combinations/mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:15c014e4845b5e357737771e99abbcf4754104f2-0.tsv
+++ b/combinations/mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:15c014e4845b5e357737771e99abbcf4754104f2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+h5py=3.7.0,htslib=1.16,cooler=0.9.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a2b8d8769c28f51df70833ffd9166d06e76cf89f:15c014e4845b5e357737771e99abbcf4754104f2

**Packages**:
- h5py=3.7.0
- htslib=1.16
- cooler=0.9.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooler_cload_tabix.xml
- cooler_makebins.xml
- cooler_balance.xml
- cooler_csort_tabix.xml

Generated with Planemo.