### PR TITLE
Add container mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:e6ec84b796f6af4bb5357aaf28aee0c0005f4dea.

### DIFF
--- a/combinations/mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:e6ec84b796f6af4bb5357aaf28aee0c0005f4dea-0.tsv
+++ b/combinations/mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:e6ec84b796f6af4bb5357aaf28aee0c0005f4dea-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+blast=2.15.0,fasttree=2.1.11,chewbbaca=3.3.3,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:e6ec84b796f6af4bb5357aaf28aee0c0005f4dea

**Packages**:
- blast=2.15.0
- fasttree=2.1.11
- chewbbaca=3.3.3
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- CreateSchema.xml
- AlleleCallEvaluator.xml
- AlleleCall.xml
- ExtractCgMLST.xml
- NSStats.xml
- JoinProfiles.xml
- DownloadSchema.xml
- PrepExternalSchema.xml

Generated with Planemo.