### PR TITLE
Add container mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:5de2b85434ba2c0e992a79fd5062323ceb50237b.

### DIFF
--- a/combinations/mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:5de2b85434ba2c0e992a79fd5062323ceb50237b-0.tsv
+++ b/combinations/mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:5de2b85434ba2c0e992a79fd5062323ceb50237b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+zip=3.0,bioconductor-maaslin2=1.18.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-deec01ab6d7d97f329b75641970afdbc33622ad4:5de2b85434ba2c0e992a79fd5062323ceb50237b

**Packages**:
- zip=3.0
- bioconductor-maaslin2=1.18.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- maaslin2.xml

Generated with Planemo.