### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7b9806e727430fce4921956fa5019934d44bc82a.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7b9806e727430fce4921956fa5019934d44bc82a-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7b9806e727430fce4921956fa5019934d44bc82a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pigz=2.8,sra-tools=3.0.8,samtools=1.18	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7b9806e727430fce4921956fa5019934d44bc82a

**Packages**:
- pigz=2.8
- sra-tools=3.0.8
- samtools=1.18
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sam_dump.xml
- fastq_dump.xml
- fasterq_dump.xml

Generated with Planemo.