### PR TITLE
Add container mulled-v2-5c3f21e6a899369dfc339a978cd605711887ab72:73ad24804b7531f5c21bf609ed200d5d7a53dd2e.

### DIFF
--- a/combinations/mulled-v2-5c3f21e6a899369dfc339a978cd605711887ab72:73ad24804b7531f5c21bf609ed200d5d7a53dd2e-0.tsv
+++ b/combinations/mulled-v2-5c3f21e6a899369dfc339a978cd605711887ab72:73ad24804b7531f5c21bf609ed200d5d7a53dd2e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl-number-format=1.75,samtools=0.1.18,r=3.4.1,tectonic=0.1.6,bedtools=2.17.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5c3f21e6a899369dfc339a978cd605711887ab72:73ad24804b7531f5c21bf609ed200d5d7a53dd2e

**Packages**:
- perl-number-format=1.75
- samtools=0.1.18
- r=3.4.1
- tectonic=0.1.6
- bedtools=2.17.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- CoverageReport.xml

Generated with Planemo.