### PR TITLE
Add container mulled-v2-828261ee15686b645a04dfab0916c486133720f5:9bf3957d497c6662d55dbd595620b9b57946efb9.

### DIFF
--- a/combinations/mulled-v2-828261ee15686b645a04dfab0916c486133720f5:9bf3957d497c6662d55dbd595620b9b57946efb9-0.tsv
+++ b/combinations/mulled-v2-828261ee15686b645a04dfab0916c486133720f5:9bf3957d497c6662d55dbd595620b9b57946efb9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sed=4.8,perl=5.26	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-828261ee15686b645a04dfab0916c486133720f5:9bf3957d497c6662d55dbd595620b9b57946efb9

**Packages**:
- sed=4.8
- perl=5.26
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cmsearch-deoverlap.xml

Generated with Planemo.