### PR TITLE
add star samtools versions

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -604,3 +604,4 @@ bwameth=0.2.7,bwa-mem2=2.2.1
 pasta=1.9.0,pigz=2.8
 longphase=1.7.3,htslib=1.20
 r-base=4.4.1,r-igraph=2.0.3,r-dplyr=1.1.4,r-tidyr=1.3.1,r-readr=2.1.5,r-ggplot2=3.5.1
+bioconda-star=2.7.10a,bioconda-samtools=1.18,bioconda-htslib=1.18

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -603,4 +603,4 @@ lumpy-sv=0.3.1	quay.io/bioconda/base-glibc-busybox-bash:3.1	3
 bwameth=0.2.7,bwa-mem2=2.2.1
 pasta=1.9.0,pigz=2.8
 longphase=1.7.3,htslib=1.20
-r-base,r-igraph,r-dplyr
+r-base=4.4.1,r-igraph=2.0.3,r-dplyr=1.1.4,r-tidyr=1.3.1,r-readr=2.1.5,r-ggplot2=3.5.1

--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -604,4 +604,5 @@ bwameth=0.2.7,bwa-mem2=2.2.1
 pasta=1.9.0,pigz=2.8
 longphase=1.7.3,htslib=1.20
 r-base=4.4.1,r-igraph=2.0.3,r-dplyr=1.1.4,r-tidyr=1.3.1,r-readr=2.1.5,r-ggplot2=3.5.1
-bioconda-star=2.7.10a,bioconda-samtools=1.18,bioconda-htslib=1.18
+telseq=0.0.2,samtools=1.20
+star=2.7.10a,samtools=1.18,htslib=1.18


### PR DESCRIPTION
This addition adds the following packages to a container: bioconda-star=2.7.10a,bioconda-samtools=1.18,bioconda-htslib=1.18
It has the following hash: mulled-v2-540529f75bde6c0b7eab966a6d7bab15693c6aa1:53e6430e8761d87a68e7210d328191ea0e297aa6-0 