### PR TITLE
Add container mulled-v2-1206fe8c995e5fd3e694425a5cff2c4a4c367a4d:53b68842ad2f64d14b3bbe50b1e944a60436224b.

### DIFF
--- a/combinations/mulled-v2-1206fe8c995e5fd3e694425a5cff2c4a4c367a4d:53b68842ad2f64d14b3bbe50b1e944a60436224b-0.tsv
+++ b/combinations/mulled-v2-1206fe8c995e5fd3e694425a5cff2c4a4c367a4d:53b68842ad2f64d14b3bbe50b1e944a60436224b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.22.0,orientationpy=0.2.0.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1206fe8c995e5fd3e694425a5cff2c4a4c367a4d:53b68842ad2f64d14b3bbe50b1e944a60436224b

**Packages**:
- scikit-image=0.22.0
- orientationpy=0.2.0.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- orientationpy.xml

Generated with Planemo.