### PR TITLE
Add container mulled-v2-3ffca7af725971ca3232b6e98526cfb5ed81828c:76f24b7c13470ff9abbe70f3dcfabf8961dd2a60.

### DIFF
--- a/combinations/mulled-v2-3ffca7af725971ca3232b6e98526cfb5ed81828c:76f24b7c13470ff9abbe70f3dcfabf8961dd2a60-0.tsv
+++ b/combinations/mulled-v2-3ffca7af725971ca3232b6e98526cfb5ed81828c:76f24b7c13470ff9abbe70f3dcfabf8961dd2a60-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,bedtools=2.31.1,biopython=1.83,bowtie=1.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3ffca7af725971ca3232b6e98526cfb5ed81828c:76f24b7c13470ff9abbe70f3dcfabf8961dd2a60

**Packages**:
- samtools=1.19.2
- bedtools=2.31.1
- biopython=1.83
- bowtie=1.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- repenrich.xml

Generated with Planemo.