### PR TITLE
Add container mulled-v2-b764d1cdc31273041400c6cc1390702189f41bda:b7ddc50ec6967f35af97ac0476ce0a415213ffda.

### DIFF
--- a/combinations/mulled-v2-b764d1cdc31273041400c6cc1390702189f41bda:b7ddc50ec6967f35af97ac0476ce0a415213ffda-0.tsv
+++ b/combinations/mulled-v2-b764d1cdc31273041400c6cc1390702189f41bda:b7ddc50ec6967f35af97ac0476ce0a415213ffda-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.20,scikit-image=0.18.1,superdsm=0.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b764d1cdc31273041400c6cc1390702189f41bda:b7ddc50ec6967f35af97ac0476ce0a415213ffda

**Packages**:
- numpy=1.20
- scikit-image=0.18.1
- superdsm=0.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- colorize_labels.xml

Generated with Planemo.