### PR TITLE
Add container mulled-v2-c89532d7d58608b69c1a896707ec4cf926b98182:f42f8452ef30fd9df25b4e403c103977bc4c90df.

### DIFF
--- a/combinations/mulled-v2-c89532d7d58608b69c1a896707ec4cf926b98182:f42f8452ef30fd9df25b4e403c103977bc4c90df-0.tsv
+++ b/combinations/mulled-v2-c89532d7d58608b69c1a896707ec4cf926b98182:f42f8452ef30fd9df25b4e403c103977bc4c90df-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-reticulate=1.32.0,loompy=3.0.6,python=3.10,anndata=0.10.0,r-sceasy=0.0.7,r-anndata=0.7.5.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c89532d7d58608b69c1a896707ec4cf926b98182:f42f8452ef30fd9df25b4e403c103977bc4c90df

**Packages**:
- r-reticulate=1.32.0
- loompy=3.0.6
- python=3.10
- anndata=0.10.0
- r-sceasy=0.0.7
- r-anndata=0.7.5.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sceasy.xml

Generated with Planemo.