### PR TITLE
Add container mulled-v2-5f5572acbb4778dc6a42fdb81d01e74c962d7fde:9c103864261fb4b8e993e0f77fe68fc38ea78e19.

### DIFF
--- a/combinations/mulled-v2-5f5572acbb4778dc6a42fdb81d01e74c962d7fde:9c103864261fb4b8e993e0f77fe68fc38ea78e19-0.tsv
+++ b/combinations/mulled-v2-5f5572acbb4778dc6a42fdb81d01e74c962d7fde:9c103864261fb4b8e993e0f77fe68fc38ea78e19-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+openai=1.35.13,python=3.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5f5572acbb4778dc6a42fdb81d01e74c962d7fde:9c103864261fb4b8e993e0f77fe68fc38ea78e19

**Packages**:
- openai=1.35.13
- python=3.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- chatgpt.xml

Generated with Planemo.