### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:a463922e8d5f63c492ba8a0e8bfb79ebebe5a051.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:a463922e8d5f63c492ba8a0e8bfb79ebebe5a051-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:a463922e8d5f63c492ba8a0e8bfb79ebebe5a051-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mosdepth=0.3.7,gzip=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:a463922e8d5f63c492ba8a0e8bfb79ebebe5a051

**Packages**:
- mosdepth=0.3.7
- gzip=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.