### PR TITLE
Add container mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:c5ab2f58e2a3625979f4792f0349eea2b3a6a146.

### DIFF
--- a/combinations/mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:c5ab2f58e2a3625979f4792f0349eea2b3a6a146-0.tsv
+++ b/combinations/mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:c5ab2f58e2a3625979f4792f0349eea2b3a6a146-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-optparse=1.7.4,pysam=0.22.0,r-ggplot2=3.4.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e15ea4953ab53ae0cd3706bdda1f5546ba55058:c5ab2f58e2a3625979f4792f0349eea2b3a6a146

**Packages**:
- r-optparse=1.7.4
- pysam=0.22.0
- r-ggplot2=3.4.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mapping_quality_stats.xml

Generated with Planemo.