### PR TITLE
Add container mulled-v2-5cff1ba4f2e5d001161801a13e98277593018bc8:75880e377b0d5ff10d0be10fae79c73eb89d010b.

### DIFF
--- a/combinations/mulled-v2-5cff1ba4f2e5d001161801a13e98277593018bc8:75880e377b0d5ff10d0be10fae79c73eb89d010b-0.tsv
+++ b/combinations/mulled-v2-5cff1ba4f2e5d001161801a13e98277593018bc8:75880e377b0d5ff10d0be10fae79c73eb89d010b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,orientationpy=0.2.0.4,scikit-image=0.22.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5cff1ba4f2e5d001161801a13e98277593018bc8:75880e377b0d5ff10d0be10fae79c73eb89d010b

**Packages**:
- giatools=0.1
- orientationpy=0.2.0.4
- scikit-image=0.22.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- orientationpy.xml

Generated with Planemo.