### PR TITLE
Add container mulled-v2-e44905e0f4a1fd200870baae917943f846bd2b85:5db3aed1d85889a3a05c339f8a9c212e0b337b0f.

### DIFF
--- a/combinations/mulled-v2-e44905e0f4a1fd200870baae917943f846bd2b85:5db3aed1d85889a3a05c339f8a9c212e0b337b0f-0.tsv
+++ b/combinations/mulled-v2-e44905e0f4a1fd200870baae917943f846bd2b85:5db3aed1d85889a3a05c339f8a9c212e0b337b0f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+libiconv=1.15,r-pheatmap=1.0.10,bioconductor-rhdf5=2.26.2,bioconductor-genomicfeatures=1.34.1,r-ggrepel=0.8.0,libgfortran=3.0.0,r-gplots=3.0.1,r-getopt=1.20.2,r-rjson=0.2.20,bioconductor-tximport=1.10.0,bioconductor-deseq2=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e44905e0f4a1fd200870baae917943f846bd2b85:5db3aed1d85889a3a05c339f8a9c212e0b337b0f

**Packages**:
- libiconv=1.15
- r-pheatmap=1.0.10
- bioconductor-rhdf5=2.26.2
- bioconductor-genomicfeatures=1.34.1
- r-ggrepel=0.8.0
- libgfortran=3.0.0
- r-gplots=3.0.1
- r-getopt=1.20.2
- r-rjson=0.2.20
- bioconductor-tximport=1.10.0
- bioconductor-deseq2=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deseq2.xml

Generated with Planemo.