### PR TITLE
Add container mulled-v2-41ac18bc26bb6bdd970eca1e6f8d5754c1351358:c46861c74631255028f348aba83a68b8f6c1842e.

### DIFF
--- a/combinations/mulled-v2-41ac18bc26bb6bdd970eca1e6f8d5754c1351358:c46861c74631255028f348aba83a68b8f6c1842e-0.tsv
+++ b/combinations/mulled-v2-41ac18bc26bb6bdd970eca1e6f8d5754c1351358:c46861c74631255028f348aba83a68b8f6c1842e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8.3,kallisto=0.43.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-41ac18bc26bb6bdd970eca1e6f8d5754c1351358:c46861c74631255028f348aba83a68b8f6c1842e

**Packages**:
- python=3.8.3
- kallisto=0.43.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kallisto_index_builder.xml

Generated with Planemo.