### PR TITLE
Add container mulled-v2-3af3a634048789902c3a7b75a55fbdddb4ed6418:9e44edc26687ce8e9bd3337bfcc901f084679dc8.

### DIFF
--- a/combinations/mulled-v2-3af3a634048789902c3a7b75a55fbdddb4ed6418:9e44edc26687ce8e9bd3337bfcc901f084679dc8-0.tsv
+++ b/combinations/mulled-v2-3af3a634048789902c3a7b75a55fbdddb4ed6418:9e44edc26687ce8e9bd3337bfcc901f084679dc8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+superdsm=0.1.3,scikit-image=0.18.1,mkl=2020.0,ray-core=1.6.0,blas=*=mkl	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3af3a634048789902c3a7b75a55fbdddb4ed6418:9e44edc26687ce8e9bd3337bfcc901f084679dc8

**Packages**:
- superdsm=0.1.3
- scikit-image=0.18.1
- mkl=2020.0
- ray-core=1.6.0
- blas=*=mkl
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- superdsm.xml

Generated with Planemo.