### PR TITLE
Add container mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:9f5e39bc8bac8dc3de4de0c269b0ec6d330532da.

### DIFF
--- a/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:9f5e39bc8bac8dc3de4de0c269b0ec6d330532da-0.tsv
+++ b/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:9f5e39bc8bac8dc3de4de0c269b0ec6d330532da-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ucsc-blat=377,diamond=2.1.4,proteinortho=6.3.1,last=1422,blast=2.13.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:9f5e39bc8bac8dc3de4de0c269b0ec6d330532da

**Packages**:
- ucsc-blat=377
- diamond=2.1.4
- proteinortho=6.3.1
- last=1422
- blast=2.13.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho_grab_proteins.xml
- proteinortho_summary.xml
- proteinortho.xml

Generated with Planemo.