### PR TITLE
Add container mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:55697c6a1184380a39dd7cd9dd28753b9f263dce.

### DIFF
--- a/combinations/mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:55697c6a1184380a39dd7cd9dd28753b9f263dce-0.tsv
+++ b/combinations/mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:55697c6a1184380a39dd7cd9dd28753b9f263dce-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+varvamp=1.2.0,seqfold=0.7.17,primer3-py=2.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b5c018a50c354783462ee725dfd710a92289c489:55697c6a1184380a39dd7cd9dd28753b9f263dce

**Packages**:
- varvamp=1.2.0
- seqfold=0.7.17
- primer3-py=2.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- varvamp.xml

Generated with Planemo.