### PR TITLE
Add container mulled-v2-1b09fde1d665afa1e45c2d55d3694310277354bb:7ed8fa6b9c1454cdf2afd34e4ce5b3c5d515b9ab.

### DIFF
--- a/combinations/mulled-v2-1b09fde1d665afa1e45c2d55d3694310277354bb:7ed8fa6b9c1454cdf2afd34e4ce5b3c5d515b9ab-0.tsv
+++ b/combinations/mulled-v2-1b09fde1d665afa1e45c2d55d3694310277354bb:7ed8fa6b9c1454cdf2afd34e4ce5b3c5d515b9ab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r=3.6.0,rpy2=3.3.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1b09fde1d665afa1e45c2d55d3694310277354bb:7ed8fa6b9c1454cdf2afd34e4ce5b3c5d515b9ab

**Packages**:
- r=3.6.0
- rpy2=3.3.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- histogram2.xml

Generated with Planemo.