### PR TITLE
Add container mulled-v2-05cf43442a9cbaa9f9bd04c1ce69c6825753af93:278925ddb2e0c41bb8fb9c63af79f8a32fe80901.

### DIFF
--- a/combinations/mulled-v2-05cf43442a9cbaa9f9bd04c1ce69c6825753af93:278925ddb2e0c41bb8fb9c63af79f8a32fe80901-0.tsv
+++ b/combinations/mulled-v2-05cf43442a9cbaa9f9bd04c1ce69c6825753af93:278925ddb2e0c41bb8fb9c63af79f8a32fe80901-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tifffile=2021.7.2,scikit-image=0.18.3,giatools=0.1,numpy=1.24.4,pillow=10.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-05cf43442a9cbaa9f9bd04c1ce69c6825753af93:278925ddb2e0c41bb8fb9c63af79f8a32fe80901

**Packages**:
- tifffile=2021.7.2
- scikit-image=0.18.3
- giatools=0.1
- numpy=1.24.4
- pillow=10.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- scale_image.xml

Generated with Planemo.