### PR TITLE
Add container mulled-v2-3d3f711fe6839930a8c445eee29baa27b67145bf:e21c53b6a8567d30d6760e0b0b1671eaa51ffe42.

### DIFF
--- a/combinations/mulled-v2-3d3f711fe6839930a8c445eee29baa27b67145bf:e21c53b6a8567d30d6760e0b0b1671eaa51ffe42-0.tsv
+++ b/combinations/mulled-v2-3d3f711fe6839930a8c445eee29baa27b67145bf:e21c53b6a8567d30d6760e0b0b1671eaa51ffe42-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.20,cvxpy=1.1.13,scipy=1.6.3,mkl=2020.0,scikit-image=0.18.1,blas=1.0=mkl,giatools=0.1.1,cvxopt=1.2.6,ray-core=1.6.0,superdsm=0.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3d3f711fe6839930a8c445eee29baa27b67145bf:e21c53b6a8567d30d6760e0b0b1671eaa51ffe42

**Packages**:
- numpy=1.20
- cvxpy=1.1.13
- scipy=1.6.3
- mkl=2020.0
- scikit-image=0.18.1
- blas=1.0=mkl
- giatools=0.1.1
- cvxopt=1.2.6
- ray-core=1.6.0
- superdsm=0.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- superdsm.xml

Generated with Planemo.