### PR TITLE
Add container mulled-v2-b0ec20b47821f007011bf96a330aac2e98102ede:03d3935c8f4095783ce7191be497dca9967a98e4.

### DIFF
--- a/combinations/mulled-v2-b0ec20b47821f007011bf96a330aac2e98102ede:03d3935c8f4095783ce7191be497dca9967a98e4-0.tsv
+++ b/combinations/mulled-v2-b0ec20b47821f007011bf96a330aac2e98102ede:03d3935c8f4095783ce7191be497dca9967a98e4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-dt=0.18,r-base=4.1.2,r-essentials=4.1,bioconductor-phyloseq=1.38.0,frogs=4.1.0,bioconductor-deseq2=1.34.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b0ec20b47821f007011bf96a330aac2e98102ede:03d3935c8f4095783ce7191be497dca9967a98e4

**Packages**:
- r-dt=0.18
- r-base=4.1.2
- r-essentials=4.1
- bioconductor-phyloseq=1.38.0
- frogs=4.1.0
- bioconductor-deseq2=1.34.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deseq2_visualisation.xml

Generated with Planemo.