### PR TITLE
Add container mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e.

### DIFF
--- a/combinations/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e-0.tsv
+++ b/combinations/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.20,bwa=0.7.18	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e

**Packages**:
- samtools=1.20
- bwa=0.7.18
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bwa-mem.xml
- bwa.xml

Generated with Planemo.