### PR TITLE
MSA+pigz Containers

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -507,3 +507,6 @@ bwa-mem2=2.2.1,samtools=1.18
 manta=1.6.0,samtools=1.18
 minimap2=2.24,samtools=1.18
 gatk4=4.4.0.0,samtools=1.18
+clustalo=1.2.4,pigz=2.8
+muscle=5.1,pigz=2.8
+mafft=7.520,pigz=2.8


### PR DESCRIPTION
Adds mulled containers for clustalo, mafft and muscle containing pigz.
For use in updating the corresponding NFCore modules to produce compressed output.