### PR TITLE
Add container mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:02bc249dd2aeace3e37fbb3f7e63b3feb7b42006.

### DIFF
--- a/combinations/mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:02bc249dd2aeace3e37fbb3f7e63b3feb7b42006-0.tsv
+++ b/combinations/mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:02bc249dd2aeace3e37fbb3f7e63b3feb7b42006-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-limma=3.58.1,r-getopt=1.20.4,r-rjson=0.2.21,bioconductor-edger=4.0.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cef53b7069b3a7ea287d8c7fb76532c54bd77c7c:02bc249dd2aeace3e37fbb3f7e63b3feb7b42006

**Packages**:
- bioconductor-limma=3.58.1
- r-getopt=1.20.4
- r-rjson=0.2.21
- bioconductor-edger=4.0.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- edger-repenrich.xml

Generated with Planemo.