### PR TITLE
Add container mulled-v2-4aa2a09b3898d8ad4484430e76e750f709b0d082:9c5c2211c66e430caac05cacbf55b458821b0e90.

### DIFF
--- a/combinations/mulled-v2-4aa2a09b3898d8ad4484430e76e750f709b0d082:9c5c2211c66e430caac05cacbf55b458821b0e90-0.tsv
+++ b/combinations/mulled-v2-4aa2a09b3898d8ad4484430e76e750f709b0d082:9c5c2211c66e430caac05cacbf55b458821b0e90-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.18.1,numpy=1.20,medpy=0.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4aa2a09b3898d8ad4484430e76e750f709b0d082:9c5c2211c66e430caac05cacbf55b458821b0e90

**Packages**:
- scikit-image=0.18.1
- numpy=1.20
- medpy=0.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- anisotropic_diffusion.xml

Generated with Planemo.