### PR TITLE
Add container gotree:0.3.1.

### DIFF
--- a/combinations/gotree:0.3.1-0.tsv
+++ b/combinations/gotree:0.3.1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gotree=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: gotree:0.3.1

**Packages**:
- gotree=0.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- booster_galaxy.xml

Generated with Planemo.