### PR TITLE
Add container mulled-v2-345114f0b78b33ecf35ee6488647d9e7bfcbb849:db6580f58ed4e07661ae464ca3d96c10445f3ab1.

### DIFF
--- a/combinations/mulled-v2-345114f0b78b33ecf35ee6488647d9e7bfcbb849:db6580f58ed4e07661ae464ca3d96c10445f3ab1-0.tsv
+++ b/combinations/mulled-v2-345114f0b78b33ecf35ee6488647d9e7bfcbb849:db6580f58ed4e07661ae464ca3d96c10445f3ab1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mudirac=1.0.1,matplotlib=3.5.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-345114f0b78b33ecf35ee6488647d9e7bfcbb849:db6580f58ed4e07661ae464ca3d96c10445f3ab1

**Packages**:
- mudirac=1.0.1
- matplotlib=3.5.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mudirac.xml

Generated with Planemo.