### PR TITLE
Add container mulled-v2-8486357bda724e1a7a2180b2ae893313fca88853:fc08a9beec8a04da7ec54957fbab98364dceb590.

### DIFF
--- a/combinations/mulled-v2-8486357bda724e1a7a2180b2ae893313fca88853:fc08a9beec8a04da7ec54957fbab98364dceb590-0.tsv
+++ b/combinations/mulled-v2-8486357bda724e1a7a2180b2ae893313fca88853:fc08a9beec8a04da7ec54957fbab98364dceb590-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+statsmodels=0.14.2,scanpy=1.10.2,scipy=1.14.1,scanorama=1.7.4,pandas=2.2.2,anndata=0.10.3,bbknn=1.6.0,numpy=1.26.4,pynndescent=0.5.13,harmonypy=0.0.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8486357bda724e1a7a2180b2ae893313fca88853:fc08a9beec8a04da7ec54957fbab98364dceb590

**Packages**:
- statsmodels=0.14.2
- scanpy=1.10.2
- scipy=1.14.1
- scanorama=1.7.4
- pandas=2.2.2
- anndata=0.10.3
- bbknn=1.6.0
- numpy=1.26.4
- pynndescent=0.5.13
- harmonypy=0.0.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- remove_confounders.xml

Generated with Planemo.