### PR TITLE
Add container mulled-v2-f7371d5485918f52639977b16bd54bf3c3e2953a:c2c21b23f6954a7b1d22b1b9bfd3064028512f73.

### DIFF
--- a/combinations/mulled-v2-f7371d5485918f52639977b16bd54bf3c3e2953a:c2c21b23f6954a7b1d22b1b9bfd3064028512f73-0.tsv
+++ b/combinations/mulled-v2-f7371d5485918f52639977b16bd54bf3c3e2953a:c2c21b23f6954a7b1d22b1b9bfd3064028512f73-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scipy=1.12.0,numpy=1.26.4,scikit-image=0.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f7371d5485918f52639977b16bd54bf3c3e2953a:c2c21b23f6954a7b1d22b1b9bfd3064028512f73

**Packages**:
- scipy=1.12.0
- numpy=1.26.4
- scikit-image=0.22.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- voronoi_tessellation.xml

Generated with Planemo.