### PR TITLE
Add container mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:4547ceb4454697ca216afa82c49a921570a2dab6.

### DIFF
--- a/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:4547ceb4454697ca216afa82c49a921570a2dab6-0.tsv
+++ b/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:4547ceb4454697ca216afa82c49a921570a2dab6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandoc=3.2,gmp=6.3.0,cojac=0.9.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:4547ceb4454697ca216afa82c49a921570a2dab6

**Packages**:
- pandoc=3.2
- gmp=6.3.0
- cojac=0.9.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_pubmut.xml

Generated with Planemo.