### PR TITLE
Add container mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:cc0d0a81b925169f595fa865742dc6e1e836f3cc.

### DIFF
--- a/combinations/mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:cc0d0a81b925169f595fa865742dc6e1e836f3cc-0.tsv
+++ b/combinations/mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:cc0d0a81b925169f595fa865742dc6e1e836f3cc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trimmomatic=0.39,coreutils=9.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:cc0d0a81b925169f595fa865742dc6e1e836f3cc

**Packages**:
- trimmomatic=0.39
- coreutils=9.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- trimmomatic.xml

Generated with Planemo.