### PR TITLE
add old datamash

### DIFF
--- a/combinations/datamash:1.0.6-0.tsv
+++ b/combinations/datamash:1.0.6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+datamash=1.0.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
Trying to get rid of conda envs. Need a container for an old version of: https://github.com/galaxyproject/tools-iuc/tree/main/tools/datamash