### PR TITLE
Add container mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:d06fc1f22d7d914ee5752659b49114ff2ecf7a0f.

### DIFF
--- a/combinations/mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:d06fc1f22d7d914ee5752659b49114ff2ecf7a0f-0.tsv
+++ b/combinations/mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:d06fc1f22d7d914ee5752659b49114ff2ecf7a0f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.2.0,pandas=1.2.4,numpy=1.26.4,scikit-image=0.21,tifffile=2024.6.18	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1969271ffece8920441ded0a2410f8218b13d934:d06fc1f22d7d914ee5752659b49114ff2ecf7a0f

**Packages**:
- giatools=0.2.0
- pandas=1.2.4
- numpy=1.26.4
- scikit-image=0.21
- tifffile=2024.6.18
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- spot_detection_2d.xml

Generated with Planemo.