### PR TITLE
Add container mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:706e4ab8e30732c9392db1e7c9007263dd91ed4d.

### DIFF
--- a/combinations/mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:706e4ab8e30732c9392db1e7c9007263dd91ed4d-0.tsv
+++ b/combinations/mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:706e4ab8e30732c9392db1e7c9007263dd91ed4d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+baredsc=1.1.1,gzip=1.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:706e4ab8e30732c9392db1e7c9007263dd91ed4d

**Packages**:
- baredsc=1.1.1
- gzip=1.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- baredsc_2d.xml
- baredsc_combine_1d.xml
- baredsc_1d.xml
- baredsc_combine_2d.xml

Generated with Planemo.