### PR TITLE
Update Sambamba to 1.0.1 in recent containers

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -319,7 +319,7 @@ svdb=2.8.1,samtools=1.16.1
 svdb=2.8.1,samtools=1.19.2
 r-base=4.1.2,changeo=1.2.0,r-alakazam=1.2.0,phylip=3.697,r-optparse=1.7.1
 ont-fast5-api=0.4.1,r-tailfindr=1.3.0
-gatk4=4.2.6.1,samtools=1.15.1,sambamba=0.8.2,bcftools=1.15.1,perl=5.32.1,r-base=4.1.2
+gatk4=4.2.6.1,samtools=1.15.1,sambamba=1.0.1,bcftools=1.15.1,perl=5.32.1,r-base=4.1.2
 bwa=0.7.17,prinseq-plus-plus=1.2.4,perl=5.26
 levenshtein=0.20.1
 pysam=0.19.1,edlib=1.3.9,tqdm=4.64.0
@@ -548,7 +548,7 @@ pyrodigal=3.3.0,pigz=2.6
 kraken2=2.1.3,gnu-coreutils=9.4
 macs2=2.2.9.1,mawk=1.3.4
 kraken2=2.1.3,coreutils=9.4
-bwa=0.7.17,samtools=1.19.2,sambamba=1.0
+bwa=0.7.17,samtools=1.19.2,sambamba=1.0.1
 optitype=1.3.5,coincbc=2.10.0
 python=3.11.0,requests=2.31.0,biopython=1.83.0
 r-hwriter=1.3.2,r-ggplot2=3.4.4,r-ini=0.3.1,r-ashr=2.2_63,r-dplyr=1.1.4,r-ggrepel=0.9.5,r-png=0.1_8,bioconductor-reportingtools=2.42.2,bioconductor-deseq2=1.42.0,bioconductor-complexheatmap=2.18.0,bioconductor-tximport=1.30.0
@@ -564,7 +564,7 @@ r-base=4.3,r-catboost=1.2,r-ABCanalysis=1.2,r-C50=0.1.8,r-caret=6.0,r-data.table
 picard=3.1.1,samtools=1.19.2
 bedtools=2.31.1,ucsc-bedgraphtobigwig=445,samtools=1.16.1
 star=2.7.11b,samtools=1.19.2,mawk=1.3.4
-bwa-mem2=2.2.1,samtools=1.19.2,sambamba=1.0
+bwa-mem2=2.2.1,samtools=1.19.2,sambamba=1.0.1
 decoupler-py=1.6.0,pandas=2.2.1
 crabz=0.9.0
 panphlan=3.1,bzip2=1.0.8
@@ -581,7 +581,7 @@ bedtools=2.31.1,samtools=1.19.2,python=3.11.4
 r-base=4.2.1,r-proteus-bartongroup=0.2.16,bioconductor-limma=3.54.0,r-plotly=4.10.2,r-ggplot2=3.4.4
 segalign-full=0.1.2.1,bashlex=0.18
 r-base=4.3,r-dartr,r-pophelper,r-reshape2,r-vcfr
-bwa=0.7.18,samtools=1.20,sambamba=1.0
+bwa=0.7.18,samtools=1.20,sambamba=1.0.1
 kma=1.4.14,samtools=1.20
 kma=1.4.9,samtools=1.20
 bwa-meme=1.0.6,mbuffer=20160228,samtools=1.20


### PR DESCRIPTION
- the Bioconda Sambamba package >=0.8.1,<=1.0=h98b6b92_0 uses an unoptimised binary, see:
  - https://github.com/bioconda/bioconda-recipes/pull/48071
  - https://github.com/bioconda/bioconda-recipes/pull/48074
- this change updates all affected containers to the latest fixed Sambamba package