### PR TITLE
Add container mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:97cdc6b6bd93ff99cee22c4cd7554705e789ab56.

### DIFF
--- a/combinations/mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:97cdc6b6bd93ff99cee22c4cd7554705e789ab56-0.tsv
+++ b/combinations/mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:97cdc6b6bd93ff99cee22c4cd7554705e789ab56-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mafft=7.407,fasttree=2.1.9,r-essentials=4.1,r-base=4.1.2,frogs=4.1.0,r-phangorn=2.7.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:97cdc6b6bd93ff99cee22c4cd7554705e789ab56

**Packages**:
- mafft=7.407
- fasttree=2.1.9
- r-essentials=4.1
- r-base=4.1.2
- frogs=4.1.0
- r-phangorn=2.7.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tree.xml

Generated with Planemo.