### PR TITLE
Add container mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:400788509c617f5ce73fcd8c4d4b2b0587ae76d7.

### DIFF
--- a/combinations/mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:400788509c617f5ce73fcd8c4d4b2b0587ae76d7-0.tsv
+++ b/combinations/mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:400788509c617f5ce73fcd8c4d4b2b0587ae76d7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.10=h2e538c0_3,sambamba=0.8.1=hadffe2f_1,freebayes=1.3.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cd82d87fc4e5e988bb39fc5feed273ac9449cffd:400788509c617f5ce73fcd8c4d4b2b0587ae76d7

**Packages**:
- samtools=1.10=h2e538c0_3
- sambamba=0.8.1=hadffe2f_1
- freebayes=1.3.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- artbio_bam_cleaning.xml

Generated with Planemo.