### PR TITLE
Add container mulled-v2-80d25dd456f44e810bc19230e5d0a79df3d0911e:2bee98371551ee2865e397bcf99b4df05520fd39.

### DIFF
--- a/combinations/mulled-v2-80d25dd456f44e810bc19230e5d0a79df3d0911e:2bee98371551ee2865e397bcf99b4df05520fd39-0.tsv
+++ b/combinations/mulled-v2-80d25dd456f44e810bc19230e5d0a79df3d0911e:2bee98371551ee2865e397bcf99b4df05520fd39-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.22.0,scipy=1.12.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-80d25dd456f44e810bc19230e5d0a79df3d0911e:2bee98371551ee2865e397bcf99b4df05520fd39

**Packages**:
- scikit-image=0.22.0
- scipy=1.12.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- morphological_operations.xml

Generated with Planemo.