### PR TITLE
Add container mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a95f0e0ff448eede323315668bfa8ee64c918ebb.

### DIFF
--- a/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a95f0e0ff448eede323315668bfa8ee64c918ebb-0.tsv
+++ b/combinations/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a95f0e0ff448eede323315668bfa8ee64c918ebb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.20,sra-tools=3.1.1,pigz=2.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:a95f0e0ff448eede323315668bfa8ee64c918ebb

**Packages**:
- samtools=1.20
- sra-tools=3.1.1
- pigz=2.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fastq_dump.xml
- sam_dump.xml
- fasterq_dump.xml

Generated with Planemo.