### PR TITLE
Add container mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:c14499e89a601f8d922939ef07ce1c0eee1625d5.

### DIFF
--- a/combinations/mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:c14499e89a601f8d922939ef07ce1c0eee1625d5-0.tsv
+++ b/combinations/mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:c14499e89a601f8d922939ef07ce1c0eee1625d5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-amrfinderplus=3.12.8,pandas=1.5.1,python=3.10.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:c14499e89a601f8d922939ef07ce1c0eee1625d5

**Packages**:
- ncbi-amrfinderplus=3.12.8
- pandas=1.5.1
- python=3.10.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_build_amrfinderplus.xml

Generated with Planemo.