### PR TITLE
Add container mulled-v2-f5649727e5620c22da315f4ce34666a04f54e1dc:f4fe604a41fe056f7ad540300d73e2fe090fa8cb.

### DIFF
--- a/combinations/mulled-v2-f5649727e5620c22da315f4ce34666a04f54e1dc:f4fe604a41fe056f7ad540300d73e2fe090fa8cb-0.tsv
+++ b/combinations/mulled-v2-f5649727e5620c22da315f4ce34666a04f54e1dc:f4fe604a41fe056f7ad540300d73e2fe090fa8cb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gatk=1.4,r=2.11.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f5649727e5620c22da315f4ce34666a04f54e1dc:f4fe604a41fe056f7ad540300d73e2fe090fa8cb

**Packages**:
- gatk=1.4
- r=2.11.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- analyze_covariates.xml

Generated with Planemo.