### PR TITLE
Add container mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:43ff19c348e21674cd51004463f1ea0b2e5f2336.

### DIFF
--- a/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:43ff19c348e21674cd51004463f1ea0b2e5f2336-0.tsv
+++ b/combinations/mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:43ff19c348e21674cd51004463f1ea0b2e5f2336-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasta3=36.3.8,mafft=7.526	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-027f30e88c6da4ab4b0170ff590dbab158b07243:43ff19c348e21674cd51004463f1ea0b2e5f2336

**Packages**:
- fasta3=36.3.8
- mafft=7.526
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mafft-add.xml
- mafft.xml

Generated with Planemo.