### PR TITLE
add pasta+pigz

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -597,3 +597,4 @@ r-shiny=1.8.1.1,bioconductor-phyloseq=1.46.0,r-curl=5.1.0,r-biocmanager=1.30.23
 vardict-java=1.8.3,htslib=1.20
 lumpy-sv=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:3.1	3
 bwameth=0.2.7,bwa-mem2=2.2.1
+pasta=1.9.0,pigz=2.8


### PR DESCRIPTION
Adds a module for PASTA + PIGZ, for use in an nf-core module for PASTA.