### PR TITLE
Add container mulled-v2-c9b9b4a69627fb76616c1fdfeca17afd5a0e6f6f:cec2f4e412eb743e2ea6ab49dd3d7f07b9385bfb.

### DIFF
--- a/combinations/mulled-v2-c9b9b4a69627fb76616c1fdfeca17afd5a0e6f6f:cec2f4e412eb743e2ea6ab49dd3d7f07b9385bfb-0.tsv
+++ b/combinations/mulled-v2-c9b9b4a69627fb76616c1fdfeca17afd5a0e6f6f:cec2f4e412eb743e2ea6ab49dd3d7f07b9385bfb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-edger=4.0.2,bedtools=2.23.0,bowtie=1.0.0,samtools=1.19.2,bioconductor-limma=3.58.1,r-getopt=1.20.4,biopython=1.83,r-rjson=0.2.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c9b9b4a69627fb76616c1fdfeca17afd5a0e6f6f:cec2f4e412eb743e2ea6ab49dd3d7f07b9385bfb

**Packages**:
- bioconductor-edger=4.0.2
- bedtools=2.23.0
- bowtie=1.0.0
- samtools=1.19.2
- bioconductor-limma=3.58.1
- r-getopt=1.20.4
- biopython=1.83
- r-rjson=0.2.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- edger-repenrich.xml
- repenrich.xml

Generated with Planemo.