### PR TITLE
Add container mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:f23683a4cc13e82ecb3b7ca5a93f691d45f2004e.

### DIFF
--- a/combinations/mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:f23683a4cc13e82ecb3b7ca5a93f691d45f2004e-0.tsv
+++ b/combinations/mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:f23683a4cc13e82ecb3b7ca5a93f691d45f2004e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-getopt=1.20.4,bioconductor-dexseq=1.48.0,r-rjson=0.2.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fea8e2ec7865bae7662aedaa658cc243a31f7399:f23683a4cc13e82ecb3b7ca5a93f691d45f2004e

**Packages**:
- r-getopt=1.20.4
- bioconductor-dexseq=1.48.0
- r-rjson=0.2.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plotdexseq.xml
- dexseq_count.xml
- dexseq.xml

Generated with Planemo.