### PR TITLE
Add container mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:d0a1fea2187fff2823e6e1602300b10ab9f3643d.

### DIFF
--- a/combinations/mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:d0a1fea2187fff2823e6e1602300b10ab9f3643d-0.tsv
+++ b/combinations/mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:d0a1fea2187fff2823e6e1602300b10ab9f3643d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.12,baredsc=1.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:d0a1fea2187fff2823e6e1602300b10ab9f3643d

**Packages**:
- gzip=1.12
- baredsc=1.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- baredsc_2d.xml
- baredsc_combine_1d.xml
- baredsc_1d.xml
- baredsc_combine_2d.xml

Generated with Planemo.