### PR TITLE
Add container mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:caa33073524aca7a4919ccd6ac088104e51e441a.

### DIFF
--- a/combinations/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:caa33073524aca7a4919ccd6ac088104e51e441a-0.tsv
+++ b/combinations/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:caa33073524aca7a4919ccd6ac088104e51e441a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.18,bedtools=2.31.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:caa33073524aca7a4919ccd6ac088104e51e441a

**Packages**:
- samtools=1.18
- bedtools=2.31.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- coverageBed.xml
- bamToBed.xml
- intersectBed.xml

Generated with Planemo.