### PR TITLE
Add container mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:756fe1b5be80e4a6ec32e64796d213bde016d726.

### DIFF
--- a/combinations/mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:756fe1b5be80e4a6ec32e64796d213bde016d726-0.tsv
+++ b/combinations/mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:756fe1b5be80e4a6ec32e64796d213bde016d726-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+frogs=4.1.0,swarm=3.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:756fe1b5be80e4a6ec32e64796d213bde016d726

**Packages**:
- frogs=4.1.0
- swarm=3.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- clustering.xml

Generated with Planemo.