### PR TITLE
Add container mulled-v2-5651db4442d8ffdc0f486478f33a6ed56364d28f:b3e3254550607ed7032747d4a99e36a14a99286f.

### DIFF
--- a/combinations/mulled-v2-5651db4442d8ffdc0f486478f33a6ed56364d28f:b3e3254550607ed7032747d4a99e36a14a99286f-0.tsv
+++ b/combinations/mulled-v2-5651db4442d8ffdc0f486478f33a6ed56364d28f:b3e3254550607ed7032747d4a99e36a14a99286f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.3.3,r-bold=1.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5651db4442d8ffdc0f486478f33a6ed56364d28f:b3e3254550607ed7032747d4a99e36a14a99286f

**Packages**:
- r-base=4.3.3
- r-bold=1.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- retrieve_bold.xml

Generated with Planemo.