### PR TITLE
Add container mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:6b03915ef5f3e05350c411126f65ed96db14f4ec.

### DIFF
--- a/combinations/mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:6b03915ef5f3e05350c411126f65ed96db14f4ec-0.tsv
+++ b/combinations/mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:6b03915ef5f3e05350c411126f65ed96db14f4ec-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.13,baredsc=1.1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a8aa3c443efb5e2a235a597152a8b79bb2711e1d:6b03915ef5f3e05350c411126f65ed96db14f4ec

**Packages**:
- gzip=1.13
- baredsc=1.1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- baredsc_1d.xml
- baredsc_combine_2d.xml
- baredsc_combine_1d.xml
- baredsc_2d.xml

Generated with Planemo.