### PR TITLE
Add container mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:ed2487a31980edcb286be0498dbe4bb9653a4e2e.

### DIFF
--- a/combinations/mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:ed2487a31980edcb286be0498dbe4bb9653a4e2e-0.tsv
+++ b/combinations/mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:ed2487a31980edcb286be0498dbe4bb9653a4e2e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.23.3,scikit-image=0.18.1,tifffile=2020.10.1,scipy=1.13.0,giatools=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-59b37dc772fcd321b9e695c76dd19b94a8765971:ed2487a31980edcb286be0498dbe4bb9653a4e2e

**Packages**:
- numpy=1.23.3
- scikit-image=0.18.1
- tifffile=2020.10.1
- scipy=1.13.0
- giatools=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- slice_image.xml

Generated with Planemo.