### PR TITLE
Add container mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:1567486dbcdf863a059e79accc81a002884ef107.

### DIFF
--- a/combinations/mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:1567486dbcdf863a059e79accc81a002884ef107-0.tsv
+++ b/combinations/mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:1567486dbcdf863a059e79accc81a002884ef107-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,bbmap=39.06	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:1567486dbcdf863a059e79accc81a002884ef107

**Packages**:
- samtools=1.19.2
- bbmap=39.06
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bbduk.xml
- tadpole.xml
- bbnorm.xml
- bbmap.xml
- bbmerge.xml
- callvariants.xml

Generated with Planemo.