### PR TITLE
Add container mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:effd12f11129d05da09bd39207e750638a863c44.

### DIFF
--- a/combinations/mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:effd12f11129d05da09bd39207e750638a863c44-0.tsv
+++ b/combinations/mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:effd12f11129d05da09bd39207e750638a863c44-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scipy=1.12.0,numpy=1.26.4,scikit-image=0.22.0,tifffile=2024.2.12,giatools=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:effd12f11129d05da09bd39207e750638a863c44

**Packages**:
- scipy=1.12.0
- numpy=1.26.4
- scikit-image=0.22.0
- tifffile=2024.2.12
- giatools=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- filter.xml

Generated with Planemo.