### PR TITLE
Add container mulled-v2-99423e5958e26cc5debaeed25a685e92f8512c18:484ae9e48edf2af8770b436dcb0def1bc90533ce.

### DIFF
--- a/combinations/mulled-v2-99423e5958e26cc5debaeed25a685e92f8512c18:484ae9e48edf2af8770b436dcb0def1bc90533ce-0.tsv
+++ b/combinations/mulled-v2-99423e5958e26cc5debaeed25a685e92f8512c18:484ae9e48edf2af8770b436dcb0def1bc90533ce-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.2.2,locarna=2.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-99423e5958e26cc5debaeed25a685e92f8512c18:484ae9e48edf2af8770b436dcb0def1bc90533ce

**Packages**:
- r-base=4.2.2
- locarna=2.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- locarna_multiple.xml
- locarna_reliability_profile.xml
- locarna_pairwise_p.xml
- locarna_pairwise.xml
- locarna_exparnap.xml

Generated with Planemo.