### PR TITLE
Add container mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:0ee06cb3c4bbe21591e4554382f7c0e1491fdc50.

### DIFF
--- a/combinations/mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:0ee06cb3c4bbe21591e4554382f7c0e1491fdc50-0.tsv
+++ b/combinations/mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:0ee06cb3c4bbe21591e4554382f7c0e1491fdc50-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-plotly=4.9.3,r-base=4.1.2,r-essentials=4.1,bioconductor-phyloseq=1.38.0,frogs=4.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:0ee06cb3c4bbe21591e4554382f7c0e1491fdc50

**Packages**:
- r-plotly=4.9.3
- r-base=4.1.2
- r-essentials=4.1
- bioconductor-phyloseq=1.38.0
- frogs=4.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- phyloseq_composition.xml
- phyloseq_structure.xml

Generated with Planemo.