### PR TITLE
Add container mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:f194ac206a48cce1675635350fa84441dd1df3cb.

### DIFF
--- a/combinations/mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:f194ac206a48cce1675635350fa84441dd1df3cb-0.tsv
+++ b/combinations/mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:f194ac206a48cce1675635350fa84441dd1df3cb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pybigtools=0.1.4,python=3.12.3,numpy=2.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:f194ac206a48cce1675635350fa84441dd1df3cb

**Packages**:
- pybigtools=0.1.4
- python=3.12.3
- numpy=2.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bigwig_outlier_bed.xml

Generated with Planemo.