### PR TITLE
Add container mulled-v2-d30122e570a84ca92732535ca2dd983b60ae02dd:cbfa7c4338dfe91c0e4a245dca0da2a87497cce1.

### DIFF
--- a/combinations/mulled-v2-d30122e570a84ca92732535ca2dd983b60ae02dd:cbfa7c4338dfe91c0e4a245dca0da2a87497cce1-0.tsv
+++ b/combinations/mulled-v2-d30122e570a84ca92732535ca2dd983b60ae02dd:cbfa7c4338dfe91c0e4a245dca0da2a87497cce1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pillow=10.0.1,numpy=1.24.4,tifffile=2021.7.2,scikit-image=0.18.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d30122e570a84ca92732535ca2dd983b60ae02dd:cbfa7c4338dfe91c0e4a245dca0da2a87497cce1

**Packages**:
- pillow=10.0.1
- numpy=1.24.4
- tifffile=2021.7.2
- scikit-image=0.18.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scale_image.xml

Generated with Planemo.