### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:6370b8cc1ee95918aa91898be337299a3e8e2bcc.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:6370b8cc1ee95918aa91898be337299a3e8e2bcc-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:6370b8cc1ee95918aa91898be337299a3e8e2bcc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=15.19.1,p7zip=16.02,ca-certificates=2023.7.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:6370b8cc1ee95918aa91898be337299a3e8e2bcc

**Packages**:
- ncbi-datasets-cli=15.19.1
- p7zip=16.02
- ca-certificates=2023.7.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.