### PR TITLE
Add container mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:de5e0f1978a7b6717dba24e1f162d8f8a91a322c.

### DIFF
--- a/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:de5e0f1978a7b6717dba24e1f162d8f8a91a322c-0.tsv
+++ b/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:de5e0f1978a7b6717dba24e1f162d8f8a91a322c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+requests=2.25.1,python=3.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:de5e0f1978a7b6717dba24e1f162d8f8a91a322c

**Packages**:
- requests=2.25.1
- python=3.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_pasteurqtl.xml

Generated with Planemo.