### PR TITLE
Add container mulled-v2-54cca3e236d52994142944fa1a8c71d2b6d6f5da:0cd80860ece108ea6db0916304205642a0ea86e0.

### DIFF
--- a/combinations/mulled-v2-54cca3e236d52994142944fa1a8c71d2b6d6f5da:0cd80860ece108ea6db0916304205642a0ea86e0-0.tsv
+++ b/combinations/mulled-v2-54cca3e236d52994142944fa1a8c71d2b6d6f5da:0cd80860ece108ea6db0916304205642a0ea86e0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie=1.2.0,python=3.8.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-54cca3e236d52994142944fa1a8c71d2b6d6f5da:0cd80860ece108ea6db0916304205642a0ea86e0

**Packages**:
- bowtie=1.2.0
- python=3.8.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bowtie_color_space_index_builder.xml
- bowtie_index_builder.xml

Generated with Planemo.