### PR TITLE
Add combination for optitype and coincbc

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -545,3 +545,4 @@ kraken2=2.1.3,gnu-coreutils=9.4
 macs2=2.2.9.1,mawk=1.3.4
 kraken2=2.1.3,coreutils=9.4
 bwa=0.7.17,samtools=1.19.2,sambamba=1.0
+optitype=1.3.5,coincbc=2.10.0


### PR DESCRIPTION
This adds a combination for `OptiType` and `Coincbc` in order to allow execution of `OptiType` with the cbc solver.