### PR TITLE
Add container mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:8b255fc4d8ca8c1e1dbf4f41a9f274c2eaa17cc9.

### DIFF
--- a/combinations/mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:8b255fc4d8ca8c1e1dbf4f41a9f274c2eaa17cc9-0.tsv
+++ b/combinations/mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:8b255fc4d8ca8c1e1dbf4f41a9f274c2eaa17cc9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.20,unicycler=0.5.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-12fced2530e0a51de91b029c85af463cedb62bee:8b255fc4d8ca8c1e1dbf4f41a9f274c2eaa17cc9

**Packages**:
- samtools=1.20
- unicycler=0.5.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- unicycler.xml

Generated with Planemo.