### PR TITLE
Add container mulled-v2-cda17ae6e704c03b90ac5363e2f0d2e9541adcca:4ed37b7f0218a61f7a0ce6a2c06650d521c2b4b0.

### DIFF
--- a/combinations/mulled-v2-cda17ae6e704c03b90ac5363e2f0d2e9541adcca:4ed37b7f0218a61f7a0ce6a2c06650d521c2b4b0-0.tsv
+++ b/combinations/mulled-v2-cda17ae6e704c03b90ac5363e2f0d2e9541adcca:4ed37b7f0218a61f7a0ce6a2c06650d521c2b4b0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tifffile=2020.10.1,numpy=1.23.3,scikit-image=0.18.1,giatools=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cda17ae6e704c03b90ac5363e2f0d2e9541adcca:4ed37b7f0218a61f7a0ce6a2c06650d521c2b4b0

**Packages**:
- tifffile=2020.10.1
- numpy=1.23.3
- scikit-image=0.18.1
- giatools=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- split_labelmap.xml
- histogram_equalization.xml

Generated with Planemo.