### PR TITLE
Add `kma=1.4.9,samtools=1.20` combination

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -582,3 +582,4 @@ r-base=4.2.1,r-proteus-bartongroup=0.2.16,bioconductor-limma=3.54.0,r-plotly=4.1
 segalign-full=0.1.2.1,bashlex=0.18
 r-base=4.3,r-dartr,r-pophelper,r-reshape2,r-vcfr
 bwa=0.7.18,samtools=1.20,sambamba=1.0
+kma=1.4.14,samtools=1.20

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -583,3 +583,4 @@ segalign-full=0.1.2.1,bashlex=0.18
 r-base=4.3,r-dartr,r-pophelper,r-reshape2,r-vcfr
 bwa=0.7.18,samtools=1.20,sambamba=1.0
 kma=1.4.14,samtools=1.20
+kma=1.4.9,samtools=1.20


### PR DESCRIPTION
Adding a mulled container with `kma=1.4.9,samtools=1.20` due to an issue with piping `kma` output to `samtools` in `kma=1.4.14` (https://github.com/arpcard/rgi/issues/273).