### PR TITLE
Add container mulled-v2-2f6e435d4aa1a5abd2820be7bad83f4724be5ce9:62a4f825dbc972cdcffe9cc45942dec8469397cb.

### DIFF
--- a/combinations/mulled-v2-2f6e435d4aa1a5abd2820be7bad83f4724be5ce9:62a4f825dbc972cdcffe9cc45942dec8469397cb-0.tsv
+++ b/combinations/mulled-v2-2f6e435d4aa1a5abd2820be7bad83f4724be5ce9:62a4f825dbc972cdcffe9cc45942dec8469397cb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mrbayes=3.2.7,gotree=0.3.1,goalign=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2f6e435d4aa1a5abd2820be7bad83f4724be5ce9:62a4f825dbc972cdcffe9cc45942dec8469397cb

**Packages**:
- mrbayes=3.2.7
- gotree=0.3.1
- goalign=0.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mrbayes.xml

Generated with Planemo.