### PR TITLE
Add container mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:f01f2bb89bd4c09e7ac156d4371df2eb495534e5.

### DIFF
--- a/combinations/mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:f01f2bb89bd4c09e7ac156d4371df2eb495534e5-0.tsv
+++ b/combinations/mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:f01f2bb89bd4c09e7ac156d4371df2eb495534e5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,mummer4=4.0.0rc1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:f01f2bb89bd4c09e7ac156d4371df2eb495534e5

**Packages**:
- samtools=1.19.2
- mummer4=4.0.0rc1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- delta-filter.xml
- dnadiff.xml
- show-coords.xml

Generated with Planemo.