### PR TITLE
Add container mulled-v2-058593ade93b12389c2fef93c2b1ca0cdeee1113:da5ebca9afe6c91fd3c0909f6a8f8d3dee4236e4.

### DIFF
--- a/combinations/mulled-v2-058593ade93b12389c2fef93c2b1ca0cdeee1113:da5ebca9afe6c91fd3c0909f6a8f8d3dee4236e4-0.tsv
+++ b/combinations/mulled-v2-058593ade93b12389c2fef93c2b1ca0cdeee1113:da5ebca9afe6c91fd3c0909f6a8f8d3dee4236e4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-maldiquantforeign=0.14.1,r-scales=1.3.0,r-maldiquant=1.22.2,r-gridextra=2.3,r-randomcolor=1.1.0.1,r-ggplot2=3.5.1,r-rcolorbrewer=1.1_3,r-pheatmap=1.0.12,r-kernsmooth=2.23_24,bioconductor-sva=3.50.0,bioconductor-cardinal=3.4.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-058593ade93b12389c2fef93c2b1ca0cdeee1113:da5ebca9afe6c91fd3c0909f6a8f8d3dee4236e4

**Packages**:
- r-maldiquantforeign=0.14.1
- r-scales=1.3.0
- r-maldiquant=1.22.2
- r-gridextra=2.3
- r-randomcolor=1.1.0.1
- r-ggplot2=3.5.1
- r-rcolorbrewer=1.1_3
- r-pheatmap=1.0.12
- r-kernsmooth=2.23_24
- bioconductor-sva=3.50.0
- bioconductor-cardinal=3.4.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mz_images.xml
- combine.xml
- spatial_DGMM.xml
- segmentation.xml
- filtering.xml
- data_exporter.xml
- preprocessing.xml
- colocalization.xml
- classification.xml
- quality_report.xml
- spectra_plots.xml

Generated with Planemo.