### PR TITLE
Add container mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:fc05fd5c0e4b90dbdc4e9d4391cd40d9a39d5b6f.

### DIFF
--- a/combinations/mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:fc05fd5c0e4b90dbdc4e9d4391cd40d9a39d5b6f-0.tsv
+++ b/combinations/mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:fc05fd5c0e4b90dbdc4e9d4391cd40d9a39d5b6f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+frogs=4.1.0,itsx=1.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:fc05fd5c0e4b90dbdc4e9d4391cd40d9a39d5b6f

**Packages**:
- frogs=4.1.0
- itsx=1.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- itsx.xml

Generated with Planemo.