### PR TITLE
Add sanntis + interproscan mulled container

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -562,3 +562,4 @@ picard=3.1.1,samtools=1.19.2
 bedtools=2.31.1,ucsc-bedgraphtobigwig=445,samtools=1.16.1
 star=2.7.11b,samtools=1.19.2,mawk=1.3.4
 bwa-mem2=2.2.1,samtools=1.19.2,sambamba=1.0
+sanntis=0.9.3.5,interproscan=5.59_91.0


### PR DESCRIPTION
`interproscan` is a dependency of `sanntis` which was kept seperately until now for users who already have an `interproscan` installation (see discussion [here](https://github.com/bioconda/bioconda-recipes/issues/46396)) or who don't use Linux (since `interproscan` is available for Linux-only). However, a bundled package will be very handy for many users and developers of automated pipelines.