### PR TITLE
Add container mulled-v2-f01e242bdea19948f0576fdca94777242fe4c2cb:0fa3d8c397aa55d1a9bac7f4ff40847e02ea5124.

### DIFF
--- a/combinations/mulled-v2-f01e242bdea19948f0576fdca94777242fe4c2cb:0fa3d8c397aa55d1a9bac7f4ff40847e02ea5124-0.tsv
+++ b/combinations/mulled-v2-f01e242bdea19948f0576fdca94777242fe4c2cb:0fa3d8c397aa55d1a9bac7f4ff40847e02ea5124-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bedtools=2.31.0,ucsc-bedgraphtobigwig=445,samtools=1.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f01e242bdea19948f0576fdca94777242fe4c2cb:0fa3d8c397aa55d1a9bac7f4ff40847e02ea5124

**Packages**:
- bedtools=2.31.0
- ucsc-bedgraphtobigwig=445
- samtools=1.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sam_to_bigwig_converter.xml

Generated with Planemo.