### PR TITLE
Add container mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:509f4d2a86060dc0cf0ea3bd01d92c7131ac9a3a.

### DIFF
--- a/combinations/mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:509f4d2a86060dc0cf0ea3bd01d92c7131ac9a3a-0.tsv
+++ b/combinations/mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:509f4d2a86060dc0cf0ea3bd01d92c7131ac9a3a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sortmerna=4.3.6,samtools=1.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:509f4d2a86060dc0cf0ea3bd01d92c7131ac9a3a

**Packages**:
- sortmerna=4.3.6
- samtools=1.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sortmerna.xml

Generated with Planemo.