### PR TITLE
Add container mulled-v2-88265e98fd58dfe97b679d20a28bc4bccd5c6aea:6951e6dbf73afe8ed59889adbc9bc3502d284210.

### DIFF
--- a/combinations/mulled-v2-88265e98fd58dfe97b679d20a28bc4bccd5c6aea:6951e6dbf73afe8ed59889adbc9bc3502d284210-0.tsv
+++ b/combinations/mulled-v2-88265e98fd58dfe97b679d20a28bc4bccd5c6aea:6951e6dbf73afe8ed59889adbc9bc3502d284210-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,numpy=1.26.4,scipy=1.12.0,scikit-image=0.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-88265e98fd58dfe97b679d20a28bc4bccd5c6aea:6951e6dbf73afe8ed59889adbc9bc3502d284210

**Packages**:
- giatools=0.1
- numpy=1.26.4
- scipy=1.12.0
- scikit-image=0.22.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- voronoi_tessellation.xml

Generated with Planemo.