### PR TITLE
Add container mulled-v2-f17e573e43901ebf99fbfbdf4750f1f0a9655ada:27a48b941ada3662259fa30c2362e696ff761b8f.

### DIFF
--- a/combinations/mulled-v2-f17e573e43901ebf99fbfbdf4750f1f0a9655ada:27a48b941ada3662259fa30c2362e696ff761b8f-0.tsv
+++ b/combinations/mulled-v2-f17e573e43901ebf99fbfbdf4750f1f0a9655ada:27a48b941ada3662259fa30c2362e696ff761b8f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+motus=3.1.0,tar=1.34	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f17e573e43901ebf99fbfbdf4750f1f0a9655ada:27a48b941ada3662259fa30c2362e696ff761b8f

**Packages**:
- motus=3.1.0
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- motus_profiler.xml
- motus_merge.xml

Generated with Planemo.