### PR TITLE
Add container mulled-v2-b1ce9fefe9e1e393bb34bf36a3ea3b5e5c07dec8:cf8c97b7da309efe473436eec329389d9131f7e6.

### DIFF
--- a/combinations/mulled-v2-b1ce9fefe9e1e393bb34bf36a3ea3b5e5c07dec8:cf8c97b7da309efe473436eec329389d9131f7e6-0.tsv
+++ b/combinations/mulled-v2-b1ce9fefe9e1e393bb34bf36a3ea3b5e5c07dec8:cf8c97b7da309efe473436eec329389d9131f7e6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+networkx=1.11,reago=1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b1ce9fefe9e1e393bb34bf36a3ea3b5e5c07dec8:cf8c97b7da309efe473436eec329389d9131f7e6

**Packages**:
- networkx=1.11
- reago=1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- reago.xml

Generated with Planemo.