### PR TITLE
Add container mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:3d0fd3b412ed7163eaf689289f1676ac32535c4b.

### DIFF
--- a/combinations/mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:3d0fd3b412ed7163eaf689289f1676ac32535c4b-0.tsv
+++ b/combinations/mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:3d0fd3b412ed7163eaf689289f1676ac32535c4b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-maaslin2=1.16.0,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:3d0fd3b412ed7163eaf689289f1676ac32535c4b

**Packages**:
- bioconductor-maaslin2=1.16.0
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- maaslin2.xml

Generated with Planemo.