### PR TITLE
Add Kraken2 + coreutils combination

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -540,3 +540,4 @@ gem3-mapper=3.6.1,samtools=1.17
 pyrodigal=3.3.0,pigz=2.6
 kraken2=2.1.3,gnu-coreutils=9.4
 macs2=2.2.9.1,mawk=1.3.4
+kraken2=2.1.3,coreutils=9.4


### PR DESCRIPTION
This is a follow up to [this PR](https://github.com/BioContainers/multi-package-containers/pull/2935), which in fact did not solve the problem as it seems that the `gnu-coreutils` conda package didn't actually place the tools/binaries in the container.

I just discovered that the `coreutils` (i.e., without the `gnu-` prefix) also works just as well, and a local build of that singularity container worked for me correctly.

If removal of the previous container is possible (mulled-v2-4e263fb896be122f4594792ae66a3020b4f9059f:2e0b144854b4a3d69b5df7a0340a60db846cc8bf-0), it is fine to do so.