### PR TITLE
Add container mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:4dc639196ebedd51309f55f19f76b73b75d2e355.

### DIFF
--- a/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:4dc639196ebedd51309f55f19f76b73b75d2e355-0.tsv
+++ b/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:4dc639196ebedd51309f55f19f76b73b75d2e355-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.82,findutils=4.6.0,pyyaml=6.0.1,samtools=1.19,zip=3.0,hictk=0.0.12-0,jbrowse2=2.13.1,bcbio-gff=0.7.1,tabix=1.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:4dc639196ebedd51309f55f19f76b73b75d2e355

**Packages**:
- biopython=1.82
- findutils=4.6.0
- pyyaml=6.0.1
- samtools=1.19
- zip=3.0
- hictk=0.0.12-0
- jbrowse2=2.13.1
- bcbio-gff=0.7.1
- tabix=1.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- jbrowse2.xml

Generated with Planemo.