### PR TITLE
Add container mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:d211fac66429dc93cd6d2f9ca8425e4653ffab3e.

### DIFF
--- a/combinations/mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:d211fac66429dc93cd6d2f9ca8425e4653ffab3e-0.tsv
+++ b/combinations/mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:d211fac66429dc93cd6d2f9ca8425e4653ffab3e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.9.12,torchvision=0.18.1,pytorch=2.3.1,imageio=2.34.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:d211fac66429dc93cd6d2f9ca8425e4653ffab3e

**Packages**:
- python=3.9.12
- torchvision=0.18.1
- pytorch=2.3.1
- imageio=2.34.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bioimage_inference.xml

Generated with Planemo.