### PR TITLE
Add container mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:f3370f24695c57921a5f15b5625c16e2df7f9cea.

### DIFF
--- a/combinations/mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:f3370f24695c57921a5f15b5625c16e2df7f9cea-0.tsv
+++ b/combinations/mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:f3370f24695c57921a5f15b5625c16e2df7f9cea-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.5,tar=1.34,findutils=4.6.0,merqury=1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-18b619b415d9ff69d3a7bacbbb7b09f45ba1a215:f3370f24695c57921a5f15b5625c16e2df7f9cea

**Packages**:
- coreutils=9.5
- tar=1.34
- findutils=4.6.0
- merqury=1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- merqury.xml
- merqury_plot_CN.xml

Generated with Planemo.