### PR TITLE
Add container mulled-v2-58eed1d464ac6df4d57e4207a92ccbc162cef880:770123dc2cab961f5c3bdb2d61fe0db32164bc76.

### DIFF
--- a/combinations/mulled-v2-58eed1d464ac6df4d57e4207a92ccbc162cef880:770123dc2cab961f5c3bdb2d61fe0db32164bc76-0.tsv
+++ b/combinations/mulled-v2-58eed1d464ac6df4d57e4207a92ccbc162cef880:770123dc2cab961f5c3bdb2d61fe0db32164bc76-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,numpy=1.20,medpy=0.4.0,scikit-image=0.18.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-58eed1d464ac6df4d57e4207a92ccbc162cef880:770123dc2cab961f5c3bdb2d61fe0db32164bc76

**Packages**:
- giatools=0.1
- numpy=1.20
- medpy=0.4.0
- scikit-image=0.18.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- anisotropic_diffusion.xml

Generated with Planemo.