### PR TITLE
Add container mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:2947815bdcfaf3cb1df285cd5e4fcf8a8a0e87c7.

### DIFF
--- a/combinations/mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:2947815bdcfaf3cb1df285cd5e4fcf8a8a0e87c7-0.tsv
+++ b/combinations/mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:2947815bdcfaf3cb1df285cd5e4fcf8a8a0e87c7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+loompy=3.0.6,scanpy=1.10.2,anndata=0.10.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:2947815bdcfaf3cb1df285cd5e4fcf8a8a0e87c7

**Packages**:
- loompy=3.0.6
- scanpy=1.10.2
- anndata=0.10.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- import.xml

Generated with Planemo.