### PR TITLE
Update OptiType and cbc container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -545,4 +545,4 @@ kraken2=2.1.3,gnu-coreutils=9.4
 macs2=2.2.9.1,mawk=1.3.4
 kraken2=2.1.3,coreutils=9.4
 bwa=0.7.17,samtools=1.19.2,sambamba=1.0
-optitype=1.3.5,coincbc=2.10.0
+optitype=1.3.5,coincbc=2.10.10


### PR DESCRIPTION
Unfortunately, I noticed that the initially specified version of `coincbc` leads to the installation of an old `pytables` version (3.6.1) that causes an error during execution of OptiType. 

Updating the `coincbc` solved that issue in a local conda env (`pytables` 3.9.2 was installed).