### PR TITLE
add container for magus 0.2.0

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -568,3 +568,4 @@ crabz=0.9.0
 r-tidyverse=2.0.0,r-base=4.3.3,r-seurat=5.0.1,bioconductor-dropletutils=1.22.0,r-pdftools=3.4.0,r-magick=2.8.3,bioconductor-preprocesscore=1.64.0,r-devtools=2.4.5,r-data.table=1.15.2,r-ggplot2=3.5.0,r-cowplot=1.1.3,r-here=1.0.1,r-argparse=2.2.2,r-dplyr=1.1.4,bioconductor-demuxmix=1.4.0
 mosdepth=0.3.7,samtools=1.19.2
 snpeff=5.2,tabix=1.11
+magus-msa=0.2.0,pigz=2.8


### PR DESCRIPTION
Reopened #3040, as magus 0.2.0 is now in the repo.