### PR TITLE
Add container mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:9d6eca439aafbf5786124c97d1b5298cc98a486e.

### DIFF
--- a/combinations/mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:9d6eca439aafbf5786124c97d1b5298cc98a486e-0.tsv
+++ b/combinations/mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:9d6eca439aafbf5786124c97d1b5298cc98a486e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyfastx=2.1.0,python=3.12.3,pytrf=1.3.3,ucsc-bedgraphtobigwig=455	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:9d6eca439aafbf5786124c97d1b5298cc98a486e

**Packages**:
- pyfastx=2.1.0
- python=3.12.3
- pytrf=1.3.3
- ucsc-bedgraphtobigwig=455
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- microsatbed.xml

Generated with Planemo.