### PR TITLE
Add container mulled-v2-232b9d8536fcef880f0e8e440ab1d531693917a1:8b0936c2d23474421d0a7cb7128d84f628958e13.

### DIFF
--- a/combinations/mulled-v2-232b9d8536fcef880f0e8e440ab1d531693917a1:8b0936c2d23474421d0a7cb7128d84f628958e13-0.tsv
+++ b/combinations/mulled-v2-232b9d8536fcef880f0e8e440ab1d531693917a1:8b0936c2d23474421d0a7cb7128d84f628958e13-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,gawk=5.3.0,coreutils=9.4,htseq=2.0.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-232b9d8536fcef880f0e8e440ab1d531693917a1:8b0936c2d23474421d0a7cb7128d84f628958e13

**Packages**:
- samtools=1.19.2
- gawk=5.3.0
- coreutils=9.4
- htseq=2.0.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- htseq-count.xml

Generated with Planemo.