### PR TITLE
Add container mulled-v2-b650fd76c895d77c3bcac2cdbf026916b381d8ab:fde5df11a0ada32101ac6c988ed52a3bdca641f7.

### DIFF
--- a/combinations/mulled-v2-b650fd76c895d77c3bcac2cdbf026916b381d8ab:fde5df11a0ada32101ac6c988ed52a3bdca641f7-0.tsv
+++ b/combinations/mulled-v2-b650fd76c895d77c3bcac2cdbf026916b381d8ab:fde5df11a0ada32101ac6c988ed52a3bdca641f7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,scipy=1.12.0,scikit-image=0.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b650fd76c895d77c3bcac2cdbf026916b381d8ab:fde5df11a0ada32101ac6c988ed52a3bdca641f7

**Packages**:
- giatools=0.1
- scipy=1.12.0
- scikit-image=0.22.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- morphological_operations.xml

Generated with Planemo.