### PR TITLE
Add container mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:681e2bdd948b7e2a69735e6343afbb2f7faa0d62.

### DIFF
--- a/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:681e2bdd948b7e2a69735e6343afbb2f7faa0d62-0.tsv
+++ b/combinations/mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:681e2bdd948b7e2a69735e6343afbb2f7faa0d62-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+zip=3.0,icescreen=1.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-aa4498f1d1f1df097e275a63a8a40cf35daab4a7:681e2bdd948b7e2a69735e6343afbb2f7faa0d62

**Packages**:
- zip=3.0
- icescreen=1.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- icescreen.xml

Generated with Planemo.