### PR TITLE
Add container mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:f83d48eb33ccc96dde5a2fb495d999e16ff0bc69.

### DIFF
--- a/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:f83d48eb33ccc96dde5a2fb495d999e16ff0bc69-0.tsv
+++ b/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:f83d48eb33ccc96dde5a2fb495d999e16ff0bc69-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,minimap2=2.27	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:f83d48eb33ccc96dde5a2fb495d999e16ff0bc69

**Packages**:
- samtools=1.19.2
- minimap2=2.27
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- minimap2.xml

Generated with Planemo.