### PR TITLE
Add container mulled-v2-bece039bf81d7078f4e991eaa85dbb26d52812cc:0275dac290b5e54577d8dc7dd1e3c3ad53b93534.

### DIFF
--- a/combinations/mulled-v2-bece039bf81d7078f4e991eaa85dbb26d52812cc:0275dac290b5e54577d8dc7dd1e3c3ad53b93534-0.tsv
+++ b/combinations/mulled-v2-bece039bf81d7078f4e991eaa85dbb26d52812cc:0275dac290b5e54577d8dc7dd1e3c3ad53b93534-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-getopt=1.20.4,bioconductor-edger=4.0.16,bioconductor-diffbind=3.12.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-bece039bf81d7078f4e991eaa85dbb26d52812cc:0275dac290b5e54577d8dc7dd1e3c3ad53b93534

**Packages**:
- r-getopt=1.20.4
- bioconductor-edger=4.0.16
- bioconductor-diffbind=3.12.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- diffbind.xml

Generated with Planemo.