### PR TITLE
Add container mulled-v2-42d83023fd1a6129f494827a5a7bce49e8c39f84:a70e5307a121e84189bd3446b5ffd6087e0a9fb6.

### DIFF
--- a/combinations/mulled-v2-42d83023fd1a6129f494827a5a7bce49e8c39f84:a70e5307a121e84189bd3446b5ffd6087e0a9fb6-0.tsv
+++ b/combinations/mulled-v2-42d83023fd1a6129f494827a5a7bce49e8c39f84:a70e5307a121e84189bd3446b5ffd6087e0a9fb6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyarrow=0.15.1,pandas=1.3.5,python=3.7,pytables=3.6.1,click=7.0,pandasql=0.7.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-42d83023fd1a6129f494827a5a7bce49e8c39f84:a70e5307a121e84189bd3446b5ffd6087e0a9fb6

**Packages**:
- pyarrow=0.15.1
- pandas=1.3.5
- python=3.7
- pytables=3.6.1
- click=7.0
- pandasql=0.7.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- query.xml

Generated with Planemo.