### PR TITLE
Add container astropy:5.2.2.

### DIFF
--- a/combinations/astropy:5.2.2-0.tsv
+++ b/combinations/astropy:5.2.2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+astropy=5.2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: astropy:5.2.2

**Packages**:
- astropy=5.2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fitsinfo.xml
- fits2table.xml

Generated with Planemo.