### PR TITLE
Add container mulled-v2-fff252eb4a112abc9fe5db056ee9a185c83e6322:72708d7b96d0075c78400cab27de5d6a706df1f5.

### DIFF
--- a/combinations/mulled-v2-fff252eb4a112abc9fe5db056ee9a185c83e6322:72708d7b96d0075c78400cab27de5d6a706df1f5-0.tsv
+++ b/combinations/mulled-v2-fff252eb4a112abc9fe5db056ee9a185c83e6322:72708d7b96d0075c78400cab27de5d6a706df1f5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.21,matplotlib=3.3.4,tifffile=2020.10.1,giatools=0.1,scikit-image=0.18.1,pillow=10.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fff252eb4a112abc9fe5db056ee9a185c83e6322:72708d7b96d0075c78400cab27de5d6a706df1f5

**Packages**:
- numpy=1.21
- matplotlib=3.3.4
- tifffile=2020.10.1
- giatools=0.1
- scikit-image=0.18.1
- pillow=10.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- overlay_images.xml

Generated with Planemo.