### PR TITLE
Add container omero-py:5.17.0.

### DIFF
--- a/combinations/omero-py:5.17.0-0.tsv
+++ b/combinations/omero-py:5.17.0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+omero-py=5.17.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: omero-py:5.17.0

**Packages**:
- omero-py=5.17.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- omero_get_children_ids.xml

Generated with Planemo.