### PR TITLE
Missing tidyr

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -517,7 +517,7 @@ gatk4=4.4.0.0,samtools=1.18,coreutils=9.3
 r-base,r-dplyr,r-optparse,r-devtools,r-topicmodels,r-philentropy,r-metrics,r-jsonlite
 presto=0.7.1,igblast=1.21.0,wget=1.20.1,biopython=1.79	quay.io/bioconda/base-glibc-busybox-bash:2.1.0	0
 bioconductor-limma=3.58.1,bioconductor-edger=4.0.2,r-data.table=1.14.10,r-gplots=3.1.3,r-statmod=1.5.0
-r-nacho=2.0.6,r-dplyr=1.1.4,r-ggplot2=3.4.4,r-fs=1.6.2,r-readr=2.1.5
+r-nacho=2.0.6,r-dplyr=1.1.4,r-ggplot2=3.4.4,r-fs=1.6.2,r-readr=2.1.5,r-tidyr=1.3.0
 r-yaml=2.3.7,r-ggplot2=3.4.4,r-dplyr=1.1.4,r-stringr=1.5.0,bioconductor-gsva=1.46.0,bioconductor-singscore=1.18.0,r-factominer=2.8.0,r-readr=2.1.5,r-tibble=3.2.1
 r-tidyr=1.3.0,r-ggplot2=3.4.4,r-dplyr=1.1.4,r-readr=2.1.5,r-stringr=1.5.0
 r-yaml=2.3.7,r-ggplot2=3.4.4,r-dplyr=1.1.4,r-fs=1.6.2,bioconductor-complexheatmap=2.18.0,r-circlize=0.4.15,r-ragg=1.2.7,r-readr=2.1.5


### PR DESCRIPTION
The previous attempt was missing r-tidyr in the function call.