### PR TITLE
Add container mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:ea2ca4ef1f5c792cffaa9a23dc0a8f74aab39a98.

### DIFF
--- a/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:ea2ca4ef1f5c792cffaa9a23dc0a8f74aab39a98-0.tsv
+++ b/combinations/mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:ea2ca4ef1f5c792cffaa9a23dc0a8f74aab39a98-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19,hicexplorer=3.7.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1aad242d5f1d2e9dfa491dd17a85e1417a2b2d64:ea2ca4ef1f5c792cffaa9a23dc0a8f74aab39a98

**Packages**:
- samtools=1.19
- hicexplorer=3.7.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hicBuildMatrix.xml

Generated with Planemo.