### PR TITLE
Add container mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:9551ae084ed50b7711a0bb879edf673e48c251ec.

### DIFF
--- a/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:9551ae084ed50b7711a0bb879edf673e48c251ec-0.tsv
+++ b/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:9551ae084ed50b7711a0bb879edf673e48c251ec-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+stringtie=2.2.2,samtools=1.20	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:9551ae084ed50b7711a0bb879edf673e48c251ec

**Packages**:
- stringtie=2.2.2
- samtools=1.20
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stringtie.xml
- stringtie_merge.xml

Generated with Planemo.