### PR TITLE
Add container mulled-v2-a8b1e1ec4fafcddd7d4c96fdaa021e5b6c1e8a67:27f652719ff0f4dfc5e3d483435124548d01020c.

### DIFF
--- a/combinations/mulled-v2-a8b1e1ec4fafcddd7d4c96fdaa021e5b6c1e8a67:27f652719ff0f4dfc5e3d483435124548d01020c-0.tsv
+++ b/combinations/mulled-v2-a8b1e1ec4fafcddd7d4c96fdaa021e5b6c1e8a67:27f652719ff0f4dfc5e3d483435124548d01020c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+grep=3.11,sed=4.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a8b1e1ec4fafcddd7d4c96fdaa021e5b6c1e8a67:27f652719ff0f4dfc5e3d483435124548d01020c

**Packages**:
- grep=3.11
- sed=4.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- grep.xml

Generated with Planemo.