### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a242232a8a2dc124aed4757fb7329acdc8b2910d.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a242232a8a2dc124aed4757fb7329acdc8b2910d-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a242232a8a2dc124aed4757fb7329acdc8b2910d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pigz=2.8,samtools=1.19.2,sra-tools=3.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a242232a8a2dc124aed4757fb7329acdc8b2910d

**Packages**:
- pigz=2.8
- samtools=1.19.2
- sra-tools=3.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fasterq_dump.xml
- sam_dump.xml
- fastq_dump.xml

Generated with Planemo.