### PR TITLE
Add container mulled-v2-ed47e5db24dd60237dd0ff06590b522fde336559:77162d5713d450574782ff3f5d8ffaa5bfb5770d.

### DIFF
--- a/combinations/mulled-v2-ed47e5db24dd60237dd0ff06590b522fde336559:77162d5713d450574782ff3f5d8ffaa5bfb5770d-0.tsv
+++ b/combinations/mulled-v2-ed47e5db24dd60237dd0ff06590b522fde336559:77162d5713d450574782ff3f5d8ffaa5bfb5770d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-scales=1.3.0,r-psych=2.4.1,r-dplyr=1.1.4,r-optparse=1.7.4,r-ggplot2=3.4.4,r-reshape2=1.4.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ed47e5db24dd60237dd0ff06590b522fde336559:77162d5713d450574782ff3f5d8ffaa5bfb5770d

**Packages**:
- r-scales=1.3.0
- r-psych=2.4.1
- r-dplyr=1.1.4
- r-optparse=1.7.4
- r-ggplot2=3.4.4
- r-reshape2=1.4.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ez_histograms.xml

Generated with Planemo.