### PR TITLE
Add container mulled-v2-5c6e61450ba38e4f7906cf8cc248ae33684f67bd:6d00578a535668f6e1dd2a24470b75f86d519bec.

### DIFF
--- a/combinations/mulled-v2-5c6e61450ba38e4f7906cf8cc248ae33684f67bd:6d00578a535668f6e1dd2a24470b75f86d519bec-0.tsv
+++ b/combinations/mulled-v2-5c6e61450ba38e4f7906cf8cc248ae33684f67bd:6d00578a535668f6e1dd2a24470b75f86d519bec-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-metabocoreutils=1.10.0,bioconductor-spectra=1.12.0,bioconductor-msbackendmsp=1.6.0,r-envipat=2.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5c6e61450ba38e4f7906cf8cc248ae33684f67bd:6d00578a535668f6e1dd2a24470b75f86d519bec

**Packages**:
- bioconductor-metabocoreutils=1.10.0
- bioconductor-spectra=1.12.0
- bioconductor-msbackendmsp=1.6.0
- r-envipat=2.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- isolib.xml

Generated with Planemo.