### PR TITLE
Add container mulled-v2-822d44a56b6e7f6101f5244fa6ceb845eead3d90:12d3e9c067e4c215530e322078324d1a535ff336.

### DIFF
--- a/combinations/mulled-v2-822d44a56b6e7f6101f5244fa6ceb845eead3d90:12d3e9c067e4c215530e322078324d1a535ff336-0.tsv
+++ b/combinations/mulled-v2-822d44a56b6e7f6101f5244fa6ceb845eead3d90:12d3e9c067e4c215530e322078324d1a535ff336-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+zip=3.0,matplotlib=3.5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-822d44a56b6e7f6101f5244fa6ceb845eead3d90:12d3e9c067e4c215530e322078324d1a535ff336

**Packages**:
- zip=3.0
- matplotlib=3.5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- larch_criteria_report.xml

Generated with Planemo.