### PR TITLE
Add container mulled-v2-2e62648fe13bf044d782b951edd75626f40d1597:1392b22c93fc7300dde46a7e5c0718b1e081bc2b.

### DIFF
--- a/combinations/mulled-v2-2e62648fe13bf044d782b951edd75626f40d1597:1392b22c93fc7300dde46a7e5c0718b1e081bc2b-0.tsv
+++ b/combinations/mulled-v2-2e62648fe13bf044d782b951edd75626f40d1597:1392b22c93fc7300dde46a7e5c0718b1e081bc2b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-lme4=1.1_27,bioconductor-multtest=2.40.0,r-lmertest=3.1_3,r-ggplot2=3.2_0,r-gridextra=2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2e62648fe13bf044d782b951edd75626f40d1597:1392b22c93fc7300dde46a7e5c0718b1e081bc2b

**Packages**:
- r-lme4=1.1_27
- bioconductor-multtest=2.40.0
- r-lmertest=3.1_3
- r-ggplot2=3.2_0
- r-gridextra=2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mixmodel.xml

Generated with Planemo.