### PR TITLE
Add container mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:1f06c2f3b8027398142cd41b4a1c47438bb0ed92.

### DIFF
--- a/combinations/mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:1f06c2f3b8027398142cd41b4a1c47438bb0ed92-0.tsv
+++ b/combinations/mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:1f06c2f3b8027398142cd41b4a1c47438bb0ed92-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+omamer=2.0.2,omark=0.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:1f06c2f3b8027398142cd41b4a1c47438bb0ed92

**Packages**:
- omamer=2.0.2
- omark=0.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- omark.xml

Generated with Planemo.