### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:e40a27a94c8f492cc36e93e81e84ff808e0fb76a.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:e40a27a94c8f492cc36e93e81e84ff808e0fb76a-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:e40a27a94c8f492cc36e93e81e84ff808e0fb76a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+busco=5.7.1,tar=1.34,fonts-conda-ecosystem=1	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:e40a27a94c8f492cc36e93e81e84ff808e0fb76a

**Packages**:
- busco=5.7.1
- tar=1.34
- fonts-conda-ecosystem=1
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.