### PR TITLE
Add container mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:2414635e64cad466325dbda09d69c7c259b3a0be.

### DIFF
--- a/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:2414635e64cad466325dbda09d69c7c259b3a0be-0.tsv
+++ b/combinations/mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:2414635e64cad466325dbda09d69c7c259b3a0be-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+proteinortho=6.3.1,ucsc-blat=445,diamond=2.1.8,last=1519,blast=2.15.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a5129ed997569a1d10393938c0cdb4aadeff3792:2414635e64cad466325dbda09d69c7c259b3a0be

**Packages**:
- proteinortho=6.3.1
- ucsc-blat=445
- diamond=2.1.8
- last=1519
- blast=2.15.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho_summary.xml
- proteinortho_grab_proteins.xml
- proteinortho.xml

Generated with Planemo.