### PR TITLE
Add container mulled-v2-d019bde6cdb2f5776275d0a1353eca763a7a67dd:dab786066faba0d7c939e81e50974844f7174d63.

### DIFF
--- a/combinations/mulled-v2-d019bde6cdb2f5776275d0a1353eca763a7a67dd:dab786066faba0d7c939e81e50974844f7174d63-0.tsv
+++ b/combinations/mulled-v2-d019bde6cdb2f5776275d0a1353eca763a7a67dd:dab786066faba0d7c939e81e50974844f7174d63-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+wget=1.21.4,virsorter=2.2.4,pulp=2.7.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d019bde6cdb2f5776275d0a1353eca763a7a67dd:dab786066faba0d7c939e81e50974844f7174d63

**Packages**:
- wget=1.21.4
- virsorter=2.2.4
- pulp=2.7.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- virsorter_datamanager.xml

Generated with Planemo.