### PR TITLE
Add container mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:84c5875c6ed06b549037277edbc46f9c240d55e7.

### DIFF
--- a/combinations/mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:84c5875c6ed06b549037277edbc46f9c240d55e7-0.tsv
+++ b/combinations/mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:84c5875c6ed06b549037277edbc46f9c240d55e7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.18,python=3.7,star=2.7.11a,gzip=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-52f8f283e3c401243cee4ee45f80122fbf6df3bb:84c5875c6ed06b549037277edbc46f9c240d55e7

**Packages**:
- samtools=1.18
- python=3.7
- star=2.7.11a
- gzip=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rna_star_index_builder.xml

Generated with Planemo.