### PR TITLE
Add container mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:2bd7dab395cc455bfc2ed75eba4a9402fe0a4664.

### DIFF
--- a/combinations/mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:2bd7dab395cc455bfc2ed75eba4a9402fe0a4664-0.tsv
+++ b/combinations/mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:2bd7dab395cc455bfc2ed75eba4a9402fe0a4664-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+getorganelle=1.7.7.1,biopython=1.79	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e8c2e84f6f77f1b96eea684ec6d1d231511ee6fa:2bd7dab395cc455bfc2ed75eba4a9402fe0a4664

**Packages**:
- getorganelle=1.7.7.1
- biopython=1.79
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- get_annotated_regions_from_gb.xml

Generated with Planemo.