### PR TITLE
Add container mulled-v2-bf8b6880ff14fcc28a1131a30745903111355891:a58322352e98742e2592eca2b0e869cddb9d47c1.

### DIFF
--- a/combinations/mulled-v2-bf8b6880ff14fcc28a1131a30745903111355891:a58322352e98742e2592eca2b0e869cddb9d47c1-0.tsv
+++ b/combinations/mulled-v2-bf8b6880ff14fcc28a1131a30745903111355891:a58322352e98742e2592eca2b0e869cddb9d47c1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.7.3,bioconductor-scran=1.28.1,r-dynamictreecut=1.63_1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-bf8b6880ff14fcc28a1131a30745903111355891:a58322352e98742e2592eca2b0e869cddb9d47c1

**Packages**:
- r-optparse=1.7.3
- bioconductor-scran=1.28.1
- r-dynamictreecut=1.63_1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scran_normalize.xml

Generated with Planemo.