### PR TITLE
Add container mulled-v2-26583c1e86681aa6c5c517a2bf9c9c54aaedcde6:a25cf5282cc7c9ead800e7a856672df6e4631a1c.

### DIFF
--- a/combinations/mulled-v2-26583c1e86681aa6c5c517a2bf9c9c54aaedcde6:a25cf5282cc7c9ead800e7a856672df6e4631a1c-0.tsv
+++ b/combinations/mulled-v2-26583c1e86681aa6c5c517a2bf9c9c54aaedcde6:a25cf5282cc7c9ead800e7a856672df6e4631a1c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+julia-divand=2.7.9,julia=1.8.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-26583c1e86681aa6c5c517a2bf9c9c54aaedcde6:a25cf5282cc7c9ead800e7a856672df6e4631a1c

**Packages**:
- julia-divand=2.7.9
- julia=1.8.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- divandfull.xml

Generated with Planemo.