### PR TITLE
Add container mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:5c10a5620e4a5ff0a946d9c97874e0a44a243985.

### DIFF
--- a/combinations/mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:5c10a5620e4a5ff0a946d9c97874e0a44a243985-0.tsv
+++ b/combinations/mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:5c10a5620e4a5ff0a946d9c97874e0a44a243985-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.23.3,scikit-image=0.18.1,tifffile=2020.10.1,giatools=0.1,pandas=2.2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:5c10a5620e4a5ff0a946d9c97874e0a44a243985

**Packages**:
- numpy=1.23.3
- scikit-image=0.18.1
- tifffile=2020.10.1
- giatools=0.1
- pandas=2.2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- 2d_feature_extraction.xml

Generated with Planemo.