### PR TITLE
Add container mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:6f377b357ec394a088a930211417c4e638eddbac.

### DIFF
--- a/combinations/mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:6f377b357ec394a088a930211417c4e638eddbac-0.tsv
+++ b/combinations/mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:6f377b357ec394a088a930211417c4e638eddbac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+cnvkit=0.9.11,scikit-learn=1.4.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-50663d6e00edeea59fd06d601e1c7fc4ead2e51e:6f377b357ec394a088a930211417c4e638eddbac

**Packages**:
- cnvkit=0.9.11
- scikit-learn=1.4.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- antitarget.xml
- target.xml
- segmetrics.xml
- batch.xml
- fix.xml
- heatmap.xml
- coverage.xml
- scatter.xml
- autobin.xml
- breaks.xml
- access.xml
- call.xml
- reference.xml
- sex.xml
- diagram.xml
- segment.xml
- genemetrics.xml

Generated with Planemo.