### PR TITLE
Add container mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:df1ba53572a52c128ac32418b66531e1b061e9f9.

### DIFF
--- a/combinations/mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:df1ba53572a52c128ac32418b66531e1b061e9f9-0.tsv
+++ b/combinations/mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:df1ba53572a52c128ac32418b66531e1b061e9f9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+frogs=4.1.0,blast=2.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:df1ba53572a52c128ac32418b66531e1b061e9f9

**Packages**:
- frogs=4.1.0
- blast=2.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cluster_filters.xml

Generated with Planemo.