### PR TITLE
Add new container for BWA MEM, SAMtools, Sambamba

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -543,3 +543,4 @@ pyrodigal=3.3.0,pigz=2.6
 kraken2=2.1.3,gnu-coreutils=9.4
 macs2=2.2.9.1,mawk=1.3.4
 kraken2=2.1.3,coreutils=9.4
+bwa=0.7.17,samtools=1.19.2,sambamba=1.0


### PR DESCRIPTION
Required for the oncoanalyser HLA remapping process. Packages:

* `bwa=0.7.17`
* `samtools=1.19.2`
* `sambamba=1.0`