### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:2cd7e96e78a1e8ae93b95964a4d738eb3785292a.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:2cd7e96e78a1e8ae93b95964a4d738eb3785292a-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:2cd7e96e78a1e8ae93b95964a4d738eb3785292a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,pigz=2.8,sra-tools=3.0.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:2cd7e96e78a1e8ae93b95964a4d738eb3785292a

**Packages**:
- samtools=1.19.2
- pigz=2.8
- sra-tools=3.0.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fasterq_dump.xml
- sam_dump.xml
- fastq_dump.xml

Generated with Planemo.