### PR TITLE
Add container mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:017d7386483ca3bb70ee3a6859e474241fd8e73a.

### DIFF
--- a/combinations/mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:017d7386483ca3bb70ee3a6859e474241fd8e73a-0.tsv
+++ b/combinations/mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:017d7386483ca3bb70ee3a6859e474241fd8e73a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+jq=1.6,wget=1.20.3,curl=8.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:017d7386483ca3bb70ee3a6859e474241fd8e73a

**Packages**:
- jq=1.6
- wget=1.20.3
- curl=8.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- biaftplink.xml

Generated with Planemo.