### PR TITLE
Add container mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:e9addfbd0b7a35a344829d5c403d29661c243944.

### DIFF
--- a/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:e9addfbd0b7a35a344829d5c403d29661c243944-0.tsv
+++ b/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:e9addfbd0b7a35a344829d5c403d29661c243944-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandoc=3.1.3,gmp=6.2.1,cojac=0.9.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:e9addfbd0b7a35a344829d5c403d29661c243944

**Packages**:
- pandoc=3.1.3
- gmp=6.2.1
- cojac=0.9.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_pubmut.xml

Generated with Planemo.