### PR TITLE
Add container mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:a1c81060cd6d312ae7a93313e208bbc8baf5e786.

### DIFF
--- a/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:a1c81060cd6d312ae7a93313e208bbc8baf5e786-0.tsv
+++ b/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:a1c81060cd6d312ae7a93313e208bbc8baf5e786-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.19,biopython=1.82,pyyaml=6.0.1,bcbio-gff=0.7.1,jbrowse2=2.12.3,hictk=0.0.12-0,tabix=1.11,findutils=4.6.0,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:a1c81060cd6d312ae7a93313e208bbc8baf5e786

**Packages**:
- samtools=1.19
- biopython=1.82
- pyyaml=6.0.1
- bcbio-gff=0.7.1
- jbrowse2=2.12.3
- hictk=0.0.12-0
- tabix=1.11
- findutils=4.6.0
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- jbrowse2.xml

Generated with Planemo.