### PR TITLE
Add container mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:446bf190e1c13ce627ef4ab7ae48222d978b4351.

### DIFF
--- a/combinations/mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:446bf190e1c13ce627ef4ab7ae48222d978b4351-0.tsv
+++ b/combinations/mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:446bf190e1c13ce627ef4ab7ae48222d978b4351-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.22.0,scipy=1.12.0,tifffile=2024.2.12,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-37b33487ca82c8769f4a024c56627c01d12f9e30:446bf190e1c13ce627ef4ab7ae48222d978b4351

**Packages**:
- scikit-image=0.22.0
- scipy=1.12.0
- tifffile=2024.2.12
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- filter.xml

Generated with Planemo.