### PR TITLE
Add container mulled-v2-a285ad7d249106a69613741e14bf83de29bb407f:4a0ec679d8d83c264af4aa8f41551585f5295846.

### DIFF
--- a/combinations/mulled-v2-a285ad7d249106a69613741e14bf83de29bb407f:4a0ec679d8d83c264af4aa8f41551585f5295846-0.tsv
+++ b/combinations/mulled-v2-a285ad7d249106a69613741e14bf83de29bb407f:4a0ec679d8d83c264af4aa8f41551585f5295846-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8,bakta=1.9.3,requests=2.27.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a285ad7d249106a69613741e14bf83de29bb407f:4a0ec679d8d83c264af4aa8f41551585f5295846

**Packages**:
- python=3.8
- bakta=1.9.3
- requests=2.27.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bakta_build_database.xml

Generated with Planemo.