### PR TITLE
Add container mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:9bec5bad67876ca8f90aa229e9df30393c63cd17.

### DIFF
--- a/combinations/mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:9bec5bad67876ca8f90aa229e9df30393c63cd17-0.tsv
+++ b/combinations/mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:9bec5bad67876ca8f90aa229e9df30393c63cd17-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+emboss=6.6.0,frogs=4.1.0,blast=2.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:9bec5bad67876ca8f90aa229e9df30393c63cd17

**Packages**:
- emboss=6.6.0
- frogs=4.1.0
- blast=2.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- taxonomic_affiliation.xml

Generated with Planemo.