### PR TITLE
Add container mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:fc5aff25e8c0f793ef4c4c4bd393ca36425d7715.

### DIFF
--- a/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:fc5aff25e8c0f793ef4c4c4bd393ca36425d7715-0.tsv
+++ b/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:fc5aff25e8c0f793ef4c4c4bd393ca36425d7715-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,deeptools=3.5.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:fc5aff25e8c0f793ef4c4c4bd393ca36425d7715

**Packages**:
- samtools=1.9
- deeptools=3.5.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plotPCA.xml
- plotCorrelation.xml
- plotCoverage.xml
- computeMatrixOperations.xml
- computeMatrix.xml
- correctGCBias.xml
- bigwigAverage.xml
- bigwigCompare.xml
- plotEnrichment.xml
- computeGCBias.xml
- plotProfiler.xml
- alignmentSieve.xml
- plotHeatmap.xml
- multiBigwigSummary.xml
- multiBamSummary.xml
- bamCompare.xml
- plotFingerprint.xml
- bamPEFragmentSize.xml
- bamCoverage.xml
- estimateReadFiltering.xml

Generated with Planemo.