### PR TITLE
Add container mulled-v2-fe50b754e7a37519324a60af3d3b47973f3d508a:e2842fa28ae4c6569f2696248aae3a604f796d65.

### DIFF
--- a/combinations/mulled-v2-fe50b754e7a37519324a60af3d3b47973f3d508a:e2842fa28ae4c6569f2696248aae3a604f796d65-0.tsv
+++ b/combinations/mulled-v2-fe50b754e7a37519324a60af3d3b47973f3d508a:e2842fa28ae4c6569f2696248aae3a604f796d65-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scipy=1.14.0,python=3.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fe50b754e7a37519324a60af3d3b47973f3d508a:e2842fa28ae4c6569f2696248aae3a604f796d65

**Packages**:
- scipy=1.14.0
- python=3.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- clustering_from_distmat.xml

Generated with Planemo.