### PR TITLE
Add container mulled-v2-016582a5c0fc56b4b694339dce5194cd4a2a6370:5d99c1726af98feabf826582a5ae5f69d617b5e2.

### DIFF
--- a/combinations/mulled-v2-016582a5c0fc56b4b694339dce5194cd4a2a6370:5d99c1726af98feabf826582a5ae5f69d617b5e2-0.tsv
+++ b/combinations/mulled-v2-016582a5c0fc56b4b694339dce5194cd4a2a6370:5d99c1726af98feabf826582a5ae5f69d617b5e2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scipy=1.11.4,wget=1.21.4,matplotlib=3.8.4,pydantic=1.10.14,tqdm=4.66.2,nbconvert=7.16.3,oda-api=1.2.15,ipython=8.22.2,gammapy=1.1,astropy=5.3.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-016582a5c0fc56b4b694339dce5194cd4a2a6370:5d99c1726af98feabf826582a5ae5f69d617b5e2

**Packages**:
- scipy=1.11.4
- wget=1.21.4
- matplotlib=3.8.4
- pydantic=1.10.14
- tqdm=4.66.2
- nbconvert=7.16.3
- oda-api=1.2.15
- ipython=8.22.2
- gammapy=1.1
- astropy=5.3.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hess_astro_tool.xml

Generated with Planemo.