### PR TITLE
Add container mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:f28bc7420f62d7ef1ed7cdf489b157ad8662c3f0.

### DIFF
--- a/combinations/mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:f28bc7420f62d7ef1ed7cdf489b157ad8662c3f0-0.tsv
+++ b/combinations/mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:f28bc7420f62d7ef1ed7cdf489b157ad8662c3f0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.20,bbmap=39.08	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f423f44972692ad764209668b09b84ec158bffe4:f28bc7420f62d7ef1ed7cdf489b157ad8662c3f0

**Packages**:
- samtools=1.20
- bbmap=39.08
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bbmap.xml
- bbmerge.xml
- bbnorm.xml
- tadpole.xml
- callvariants.xml
- bbduk.xml

Generated with Planemo.