### PR TITLE
Add container mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:8b4e203e52e94910beba264e49503d4250155db9.

### DIFF
--- a/combinations/mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:8b4e203e52e94910beba264e49503d4250155db9-0.tsv
+++ b/combinations/mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:8b4e203e52e94910beba264e49503d4250155db9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kallisto=0.46.2,samtools=1.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-143e618e2d6eef454186ce14739a2cabc5ecf645:8b4e203e52e94910beba264e49503d4250155db9

**Packages**:
- kallisto=0.46.2
- samtools=1.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kallisto_quant.xml
- kallisto_pseudo.xml

Generated with Planemo.