### PR TITLE
Add container mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:3c27a795bb93f7f03fe71735c3180bb6cab93b72.

### DIFF
--- a/combinations/mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:3c27a795bb93f7f03fe71735c3180bb6cab93b72-0.tsv
+++ b/combinations/mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:3c27a795bb93f7f03fe71735c3180bb6cab93b72-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+primer3-py=2.0.1,varvamp=1.1.3,seqfold=0.7.17	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:3c27a795bb93f7f03fe71735c3180bb6cab93b72

**Packages**:
- primer3-py=2.0.1
- varvamp=1.1.3
- seqfold=0.7.17
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- varvamp.xml

Generated with Planemo.