### PR TITLE
Add container mulled-v2-6c7b9c5e64192bee6b00fd3abae67f4f17a445cf:70fb62b3ba7ab0b3dc8358f560ce29045dc2e7af.

### DIFF
--- a/combinations/mulled-v2-6c7b9c5e64192bee6b00fd3abae67f4f17a445cf:70fb62b3ba7ab0b3dc8358f560ce29045dc2e7af-0.tsv
+++ b/combinations/mulled-v2-6c7b9c5e64192bee6b00fd3abae67f4f17a445cf:70fb62b3ba7ab0b3dc8358f560ce29045dc2e7af-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8.3,kraken=1.1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6c7b9c5e64192bee6b00fd3abae67f4f17a445cf:70fb62b3ba7ab0b3dc8358f560ce29045dc2e7af

**Packages**:
- python=3.8.3
- kraken=1.1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kraken_database_builder.xml

Generated with Planemo.