### PR TITLE
Add container mulled-v2-dc76f3d5ca12079115799a7f3a39786979c550c6:c878ed50d66d6c0b21cfcdd064428fe1ae944364.

### DIFF
--- a/combinations/mulled-v2-dc76f3d5ca12079115799a7f3a39786979c550c6:c878ed50d66d6c0b21cfcdd064428fe1ae944364-0.tsv
+++ b/combinations/mulled-v2-dc76f3d5ca12079115799a7f3a39786979c550c6:c878ed50d66d6c0b21cfcdd064428fe1ae944364-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scrublet=0.2.3,statsmodels=0.14.2,scanpy=1.10.2,scikit-misc=0.1.4,scipy=1.14.1,pandas=2.2.2,anndata=0.10.3,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dc76f3d5ca12079115799a7f3a39786979c550c6:c878ed50d66d6c0b21cfcdd064428fe1ae944364

**Packages**:
- scrublet=0.2.3
- statsmodels=0.14.2
- scanpy=1.10.2
- scikit-misc=0.1.4
- scipy=1.14.1
- pandas=2.2.2
- anndata=0.10.3
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- filter.xml

Generated with Planemo.