### PR TITLE
Add container mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:42a1f30a5d1748d6128e7fcc1e9591d499accd24.

### DIFF
--- a/combinations/mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:42a1f30a5d1748d6128e7fcc1e9591d499accd24-0.tsv
+++ b/combinations/mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:42a1f30a5d1748d6128e7fcc1e9591d499accd24-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+loompy=3.0.6,scanpy=1.9.6,anndata=0.10.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:42a1f30a5d1748d6128e7fcc1e9591d499accd24

**Packages**:
- loompy=3.0.6
- scanpy=1.9.6
- anndata=0.10.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- import.xml

Generated with Planemo.