### PR TITLE
Add container mulled-v2-adc9bb9edc31eb38b3c24786a83b7dfa530e2bea:fa3d4f1502fed7fa8e8afce4f61425a5ea23ca26.

### DIFF
--- a/combinations/mulled-v2-adc9bb9edc31eb38b3c24786a83b7dfa530e2bea:fa3d4f1502fed7fa8e8afce4f61425a5ea23ca26-0.tsv
+++ b/combinations/mulled-v2-adc9bb9edc31eb38b3c24786a83b7dfa530e2bea:fa3d4f1502fed7fa8e8afce4f61425a5ea23ca26-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.8.1,biopython=1.78	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-adc9bb9edc31eb38b3c24786a83b7dfa530e2bea:fa3d4f1502fed7fa8e8afce4f61425a5ea23ca26

**Packages**:
- python=3.8.1
- biopython=1.78
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sequence-splitter.xml

Generated with Planemo.