### PR TITLE
Add container mulled-v2-783b179b80678d5cf14bb18d7e9bc26f3317e5d7:454a8405901eb8a33ac815aded7ece39949d5007.

### DIFF
--- a/combinations/mulled-v2-783b179b80678d5cf14bb18d7e9bc26f3317e5d7:454a8405901eb8a33ac815aded7ece39949d5007-0.tsv
+++ b/combinations/mulled-v2-783b179b80678d5cf14bb18d7e9bc26f3317e5d7:454a8405901eb8a33ac815aded7ece39949d5007-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl=5.32.1,ucsc-bigwigsummary=377,ucsc-bigwiginfo=377,bc=1.07.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-783b179b80678d5cf14bb18d7e9bc26f3317e5d7:454a8405901eb8a33ac815aded7ece39949d5007

**Packages**:
- perl=5.32.1
- ucsc-bigwigsummary=377
- ucsc-bigwiginfo=377
- bc=1.07.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bigwig_to_wig.xml

Generated with Planemo.