### PR TITLE
Add container mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:a2e4688a25bd1726a756713d5233a63a5ac7f597.

### DIFF
--- a/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:a2e4688a25bd1726a756713d5233a63a5ac7f597-0.tsv
+++ b/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:a2e4688a25bd1726a756713d5233a63a5ac7f597-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,bowtie2=2.5.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:a2e4688a25bd1726a756713d5233a63a5ac7f597

**Packages**:
- samtools=1.19.2
- bowtie2=2.5.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bowtie2_wrapper.xml

Generated with Planemo.