### PR TITLE
Add container mulled-v2-fdcde7f8b012dd5952a929882e18729b4dc795ff:1b3ab78b47f40f565bf3ae7b0364ff78439b41bc.

### DIFF
--- a/combinations/mulled-v2-fdcde7f8b012dd5952a929882e18729b4dc795ff:1b3ab78b47f40f565bf3ae7b0364ff78439b41bc-0.tsv
+++ b/combinations/mulled-v2-fdcde7f8b012dd5952a929882e18729b4dc795ff:1b3ab78b47f40f565bf3ae7b0364ff78439b41bc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+parallel=20200222,fasttree=2.1.11,gotree=0.3.1,goalign=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fdcde7f8b012dd5952a929882e18729b4dc795ff:1b3ab78b47f40f565bf3ae7b0364ff78439b41bc

**Packages**:
- parallel=20200222
- fasttree=2.1.11
- gotree=0.3.1
- goalign=0.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fasttree.xml
- fasttree.xml

Generated with Planemo.