### PR TITLE
Update gatk3.5 container in hash.tsv

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -207,7 +207,7 @@ snpsift=4.3.1t,python=2.7.15,pyvcf=0.6.8,pandas=0.24.2,fred2=2.0.7,mhcflurry=1.4
 biopython,r-optparse=1.7.1,r-upsetr=1.4.0,bedtools=2.30.0
 r-optparse=1.7.1,r-desolve=1.30
 bioconductor-limma=3.50.0,bioconductor-edger=3.36.0,r-data.table=1.14.2,r-gplots=3.1.1,r-statmod=1.4.36
-gatk=3.5,samtools=1.13
+gatk=3.5,samtools=1.13,tabix=1.11
 requests=2.26	quay.io/bioconda/base-glibc-debian-bash:latest	0
 mirtop=0.4.24,samtools=1.13,r-base=4.1.1,r-data.table=1.14.2
 krakenuniq=0.5.8,pigz=2.6


### PR DESCRIPTION
Added tabix to the GATK 3.5 mulled container. 
This is needed to compress VCFs generated by GATK with bgzip (included in the tabix package). 