### PR TITLE
Add container mulled-v2-98770aaa2c7aa3e025978eff8966cbd6f8e80d9b:d6d0c1e4293bf7efa35a430451b2afd30e9e6141.

### DIFF
--- a/combinations/mulled-v2-98770aaa2c7aa3e025978eff8966cbd6f8e80d9b:d6d0c1e4293bf7efa35a430451b2afd30e9e6141-0.tsv
+++ b/combinations/mulled-v2-98770aaa2c7aa3e025978eff8966cbd6f8e80d9b:d6d0c1e4293bf7efa35a430451b2afd30e9e6141-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,fa2=0.3.5,anndata=0.10.3,scikit-learn=1.5.1,scipy=1.14.1,numpy=1.26.4,statsmodels=0.14.2,scanpy=1.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-98770aaa2c7aa3e025978eff8966cbd6f8e80d9b:d6d0c1e4293bf7efa35a430451b2afd30e9e6141

**Packages**:
- pandas=2.2.2
- fa2=0.3.5
- anndata=0.10.3
- scikit-learn=1.5.1
- scipy=1.14.1
- numpy=1.26.4
- statsmodels=0.14.2
- scanpy=1.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- inspect.xml

Generated with Planemo.