### PR TITLE
Add container mulled-v2-6d7e1b75d35ba8e36f4b5fee13956ece72efa7c6:e205c4c1fd7249d901d8a0a4c768077167a623fc.

### DIFF
--- a/combinations/mulled-v2-6d7e1b75d35ba8e36f4b5fee13956ece72efa7c6:e205c4c1fd7249d901d8a0a4c768077167a623fc-0.tsv
+++ b/combinations/mulled-v2-6d7e1b75d35ba8e36f4b5fee13956ece72efa7c6:e205c4c1fd7249d901d8a0a4c768077167a623fc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-mvtnorm=1.1-3,r-xlconnect=1.0.7,r-gdata=2.18.0.1,r-rms=6.5-0,r-base=4.2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6d7e1b75d35ba8e36f4b5fee13956ece72efa7c6:e205c4c1fd7249d901d8a0a4c768077167a623fc

**Packages**:
- r-mvtnorm=1.1-3
- r-xlconnect=1.0.7
- r-gdata=2.18.0.1
- r-rms=6.5-0
- r-base=4.2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- Moyenne_geom.xml

Generated with Planemo.