### PR TITLE
Add container mulled-v2-3b62966bb5abb1228683819650478f85a768a305:d43a85e952f1f7c936cab254dbfc78dc08515b0b.

### DIFF
--- a/combinations/mulled-v2-3b62966bb5abb1228683819650478f85a768a305:d43a85e952f1f7c936cab254dbfc78dc08515b0b-0.tsv
+++ b/combinations/mulled-v2-3b62966bb5abb1228683819650478f85a768a305:d43a85e952f1f7c936cab254dbfc78dc08515b0b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.3,sed=4.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3b62966bb5abb1228683819650478f85a768a305:d43a85e952f1f7c936cab254dbfc78dc08515b0b

**Packages**:
- coreutils=9.3
- sed=4.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sort.xml
- sorted_uniq.xml

Generated with Planemo.