### PR TITLE
Add container mulled-v2-610d25529c11a156b6267fff206bae2224f7db71:ea919c16c461d3f026eede36b1358b03b524d64d.

### DIFF
--- a/combinations/mulled-v2-610d25529c11a156b6267fff206bae2224f7db71:ea919c16c461d3f026eede36b1358b03b524d64d-0.tsv
+++ b/combinations/mulled-v2-610d25529c11a156b6267fff206bae2224f7db71:ea919c16c461d3f026eede36b1358b03b524d64d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-envipat=2.6,bioconductor-msbackendmsp=1.6.0,bioconductor-spectra=1.12.0,bioconductor-metabocoreutils=1.10.0,r-readr=2.1.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-610d25529c11a156b6267fff206bae2224f7db71:ea919c16c461d3f026eede36b1358b03b524d64d

**Packages**:
- r-envipat=2.6
- bioconductor-msbackendmsp=1.6.0
- bioconductor-spectra=1.12.0
- bioconductor-metabocoreutils=1.10.0
- r-readr=2.1.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- isolib.xml

Generated with Planemo.