### PR TITLE
Add container mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:c6e2bf273a7244984b301c7a54fe250b10f76b65.

### DIFF
--- a/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:c6e2bf273a7244984b301c7a54fe250b10f76b65-0.tsv
+++ b/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:c6e2bf273a7244984b301c7a54fe250b10f76b65-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+subread=2.0.0,samtools=1.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:c6e2bf273a7244984b301c7a54fe250b10f76b65

**Packages**:
- subread=2.0.0
- samtools=1.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- featurecounts.xml

Generated with Planemo.