### PR TITLE
Add container mulled-v2-1677ea7a1ef8d879fdebe3be1167fb4d31923fb3:d4dc61a1a2164174edc1a6ff30d1e65c3282fd85.

### DIFF
--- a/combinations/mulled-v2-1677ea7a1ef8d879fdebe3be1167fb4d31923fb3:d4dc61a1a2164174edc1a6ff30d1e65c3282fd85-0.tsv
+++ b/combinations/mulled-v2-1677ea7a1ef8d879fdebe3be1167fb4d31923fb3:d4dc61a1a2164174edc1a6ff30d1e65c3282fd85-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+loompy=3.0.6,numpy=1.26.4,anndata=0.10.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1677ea7a1ef8d879fdebe3be1167fb4d31923fb3:d4dc61a1a2164174edc1a6ff30d1e65c3282fd85

**Packages**:
- loompy=3.0.6
- numpy=1.26.4
- anndata=0.10.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- modify_loom.xml

Generated with Planemo.