### PR TITLE
Add container mulled-v2-b06e60b4c1ae2c2cfc82a11d032d5bee860eedd0:6c6ea792d4a8baddf6def0f7bd8a45edf6300ac3.

### DIFF
--- a/combinations/mulled-v2-b06e60b4c1ae2c2cfc82a11d032d5bee860eedd0:6c6ea792d4a8baddf6def0f7bd8a45edf6300ac3-0.tsv
+++ b/combinations/mulled-v2-b06e60b4c1ae2c2cfc82a11d032d5bee860eedd0:6c6ea792d4a8baddf6def0f7bd8a45edf6300ac3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+statsmodels=0.14.2,scanpy=1.10.2,leidenalg=0.10.2,scipy=1.14.1,scikit-learn=1.5.1,pandas=2.2.2,umap-learn=0.5.6,louvain=0.8.2,anndata=0.10.3,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b06e60b4c1ae2c2cfc82a11d032d5bee860eedd0:6c6ea792d4a8baddf6def0f7bd8a45edf6300ac3

**Packages**:
- statsmodels=0.14.2
- scanpy=1.10.2
- leidenalg=0.10.2
- scipy=1.14.1
- scikit-learn=1.5.1
- pandas=2.2.2
- umap-learn=0.5.6
- louvain=0.8.2
- anndata=0.10.3
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cluster_reduce_dimension.xml

Generated with Planemo.