### PR TITLE
Add container mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:ee4dab561bea9d71851b5173ab9441f8cb75cf41.

### DIFF
--- a/combinations/mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:ee4dab561bea9d71851b5173ab9441f8cb75cf41-0.tsv
+++ b/combinations/mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:ee4dab561bea9d71851b5173ab9441f8cb75cf41-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.6.0,astropy=5.2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:ee4dab561bea9d71851b5173ab9441f8cb75cf41

**Packages**:
- matplotlib=3.6.0
- astropy=5.2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fits2bitmap.xml

Generated with Planemo.