### PR TITLE
Add container mulled-v2-836b9b36e4d38833683154e16dfbb618e169de7d:9c3507e8cbf7898d4a366ea4b792a61962acf297.

### DIFF
--- a/combinations/mulled-v2-836b9b36e4d38833683154e16dfbb618e169de7d:9c3507e8cbf7898d4a366ea4b792a61962acf297-0.tsv
+++ b/combinations/mulled-v2-836b9b36e4d38833683154e16dfbb618e169de7d:9c3507e8cbf7898d4a366ea4b792a61962acf297-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,networkx=3.2.1,scikit-image=0.18.1,numpy=1.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-836b9b36e4d38833683154e16dfbb618e169de7d:9c3507e8cbf7898d4a366ea4b792a61962acf297

**Packages**:
- giatools=0.1
- networkx=3.2.1
- scikit-image=0.18.1
- numpy=1.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- colorize_labels.xml

Generated with Planemo.