### PR TITLE
Add container mulled-v2-74f87402a3cae5d74dee4372a7474f932cce15a9:c87b0465f253ee822f854bc9da985363013bb565.

### DIFF
--- a/combinations/mulled-v2-74f87402a3cae5d74dee4372a7474f932cce15a9:c87b0465f253ee822f854bc9da985363013bb565-0.tsv
+++ b/combinations/mulled-v2-74f87402a3cae5d74dee4372a7474f932cce15a9:c87b0465f253ee822f854bc9da985363013bb565-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bashlex=0.18,python=3.12,segalign-full=0.1.2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-74f87402a3cae5d74dee4372a7474f932cce15a9:c87b0465f253ee822f854bc9da985363013bb565

**Packages**:
- bashlex=0.18
- python=3.12
- segalign-full=0.1.2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- segalign.xml

Generated with Planemo.