### PR TITLE
Add plant-seg with extended base image

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -590,4 +590,4 @@ paraphase=3.1.1,minimap2=2.28,samtools=1.20
 bowtie2=2.5.4,samtools=1.20
 vardict-java=1.8.3,htslib=1.4.1
 pyopenms=2.9.1,h5py=3.9.0
-plant-seg=1.8.1,pytorch=2.3.1,bioimageio.spec=0.5.3,pyyaml=6.0.1	bioconda/extended-base-image:latest	0
+plant-seg=1.8.1,pytorch=2.3.1,bioimageio.spec=0.5.3,pyyaml=6.0.1	quay.io/bioconda/base-glibc-debian-bash:latest	0

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -590,3 +590,4 @@ paraphase=3.1.1,minimap2=2.28,samtools=1.20
 bowtie2=2.5.4,samtools=1.20
 vardict-java=1.8.3,htslib=1.4.1
 pyopenms=2.9.1,h5py=3.9.0
+plant-seg=1.8.1,pytorch=2.3.1,bioimageio.spec=0.5.3,pyyaml=6.0.1	bioconda/extended-base-image:latest	0


### PR DESCRIPTION
Add plant-seg with extended base image to hopefully fix the error

> OSError: GL ES 2.0 library not found

in https://github.com/BMCV/galaxy-image-analysis/pull/122.

Packages:
- plant-seg=1.8.1
- pytorch=2.3.1
- bioimageio.spec=0.5.3
- pyyaml=6.0.1	