### PR TITLE
Add container mulled-v2-1ce5e37334bc909572dbf75a7a943be7577d6ae9:35bfb2b41e467943573586c964d41936d97d477a.

### DIFF
--- a/combinations/mulled-v2-1ce5e37334bc909572dbf75a7a943be7577d6ae9:35bfb2b41e467943573586c964d41936d97d477a-0.tsv
+++ b/combinations/mulled-v2-1ce5e37334bc909572dbf75a7a943be7577d6ae9:35bfb2b41e467943573586c964d41936d97d477a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyvo=1.4.1,astropy=5.2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1ce5e37334bc909572dbf75a7a943be7577d6ae9:35bfb2b41e467943573586c964d41936d97d477a

**Packages**:
- pyvo=1.4.1
- astropy=5.2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- astronomical_archives.xml

Generated with Planemo.