### PR TITLE
Add container mulled-v2-011766e5c1cef90c98f1ba0fcfc5dbbbb437ccfc:1eb9f17882797462b71374c53ec5fa28a76d298b.

### DIFF
--- a/combinations/mulled-v2-011766e5c1cef90c98f1ba0fcfc5dbbbb437ccfc:1eb9f17882797462b71374c53ec5fa28a76d298b-0.tsv
+++ b/combinations/mulled-v2-011766e5c1cef90c98f1ba0fcfc5dbbbb437ccfc:1eb9f17882797462b71374c53ec5fa28a76d298b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bashlex=0.18,segalign-full=0.1.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-011766e5c1cef90c98f1ba0fcfc5dbbbb437ccfc:1eb9f17882797462b71374c53ec5fa28a76d298b

**Packages**:
- bashlex=0.18
- segalign-full=0.1.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- segalign.xml

Generated with Planemo.