### PR TITLE
Add container mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:4ef758e60876634288702514fc697babb4bab14e.

### DIFF
--- a/combinations/mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:4ef758e60876634288702514fc697babb4bab14e-0.tsv
+++ b/combinations/mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:4ef758e60876634288702514fc697babb4bab14e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.9.12,torchvision=0.19.0,pytorch=2.4.0,imageio=2.35.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:4ef758e60876634288702514fc697babb4bab14e

**Packages**:
- python=3.9.12
- torchvision=0.19.0
- pytorch=2.4.0
- imageio=2.35.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bioimage_inference.xml

Generated with Planemo.