### PR TITLE
Add container mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:b9a71ef587d64da7019719a551495c36448dd310.

### DIFF
--- a/combinations/mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:b9a71ef587d64da7019719a551495c36448dd310-0.tsv
+++ b/combinations/mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:b9a71ef587d64da7019719a551495c36448dd310-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.1.2,r-essentials=4.1,frogs=4.1.0,bioconductor-phyloseq=1.38.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:b9a71ef587d64da7019719a551495c36448dd310

**Packages**:
- r-base=4.1.2
- r-essentials=4.1
- frogs=4.1.0
- bioconductor-phyloseq=1.38.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- phyloseq_alpha_diversity.xml
- phyloseq_manova.xml
- phyloseq_clustering.xml
- phyloseq_import_data.xml

Generated with Planemo.