### PR TITLE
Add container mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:b3c012f26a7d4eba804b5c3f70ec20f899f97bb8.

### DIFF
--- a/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:b3c012f26a7d4eba804b5c3f70ec20f899f97bb8-0.tsv
+++ b/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:b3c012f26a7d4eba804b5c3f70ec20f899f97bb8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.20,stringtie=2.2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:b3c012f26a7d4eba804b5c3f70ec20f899f97bb8

**Packages**:
- samtools=1.20
- stringtie=2.2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stringtie.xml
- stringtie_merge.xml

Generated with Planemo.