### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:653de09b4280355564d19e5c12bfda02ac82a9a7.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:653de09b4280355564d19e5c12bfda02ac82a9a7-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:653de09b4280355564d19e5c12bfda02ac82a9a7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+yak=0.1,hifiasm=0.19.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:653de09b4280355564d19e5c12bfda02ac82a9a7

**Packages**:
- yak=0.1
- hifiasm=0.19.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.