### PR TITLE
Add container mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:bc2cf46822f57b1461e908b5d8b487535203ecfa.

### DIFF
--- a/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:bc2cf46822f57b1461e908b5d8b487535203ecfa-0.tsv
+++ b/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:bc2cf46822f57b1461e908b5d8b487535203ecfa-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+abyss=2.3.9,bwa=0.7.18	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:bc2cf46822f57b1461e908b5d8b487535203ecfa

**Packages**:
- abyss=2.3.9
- bwa=0.7.18
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- abyss-pe.xml

Generated with Planemo.