### PR TITLE
Add container mulled-v2-989a167ee3e464928f8a7b3236d02c4461eabefe:4e70c7617f6f798defeb87ef7c5e62b794e34f50.

### DIFF
--- a/combinations/mulled-v2-989a167ee3e464928f8a7b3236d02c4461eabefe:4e70c7617f6f798defeb87ef7c5e62b794e34f50-0.tsv
+++ b/combinations/mulled-v2-989a167ee3e464928f8a7b3236d02c4461eabefe:4e70c7617f6f798defeb87ef7c5e62b794e34f50-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl-io-gzip=0.20,apptainer,perl-io-zlib=1.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-989a167ee3e464928f8a7b3236d02c4461eabefe:4e70c7617f6f798defeb87ef7c5e62b794e34f50

**Packages**:
- perl-io-gzip=0.20
- apptainer
- perl-io-zlib=1.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- demultiplex.xml

Generated with Planemo.