### PR TITLE
Add container mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:daae02d25acd7e4d71829ba88a0a4a8b20ca1a51.

### DIFF
--- a/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:daae02d25acd7e4d71829ba88a0a4a8b20ca1a51-0.tsv
+++ b/combinations/mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:daae02d25acd7e4d71829ba88a0a4a8b20ca1a51-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2024.2.2,ncbi-datasets-cli=16.20.0,p7zip=16.02	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21b0c588b40a2ac04b248fdac276ac006fecf992:daae02d25acd7e4d71829ba88a0a4a8b20ca1a51

**Packages**:
- ca-certificates=2024.2.2
- ncbi-datasets-cli=16.20.0
- p7zip=16.02
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_gene.xml
- datasets_genome.xml

Generated with Planemo.