### PR TITLE
Add container mulled-v2-7257a7ed7bdc20a703b471c9ab6c2a88387adcef:66d0d0b3824dd9ff9baebd2a9aaa96a7660062a6.

### DIFF
--- a/combinations/mulled-v2-7257a7ed7bdc20a703b471c9ab6c2a88387adcef:66d0d0b3824dd9ff9baebd2a9aaa96a7660062a6-0.tsv
+++ b/combinations/mulled-v2-7257a7ed7bdc20a703b471c9ab6c2a88387adcef:66d0d0b3824dd9ff9baebd2a9aaa96a7660062a6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl=5.26,hmmer=3.3.2,sed=4.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7257a7ed7bdc20a703b471c9ab6c2a88387adcef:66d0d0b3824dd9ff9baebd2a9aaa96a7660062a6

**Packages**:
- perl=5.26
- hmmer=3.3.2
- sed=4.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tapscan.xml

Generated with Planemo.