### PR TITLE
Add container mulled-v2-5c17abaf6539b760e274a0ecc3b9f99c484a633b:1f86f457005bd11d1cb5198dc8942d688e017da2.

### DIFF
--- a/combinations/mulled-v2-5c17abaf6539b760e274a0ecc3b9f99c484a633b:1f86f457005bd11d1cb5198dc8942d688e017da2-0.tsv
+++ b/combinations/mulled-v2-5c17abaf6539b760e274a0ecc3b9f99c484a633b:1f86f457005bd11d1cb5198dc8942d688e017da2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scanpy=1.9.8,matplotlib=3.7,seaborn=0.12.2,cosg=1.0.1,pandas=1.5.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5c17abaf6539b760e274a0ecc3b9f99c484a633b:1f86f457005bd11d1cb5198dc8942d688e017da2

**Packages**:
- scanpy=1.9.8
- matplotlib=3.7
- seaborn=0.12.2
- cosg=1.0.1
- pandas=1.5.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cosg.xml

Generated with Planemo.