### PR TITLE
Add container mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:a46d7a3649d277242e81b5645cc946b0c25b90fd.

### DIFF
--- a/combinations/mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:a46d7a3649d277242e81b5645cc946b0c25b90fd-0.tsv
+++ b/combinations/mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:a46d7a3649d277242e81b5645cc946b0c25b90fd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mapseq=2.1.1,perl=5.26	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:a46d7a3649d277242e81b5645cc946b0c25b90fd

**Packages**:
- mapseq=2.1.1
- perl=5.26
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mapseq.xml

Generated with Planemo.