### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9b6b1396ad2539a1d8b1b518e9839c466d95cbc4.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9b6b1396ad2539a1d8b1b518e9839c466d95cbc4-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9b6b1396ad2539a1d8b1b518e9839c466d95cbc4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tar=1.34,busco=5.5.0,fonts-conda-ecosystem=1	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9b6b1396ad2539a1d8b1b518e9839c466d95cbc4

**Packages**:
- tar=1.34
- busco=5.5.0
- fonts-conda-ecosystem=1
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.