### PR TITLE
Add container mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:867c37ccb5d8cd53e350dbdeec84fd1694fd24ab.

### DIFF
--- a/combinations/mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:867c37ccb5d8cd53e350dbdeec84fd1694fd24ab-0.tsv
+++ b/combinations/mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:867c37ccb5d8cd53e350dbdeec84fd1694fd24ab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pytrf=1.3.2,ucsc-bedgraphtobigwig=455,pyfastx=2.1.0,python=3.12.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:867c37ccb5d8cd53e350dbdeec84fd1694fd24ab

**Packages**:
- pytrf=1.3.2
- ucsc-bedgraphtobigwig=455
- pyfastx=2.1.0
- python=3.12.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- microsatbed.xml

Generated with Planemo.