### PR TITLE
Add container mulled-v2-b0797a38ef74f078f551be376cb647aa4c44394d:53b8ff202310fe2d3d01e9ef57d30f23a7c57212.

### DIFF
--- a/combinations/mulled-v2-b0797a38ef74f078f551be376cb647aa4c44394d:53b8ff202310fe2d3d01e9ef57d30f23a7c57212-0.tsv
+++ b/combinations/mulled-v2-b0797a38ef74f078f551be376cb647aa4c44394d:53b8ff202310fe2d3d01e9ef57d30f23a7c57212-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tifffile=2020.10.1,pandas=2.2.2,scikit-image=0.18.1,giatools=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b0797a38ef74f078f551be376cb647aa4c44394d:53b8ff202310fe2d3d01e9ef57d30f23a7c57212

**Packages**:
- tifffile=2020.10.1
- pandas=2.2.2
- scikit-image=0.18.1
- giatools=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- 2d_filter_segmentation_by_features.xml

Generated with Planemo.