### PR TITLE
Add container mulled-v2-295c3b1e30b1b8b8cae86c1033ba99e7b63674d6:2f4c558dbcac0618112a14d10e44a4d5a69ba3d8.

### DIFF
--- a/combinations/mulled-v2-295c3b1e30b1b8b8cae86c1033ba99e7b63674d6:2f4c558dbcac0618112a14d10e44a4d5a69ba3d8-0.tsv
+++ b/combinations/mulled-v2-295c3b1e30b1b8b8cae86c1033ba99e7b63674d6:2f4c558dbcac0618112a14d10e44a4d5a69ba3d8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,r-lattice=0.22_5,bowtie=1.3.1,pysam=0.22.0,r-optparse=1.7.4,tar=1.34	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-295c3b1e30b1b8b8cae86c1033ba99e7b63674d6:2f4c558dbcac0618112a14d10e44a4d5a69ba3d8

**Packages**:
- samtools=1.19.2
- r-lattice=0.22_5
- bowtie=1.3.1
- pysam=0.22.0
- r-optparse=1.7.4
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mircounts.xml

Generated with Planemo.