### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:b840dab9bb1c96cd16a035653a2cc47a903ae322.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:b840dab9bb1c96cd16a035653a2cc47a903ae322-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:b840dab9bb1c96cd16a035653a2cc47a903ae322-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mosdepth=0.3.8,gzip=1.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:b840dab9bb1c96cd16a035653a2cc47a903ae322

**Packages**:
- mosdepth=0.3.8
- gzip=1.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.