### PR TITLE
Add container mulled-v2-ed19dfc44257898bf43bd8d7077c25de3de2fbcd:0fc817da0f65bc9ebb3ea2697431ffa1333c7f65.

### DIFF
--- a/combinations/mulled-v2-ed19dfc44257898bf43bd8d7077c25de3de2fbcd:0fc817da0f65bc9ebb3ea2697431ffa1333c7f65-0.tsv
+++ b/combinations/mulled-v2-ed19dfc44257898bf43bd8d7077c25de3de2fbcd:0fc817da0f65bc9ebb3ea2697431ffa1333c7f65-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+superdsm=0.2.0,ray-core=1.6.0,mkl=2020.0,cvxpy=1.1.13,numpy=1.20,cvxopt=1.2.6,scipy=1.6.3,scikit-image=0.18.1,blas=1.0=mkl	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ed19dfc44257898bf43bd8d7077c25de3de2fbcd:0fc817da0f65bc9ebb3ea2697431ffa1333c7f65

**Packages**:
- superdsm=0.2.0
- ray-core=1.6.0
- mkl=2020.0
- cvxpy=1.1.13
- numpy=1.20
- cvxopt=1.2.6
- scipy=1.6.3
- scikit-image=0.18.1
- blas=1.0=mkl
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- superdsm.xml

Generated with Planemo.