### PR TITLE
Add container mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:acd1ddfe983d62ee7e75f433d188a5031fcc8d2c.

### DIFF
--- a/combinations/mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:acd1ddfe983d62ee7e75f433d188a5031fcc8d2c-0.tsv
+++ b/combinations/mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:acd1ddfe983d62ee7e75f433d188a5031fcc8d2c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.18.1,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3b2d657f905f54b27cecc3b69a16afe4ff01bd5f:acd1ddfe983d62ee7e75f433d188a5031fcc8d2c

**Packages**:
- scikit-image=0.18.1
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- label_to_binary.xml

Generated with Planemo.