### PR TITLE
Add container mulled-v2-291d230364dc586f82da0be8fc0711e98a26e5b1:e0fc4abd171c4fb44adf451fa4b502e1bc03a196.

### DIFF
--- a/combinations/mulled-v2-291d230364dc586f82da0be8fc0711e98a26e5b1:e0fc4abd171c4fb44adf451fa4b502e1bc03a196-0.tsv
+++ b/combinations/mulled-v2-291d230364dc586f82da0be8fc0711e98a26e5b1:e0fc4abd171c4fb44adf451fa4b502e1bc03a196-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12.3,coreutils=9.5,ucsc-bedgraphtobigwig=455,bedtools=2.31.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-291d230364dc586f82da0be8fc0711e98a26e5b1:e0fc4abd171c4fb44adf451fa4b502e1bc03a196

**Packages**:
- python=3.12.3
- coreutils=9.5
- ucsc-bedgraphtobigwig=455
- bedtools=2.31.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bam_bed_gff_to_bigwig.xml

Generated with Planemo.