### PR TITLE
Add container mulled-v2-b5bd5f2abb1850e95b7b3eae6b4ac03846bd6904:3b09fae774db3532a48e8f2c797932eaa5606fb2.

### DIFF
--- a/combinations/mulled-v2-b5bd5f2abb1850e95b7b3eae6b4ac03846bd6904:3b09fae774db3532a48e8f2c797932eaa5606fb2-0.tsv
+++ b/combinations/mulled-v2-b5bd5f2abb1850e95b7b3eae6b4ac03846bd6904:3b09fae774db3532a48e8f2c797932eaa5606fb2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12.1,pindel=0.2.5b9,samtools=1.19.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b5bd5f2abb1850e95b7b3eae6b4ac03846bd6904:3b09fae774db3532a48e8f2c797932eaa5606fb2

**Packages**:
- python=3.12.1
- pindel=0.2.5b9
- samtools=1.19.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pindelwrapper.xml

Generated with Planemo.