### PR TITLE
Add container mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:b58ba687da160238dccca2252212bd7c1ec00ab0.

### DIFF
--- a/combinations/mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:b58ba687da160238dccca2252212bd7c1ec00ab0-0.tsv
+++ b/combinations/mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:b58ba687da160238dccca2252212bd7c1ec00ab0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.1,scikit-image=0.18.1,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-98c90af92ba1f2e32d552f245afad4b233dddad1:b58ba687da160238dccca2252212bd7c1ec00ab0

**Packages**:
- giatools=0.1
- scikit-image=0.18.1
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- repeat_channels.xml

Generated with Planemo.