### PR TITLE
Add container mulled-v2-608d60d6fab60cf693e1bb0816a95ee292ef9bed:9f1011b7bfe6d62f1e48cc1783171feaebe0b10d.

### DIFF
--- a/combinations/mulled-v2-608d60d6fab60cf693e1bb0816a95ee292ef9bed:9f1011b7bfe6d62f1e48cc1783171feaebe0b10d-0.tsv
+++ b/combinations/mulled-v2-608d60d6fab60cf693e1bb0816a95ee292ef9bed:9f1011b7bfe6d62f1e48cc1783171feaebe0b10d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bedtools=2.31.1,r-optparse=1.7.4,pysam=0.22.0,r-reshape2=1.4.4,r-ggplot2=3.4.4,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-608d60d6fab60cf693e1bb0816a95ee292ef9bed:9f1011b7bfe6d62f1e48cc1783171feaebe0b10d

**Packages**:
- bedtools=2.31.1
- r-optparse=1.7.4
- pysam=0.22.0
- r-reshape2=1.4.4
- r-ggplot2=3.4.4
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- probecoverage.xml

Generated with Planemo.