### PR TITLE
Add container mulled-v2-0da20d4734408989ea2a7cb514b3c0cc40b96198:cec6dc7924833053b0fc3b623f1f1f86cbc49b97.

### DIFF
--- a/combinations/mulled-v2-0da20d4734408989ea2a7cb514b3c0cc40b96198:cec6dc7924833053b0fc3b623f1f1f86cbc49b97-0.tsv
+++ b/combinations/mulled-v2-0da20d4734408989ea2a7cb514b3c0cc40b96198:cec6dc7924833053b0fc3b623f1f1f86cbc49b97-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scanpy=1.9.6,loompy=3.0.6,pandas=1.5.3,seaborn=0.12.2,leidenalg=0.10.1,matplotlib=3.7,louvain=0.8.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0da20d4734408989ea2a7cb514b3c0cc40b96198:cec6dc7924833053b0fc3b623f1f1f86cbc49b97

**Packages**:
- scanpy=1.9.6
- loompy=3.0.6
- pandas=1.5.3
- seaborn=0.12.2
- leidenalg=0.10.1
- matplotlib=3.7
- louvain=0.8.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- filter.xml
- normalize.xml
- inspect.xml
- plot.xml
- remove_confounders.xml
- cluster_reduce_dimension.xml

Generated with Planemo.