### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:549c2d0f54b0becbd9157567c37636eef6b06f12.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:549c2d0f54b0becbd9157567c37636eef6b06f12-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:549c2d0f54b0becbd9157567c37636eef6b06f12-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.13,mosdepth=0.3.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:549c2d0f54b0becbd9157567c37636eef6b06f12

**Packages**:
- gzip=1.13
- mosdepth=0.3.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.