### PR TITLE
Add container mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:ce24ff09be517dbfb5f91f18d08bdae4feb2fd7b.

### DIFF
--- a/combinations/mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:ce24ff09be517dbfb5f91f18d08bdae4feb2fd7b-0.tsv
+++ b/combinations/mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:ce24ff09be517dbfb5f91f18d08bdae4feb2fd7b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.11,bioconductor-lineagespot=1.6.0,r-getopt=1.20.4,r-base=4.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dfe032a0f798515010cd34cc4b1d1adecaebd69b:ce24ff09be517dbfb5f91f18d08bdae4feb2fd7b

**Packages**:
- python=3.11
- bioconductor-lineagespot=1.6.0
- r-getopt=1.20.4
- r-base=4.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lineagespot_wrapper.xml

Generated with Planemo.