### PR TITLE
Add container mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:edd0ca8b9789e275d88ae57fa62a761bbd7102a5.

### DIFF
--- a/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:edd0ca8b9789e275d88ae57fa62a761bbd7102a5-0.tsv
+++ b/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:edd0ca8b9789e275d88ae57fa62a761bbd7102a5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hicexplorer=3.7.2,samtools=1.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:edd0ca8b9789e275d88ae57fa62a761bbd7102a5

**Packages**:
- hicexplorer=3.7.2
- samtools=1.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hicBuildMatrix.xml

Generated with Planemo.