### PR TITLE
Add container mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:29c8e89bc12d33b39e760c5ca3b1cfa087927580.

### DIFF
--- a/combinations/mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:29c8e89bc12d33b39e760c5ca3b1cfa087927580-0.tsv
+++ b/combinations/mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:29c8e89bc12d33b39e760c5ca3b1cfa087927580-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rseqc=5.0.3,r-base=4.2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c80ae8d0fe5685926c9bc673e400ff09a71844fd:29c8e89bc12d33b39e760c5ca3b1cfa087927580

**Packages**:
- rseqc=5.0.3
- r-base=4.2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- read_quality.xml
- junction_annotation.xml

Generated with Planemo.