### PR TITLE
Add container mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:f40423e676a415eb9be3d76b71b2fd084e3d7bc3.

### DIFF
--- a/combinations/mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:f40423e676a415eb9be3d76b71b2fd084e3d7bc3-0.tsv
+++ b/combinations/mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:f40423e676a415eb9be3d76b71b2fd084e3d7bc3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+omero-py=5.13.1,fiji=20220414,gawk=5.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:f40423e676a415eb9be3d76b71b2fd084e3d7bc3

**Packages**:
- omero-py=5.13.1
- fiji=20220414
- gawk=5.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- incucyte_stack_and_upload_omero.xml

Generated with Planemo.