### PR TITLE
Add container mulled-v2-d7c6e3a36cf3c7d1955112b0fe2b06b786645d34:03498c2992fd91cdaec10b5be74ad2061cbdd699.

### DIFF
--- a/combinations/mulled-v2-d7c6e3a36cf3c7d1955112b0fe2b06b786645d34:03498c2992fd91cdaec10b5be74ad2061cbdd699-0.tsv
+++ b/combinations/mulled-v2-d7c6e3a36cf3c7d1955112b0fe2b06b786645d34:03498c2992fd91cdaec10b5be74ad2061cbdd699-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+statsmodels=0.14.2,scanpy=1.10.2,scikit-learn=1.5.1,scipy=1.14.1,pandas=2.2.2,anndata=0.10.3,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d7c6e3a36cf3c7d1955112b0fe2b06b786645d34:03498c2992fd91cdaec10b5be74ad2061cbdd699

**Packages**:
- statsmodels=0.14.2
- scanpy=1.10.2
- scikit-learn=1.5.1
- scipy=1.14.1
- pandas=2.2.2
- anndata=0.10.3
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- inspect.xml

Generated with Planemo.