### PR TITLE
Add container mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:1ef20c0896a63b743f0d8ddf259243145da52e1e.

### DIFF
--- a/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:1ef20c0896a63b743f0d8ddf259243145da52e1e-0.tsv
+++ b/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:1ef20c0896a63b743f0d8ddf259243145da52e1e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcbio-gff=0.7.1,hictk=0.0.12-0,jbrowse2=2.13.0,findutils=4.6.0,biopython=1.82,samtools=1.19,pyyaml=6.0.1,zip=3.0,tabix=1.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:1ef20c0896a63b743f0d8ddf259243145da52e1e

**Packages**:
- bcbio-gff=0.7.1
- hictk=0.0.12-0
- jbrowse2=2.13.0
- findutils=4.6.0
- biopython=1.82
- samtools=1.19
- pyyaml=6.0.1
- zip=3.0
- tabix=1.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- jbrowse2.xml

Generated with Planemo.