### PR TITLE
Add container mulled-v2-0cf2748ad115082bb43c94fa6543efe22832eb80:5d1c3833e2c002e615711c0eb3bcf72f28416697.

### DIFF
--- a/combinations/mulled-v2-0cf2748ad115082bb43c94fa6543efe22832eb80:5d1c3833e2c002e615711c0eb3bcf72f28416697-0.tsv
+++ b/combinations/mulled-v2-0cf2748ad115082bb43c94fa6543efe22832eb80:5d1c3833e2c002e615711c0eb3bcf72f28416697-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8.3,picard=1.56.0,samtools=0.1.18	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0cf2748ad115082bb43c94fa6543efe22832eb80:5d1c3833e2c002e615711c0eb3bcf72f28416697

**Packages**:
- python=3.8.3
- picard=1.56.0
- samtools=0.1.18
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_gatk_picard_index_builder.xml

Generated with Planemo.