### PR TITLE
Update hash.tsv:  telseq + samtools

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -604,3 +604,4 @@ bwameth=0.2.7,bwa-mem2=2.2.1
 pasta=1.9.0,pigz=2.8
 longphase=1.7.3,htslib=1.20
 r-base=4.4.1,r-igraph=2.0.3,r-dplyr=1.1.4,r-tidyr=1.3.1,r-readr=2.1.5,r-ggplot2=3.5.1
+telseq=0.0.2,samtools=1.20


### PR DESCRIPTION
telseq cannot read CRAM files. Samtools is added to read CRAM Files ( see: https://github.com/zd1/telseq/issues/26#issuecomment-704019482 )
This PR is a combination of both tools. 


(was https://github.com/bioconda/bioconda-recipes/pull/50362 )