### PR TITLE
Add container mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:358f84dad5002f3d34151195bdc0807a74319407.

### DIFF
--- a/combinations/mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:358f84dad5002f3d34151195bdc0807a74319407-0.tsv
+++ b/combinations/mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:358f84dad5002f3d34151195bdc0807a74319407-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,numpy=1.26.4,scikit-image=0.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:358f84dad5002f3d34151195bdc0807a74319407

**Packages**:
- giatools=0.1
- numpy=1.26.4
- scikit-image=0.22.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- image_math.xml

Generated with Planemo.