### PR TITLE
Add container mulled-v2-2fe77bb3f0c1022b493c3f0e64ba3dfb5ce46c9a:af41b4f56b164561ccd091dbd7f0a48f90a9a4f8.

### DIFF
--- a/combinations/mulled-v2-2fe77bb3f0c1022b493c3f0e64ba3dfb5ce46c9a:af41b4f56b164561ccd091dbd7f0a48f90a9a4f8-0.tsv
+++ b/combinations/mulled-v2-2fe77bb3f0c1022b493c3f0e64ba3dfb5ce46c9a:af41b4f56b164561ccd091dbd7f0a48f90a9a4f8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+networkx=3.2.1,numpy=1.22,scikit-image=0.18.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2fe77bb3f0c1022b493c3f0e64ba3dfb5ce46c9a:af41b4f56b164561ccd091dbd7f0a48f90a9a4f8

**Packages**:
- networkx=3.2.1
- numpy=1.22
- scikit-image=0.18.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- colorize_labels.xml

Generated with Planemo.