### PR TITLE
Updates to include coreutils package

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -468,7 +468,7 @@ bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
 perl==5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
 tophat=2.1.1,samtools=1.17
-perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep
+perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep,sort
 python=3.7.9,pandas=1.3.4,numpy=1.21.4,pyranges=0.0.115,fire=0.4.0
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -468,7 +468,7 @@ bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
 perl==5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
 tophat=2.1.1,samtools=1.17
-perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep,coreutils
+perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep,coreutils=9.5
 python=3.7.9,pandas=1.3.4,numpy=1.21.4,pyranges=0.0.115,fire=0.4.0
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -468,7 +468,7 @@ bedtools=2.31.0,samtools=1.17,ucsc-wigtobigwig=447
 r-base=4.0.2,vcftools=0.1.14-0
 perl==5.26.2,perl-sort-key=1.33,perl-yaml-libyaml=0.88
 tophat=2.1.1,samtools=1.17
-perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep,sort
+perl=5.26.2,r=3.6.0,bcftools=1.13,bedtools=2.30.0,bc=1.07.1,grep,coreutils
 python=3.7.9,pandas=1.3.4,numpy=1.21.4,pyranges=0.0.115,fire=0.4.0
 python=3.6.15,matplotlib=3.3.4,numpy=1.19.5,pyvcf=0.6.8,pysam=0.15.4,htslib=1.9
 r-base=3.5,bioconductor-htqpcr=1.36.0,bioconductor-rankprod=3.8.0,bioconductor-impute=1.56.0,r-bbmisc=1.11.0,r-psych=1.8.4,r-zoo=1.8_3,bioconductor-normqpcr=1.28.0,r-rgl=0.99.16


### PR DESCRIPTION
Mulled container I created in #2746 includes busybox `sort`, but I need GNU `sort`. This PR updates this mulled container to include `coreutils` package, which has the GNU `sort`.