### PR TITLE
Add Kraken2 + gnu-coreutils combination

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -535,4 +535,4 @@ minimap2=2.24,samtools=1.17,perl=5.32.1,staden_io_lib=1.14.14,bwa-mem2=2.2.1
 kalign3=3.3.5,pigz=2.8
 gem3-mapper=3.6.1,samtools=1.17
 pyrodigal=3.3.0,pigz=2.6
-kraken2=2.1.3,conda-forge::gnu-coreutils=9.4
+kraken2=2.1.3,gnu-coreutils=9.4

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -535,3 +535,4 @@ minimap2=2.24,samtools=1.17,perl=5.32.1,staden_io_lib=1.14.14,bwa-mem2=2.2.1
 kalign3=3.3.5,pigz=2.8
 gem3-mapper=3.6.1,samtools=1.17
 pyrodigal=3.3.0,pigz=2.6
+kraken2=2.1.3,conda-forge::gnu-coreutils=9.4


### PR DESCRIPTION
I am requesting this multi-package-container as I _believe_ that the base busybox container has a version of `chown` that is incompatible with the `kraken-build --add-to-library` command.

When trying to run using the 'standard' kraken2 biocontainer, we get the following error:

```
Masking low-complexity regions of new file... done.
Added "proteome.fasta" to library (db)
chown: unrecognized option '--from'
BusyBox v1.32.1 (2021-04-13 11:15:36 UTC) multi-call binary.

Usage: chown [-RhLHPcvf]... USER[:[GRP]] FILE...

Change the owner and/or group of each FILE to USER and/or GRP

        -R      Recurse
        -h      Affect symlinks instead of symlink targets
        -L      Traverse all symlinks to directories
        -H      Traverse symlinks on command line only
        -P      Don't traverse symlinks (default)
        -c      List changed files
        -v      List all files
        -f      Hide errors
```
        
And when searching for `chown --from`, I get a hit to the GNU-coreutils documentation: https://www.gnu.org/software/coreutils/manual/coreutils.html#index-_002d_002dfrom
        
Indeed when running locally using conda installed Kraken2, (on Ubuntu, that uses GNU coreutils), I am able to run the command with no issue.

Another option could be to update the bioconda recipe, if that is preferable.