### PR TITLE
Add container mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:e2f687caccbe94813e6a45b9d61ac7c954e78fb8.

### DIFF
--- a/combinations/mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:e2f687caccbe94813e6a45b9d61ac7c954e78fb8-0.tsv
+++ b/combinations/mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:e2f687caccbe94813e6a45b9d61ac7c954e78fb8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl=5.26,coreutils=8.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:e2f687caccbe94813e6a45b9d61ac7c954e78fb8

**Packages**:
- perl=5.26
- coreutils=8.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pasteWrapper.xml

Generated with Planemo.