### PR TITLE
Add container mulled-v2-c206a6f0d321a1f067051dbbfa14c9382274e6e1:ed91202b3c4d83d4360c42f67c2697bf0fd3f1cf.

### DIFF
--- a/combinations/mulled-v2-c206a6f0d321a1f067051dbbfa14c9382274e6e1:ed91202b3c4d83d4360c42f67c2697bf0fd3f1cf-0.tsv
+++ b/combinations/mulled-v2-c206a6f0d321a1f067051dbbfa14c9382274e6e1:ed91202b3c4d83d4360c42f67c2697bf0fd3f1cf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.12,beacon2-ri-tools=2.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c206a6f0d321a1f067051dbbfa14c9382274e6e1:ed91202b3c4d83d4360c42f67c2697bf0fd3f1cf

**Packages**:
- gzip=1.12
- beacon2-ri-tools=2.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pxf2bff.xml
- vcf2bff.xml
- csv2xlsx.xml

Generated with Planemo.