### PR TITLE
Add container mulled-v2-eafd06e894832ae3b8eed97d9bac79eebfb7c689:594f892e6d4e84e8958c7eda8edaf6449d93f81e.

### DIFF
--- a/combinations/mulled-v2-eafd06e894832ae3b8eed97d9bac79eebfb7c689:594f892e6d4e84e8958c7eda8edaf6449d93f81e-0.tsv
+++ b/combinations/mulled-v2-eafd06e894832ae3b8eed97d9bac79eebfb7c689:594f892e6d4e84e8958c7eda8edaf6449d93f81e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19.2,irissv=1.0.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-eafd06e894832ae3b8eed97d9bac79eebfb7c689:594f892e6d4e84e8958c7eda8edaf6449d93f81e

**Packages**:
- samtools=1.19.2
- irissv=1.0.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- irissv.xml

Generated with Planemo.