### PR TITLE
Add container mulled-v2-57d47adfed1b14a1f1a20f71387e3951ce834c2a:ef6af84b66bf68d1dc5eb357f2997a27eb711d50.

### DIFF
--- a/combinations/mulled-v2-57d47adfed1b14a1f1a20f71387e3951ce834c2a:ef6af84b66bf68d1dc5eb357f2997a27eb711d50-0.tsv
+++ b/combinations/mulled-v2-57d47adfed1b14a1f1a20f71387e3951ce834c2a:ef6af84b66bf68d1dc5eb357f2997a27eb711d50-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-metaboliteidmapping=1.0.0,bioconductor-org.dr.eg.db=3.16.0,bioconductor-org.ss.eg.db=3.16.0,bioconductor-org.bt.eg.db=3.16.0,bioconductor-org.gg.eg.db=3.16.0,bioconductor-org.mm.eg.db=3.16.0,bioconductor-org.xl.eg.db=3.16.0,bioconductor-org.rn.eg.db=3.16.0,bioconductor-org.ce.eg.db=3.16.0,bioconductor-org.hs.eg.db=3.16.0,bioconductor-multigsea=1.8.0,bioconductor-org.dm.eg.db=3.16.0,r-argparse=2.2.1,bioconductor-org.cf.eg.db=3.16.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-57d47adfed1b14a1f1a20f71387e3951ce834c2a:ef6af84b66bf68d1dc5eb357f2997a27eb711d50

**Packages**:
- bioconductor-metaboliteidmapping=1.0.0
- bioconductor-org.dr.eg.db=3.16.0
- bioconductor-org.ss.eg.db=3.16.0
- bioconductor-org.bt.eg.db=3.16.0
- bioconductor-org.gg.eg.db=3.16.0
- bioconductor-org.mm.eg.db=3.16.0
- bioconductor-org.xl.eg.db=3.16.0
- bioconductor-org.rn.eg.db=3.16.0
- bioconductor-org.ce.eg.db=3.16.0
- bioconductor-org.hs.eg.db=3.16.0
- bioconductor-multigsea=1.8.0
- bioconductor-org.dm.eg.db=3.16.0
- r-argparse=2.2.1
- bioconductor-org.cf.eg.db=3.16.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- multigsea.xml

Generated with Planemo.