### PR TITLE
Add container mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:df44006ca02268f5bc685ab8756f5daf2d766e2b.

### DIFF
--- a/combinations/mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:df44006ca02268f5bc685ab8756f5daf2d766e2b-0.tsv
+++ b/combinations/mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:df44006ca02268f5bc685ab8756f5daf2d766e2b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.18,numpy=1.16.5,lumpy-sv=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-60893aaa8ca66b56a7c247102c65f98165a108fd:df44006ca02268f5bc685ab8756f5daf2d766e2b

**Packages**:
- samtools=1.18
- numpy=1.16.5
- lumpy-sv=0.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lumpy.xml

Generated with Planemo.