### PR TITLE
Add container mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:3aa68c0564ff9ab90321017262288b2ad035089f.

### DIFF
--- a/combinations/mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:3aa68c0564ff9ab90321017262288b2ad035089f-0.tsv
+++ b/combinations/mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:3aa68c0564ff9ab90321017262288b2ad035089f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+frogs=4.1.0,vsearch=2.17.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:3aa68c0564ff9ab90321017262288b2ad035089f

**Packages**:
- frogs=4.1.0
- vsearch=2.17.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- remove_chimera.xml

Generated with Planemo.