### PR TITLE
Add container mulled-v2-6ae8c78268f054dbb47f98bcfa4b784ee3ef3e0d:6fa88902f5b4d741a3188f6aafb948e4fca5c85f.

### DIFF
--- a/combinations/mulled-v2-6ae8c78268f054dbb47f98bcfa4b784ee3ef3e0d:6fa88902f5b4d741a3188f6aafb948e4fca5c85f-0.tsv
+++ b/combinations/mulled-v2-6ae8c78268f054dbb47f98bcfa4b784ee3ef3e0d:6fa88902f5b4d741a3188f6aafb948e4fca5c85f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+seaborn=0.13.2,last=1548,scikit-learn=0.22.1,virsorter=2.2.4,hmmer=3.4,prodigal=2.6.3,screed=1.1.3,ncbi-genome-download=0.3.3,pandas=1.2.5,imbalanced-learn=0.7.0,pulp=2.7.0,ruamel.yaml=0.16.12,numpy=1.23.5	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6ae8c78268f054dbb47f98bcfa4b784ee3ef3e0d:6fa88902f5b4d741a3188f6aafb948e4fca5c85f

**Packages**:
- seaborn=0.13.2
- last=1548
- scikit-learn=0.22.1
- virsorter=2.2.4
- hmmer=3.4
- prodigal=2.6.3
- screed=1.1.3
- ncbi-genome-download=0.3.3
- pandas=1.2.5
- imbalanced-learn=0.7.0
- pulp=2.7.0
- ruamel.yaml=0.16.12
- numpy=1.23.5
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- virsorter_run.xml

Generated with Planemo.