### PR TITLE
Add new container for bwa-mem2, SAMtools, Sambamba

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -560,3 +560,4 @@ r-base=4.3,r-catboost=1.2,r-ABCanalysis=1.2,r-C50=0.1.8,r-caret=6.0,r-data.table
 picard=3.1.1,samtools=1.19.2
 bedtools=2.31.1,ucsc-bedgraphtobigwig=445,samtools=1.16.1
 star=2.7.11b,samtools=1.19.2,mawk=1.3.4
+bwa-mem2=2.2.1,samtools=1.19.2,sambamba=1.0


### PR DESCRIPTION
Required for the simple and rigid DNA alignment subworkflow in nf-core/oncoanalyser. Packages:

- `bwa-mem2=2.2.1`
- `samtools=1.19.2`
- `sambamba=1.0`