### PR TITLE
Add container mulled-v2-b0d0dc277483f9f016058e4d820c781616f03855:e06b734047329fd6a898286b27369a7ee596a670.

### DIFF
--- a/combinations/mulled-v2-b0d0dc277483f9f016058e4d820c781616f03855:e06b734047329fd6a898286b27369a7ee596a670-0.tsv
+++ b/combinations/mulled-v2-b0d0dc277483f9f016058e4d820c781616f03855:e06b734047329fd6a898286b27369a7ee596a670-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=4.2.1,pigz=2.3.4,seqtk=1.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b0d0dc277483f9f016058e4d820c781616f03855:e06b734047329fd6a898286b27369a7ee596a670

**Packages**:
- gawk=4.2.1
- pigz=2.3.4
- seqtk=1.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- seqtk_hety.xml
- seqtk_listhet.xml
- seqtk_fqchk.xml
- seqtk_comp.xml

Generated with Planemo.