### PR TITLE
Add container mulled-v2-784291a780593dcd9226bd4bde0c101805d870b1:a06f8b4d675e08b4697ef348fe4ca2eeb7fcaca5.

### DIFF
--- a/combinations/mulled-v2-784291a780593dcd9226bd4bde0c101805d870b1:a06f8b4d675e08b4697ef348fe4ca2eeb7fcaca5-0.tsv
+++ b/combinations/mulled-v2-784291a780593dcd9226bd4bde0c101805d870b1:a06f8b4d675e08b4697ef348fe4ca2eeb7fcaca5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+louvain=0.8.1,leidenalg=0.10.1,scanpy=1.9.6,seaborn=0.12.2,magic-impute=3.0.0,loompy=3.0.6,pandas=1.5.3,matplotlib=3.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-784291a780593dcd9226bd4bde0c101805d870b1:a06f8b4d675e08b4697ef348fe4ca2eeb7fcaca5

**Packages**:
- louvain=0.8.1
- leidenalg=0.10.1
- scanpy=1.9.6
- seaborn=0.12.2
- magic-impute=3.0.0
- loompy=3.0.6
- pandas=1.5.3
- matplotlib=3.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- filter.xml
- plot.xml
- inspect.xml
- cluster_reduce_dimension.xml
- normalize.xml
- remove_confounders.xml

Generated with Planemo.