### PR TITLE
Add container mulled-v2-98d2edbb2e8db1851608747aee7f29cdc92fdf46:c6c1b955bffb532e5bd196fbb391f62a47a228df.

### DIFF
--- a/combinations/mulled-v2-98d2edbb2e8db1851608747aee7f29cdc92fdf46:c6c1b955bffb532e5bd196fbb391f62a47a228df-0.tsv
+++ b/combinations/mulled-v2-98d2edbb2e8db1851608747aee7f29cdc92fdf46:c6c1b955bffb532e5bd196fbb391f62a47a228df-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ucsc-gtftogenepred=447,picard=3.1.1,ucsc-gff3togenepred=447	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-98d2edbb2e8db1851608747aee7f29cdc92fdf46:c6c1b955bffb532e5bd196fbb391f62a47a228df

**Packages**:
- ucsc-gtftogenepred=447
- picard=3.1.1
- ucsc-gff3togenepred=447
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- picard_CollectRnaSeqMetrics.xml

Generated with Planemo.