### PR TITLE
Add container mulled-v2-5461c1b6575cf0400330be87903dec3baaced66c:00bbdd8c6868cff6bd744b5825c54f8cf9723e38.

### DIFF
--- a/combinations/mulled-v2-5461c1b6575cf0400330be87903dec3baaced66c:00bbdd8c6868cff6bd744b5825c54f8cf9723e38-0.tsv
+++ b/combinations/mulled-v2-5461c1b6575cf0400330be87903dec3baaced66c:00bbdd8c6868cff6bd744b5825c54f8cf9723e38-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+statsmodels=0.14.2,scanpy=1.10.2,scipy=1.14.1,pandas=2.2.2,magic-impute=3.0.0,anndata=0.10.3,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5461c1b6575cf0400330be87903dec3baaced66c:00bbdd8c6868cff6bd744b5825c54f8cf9723e38

**Packages**:
- statsmodels=0.14.2
- scanpy=1.10.2
- scipy=1.14.1
- pandas=2.2.2
- magic-impute=3.0.0
- anndata=0.10.3
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- normalize.xml

Generated with Planemo.