### PR TITLE
Add container mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:590c1964844f9b94ae0ce8b10a143cbf94a6cdd4.

### DIFF
--- a/combinations/mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:590c1964844f9b94ae0ce8b10a143cbf94a6cdd4-0.tsv
+++ b/combinations/mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:590c1964844f9b94ae0ce8b10a143cbf94a6cdd4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.26.4,scikit-image=0.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:590c1964844f9b94ae0ce8b10a143cbf94a6cdd4

**Packages**:
- numpy=1.26.4
- scikit-image=0.22.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- image_math.xml

Generated with Planemo.