### PR TITLE
Add container mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:7b2f99e5d09a1c31e0236f206d9b21db634671cf.

### DIFF
--- a/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:7b2f99e5d09a1c31e0236f206d9b21db634671cf-0.tsv
+++ b/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:7b2f99e5d09a1c31e0236f206d9b21db634671cf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+vcfanno=0.3.5,samtools=1.19.2,tabix=1.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:7b2f99e5d09a1c31e0236f206d9b21db634671cf

**Packages**:
- vcfanno=0.3.5
- samtools=1.19.2
- tabix=1.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vcfanno.xml

Generated with Planemo.