### PR TITLE
Add container mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:2179b5770af210cfef67ab61b9baf52424ee028f.

### DIFF
--- a/combinations/mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:2179b5770af210cfef67ab61b9baf52424ee028f-0.tsv
+++ b/combinations/mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:2179b5770af210cfef67ab61b9baf52424ee028f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.18,star=2.7.11a,gzip=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:2179b5770af210cfef67ab61b9baf52424ee028f

**Packages**:
- samtools=1.18
- star=2.7.11a
- gzip=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rg_rnaStarSolo.xml
- rg_rnaStar.xml

Generated with Planemo.