### PR TITLE
Add container mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:6d1ccdaeef05bd2dcaee562df29ccedca9139605.

### DIFF
--- a/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:6d1ccdaeef05bd2dcaee562df29ccedca9139605-0.tsv
+++ b/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:6d1ccdaeef05bd2dcaee562df29ccedca9139605-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bwa=0.7.17,abyss=2.3.7	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:6d1ccdaeef05bd2dcaee562df29ccedca9139605

**Packages**:
- bwa=0.7.17
- abyss=2.3.7
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- abyss-pe.xml

Generated with Planemo.