### PR TITLE
Add container mulled-v2-94b9ac8bdf374803f3ddf6e27e119f7188e268d1:5a880c9e013e1cd48f6757661379e7444008d3b4.

### DIFF
--- a/combinations/mulled-v2-94b9ac8bdf374803f3ddf6e27e119f7188e268d1:5a880c9e013e1cd48f6757661379e7444008d3b4-0.tsv
+++ b/combinations/mulled-v2-94b9ac8bdf374803f3ddf6e27e119f7188e268d1:5a880c9e013e1cd48f6757661379e7444008d3b4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+macs=1.3.7.1,r=2.15.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-94b9ac8bdf374803f3ddf6e27e119f7188e268d1:5a880c9e013e1cd48f6757661379e7444008d3b4

**Packages**:
- macs=1.3.7.1
- r=2.15.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- macs_wrapper.xml

Generated with Planemo.