### PR TITLE
Add container mulled-v2-077b852b8b5440d395ad23f9f24f50c943390a84:debec88854dc974fa23c02023ea39b23fb18e6c9.

### DIFF
--- a/combinations/mulled-v2-077b852b8b5440d395ad23f9f24f50c943390a84:debec88854dc974fa23c02023ea39b23fb18e6c9-0.tsv
+++ b/combinations/mulled-v2-077b852b8b5440d395ad23f9f24f50c943390a84:debec88854dc974fa23c02023ea39b23fb18e6c9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ucsc-bigwigtobedgraph=377,pretextgraph=0.0.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-077b852b8b5440d395ad23f9f24f50c943390a84:debec88854dc974fa23c02023ea39b23fb18e6c9

**Packages**:
- ucsc-bigwigtobedgraph=377
- pretextgraph=0.0.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pretext_graph.xml

Generated with Planemo.