### PR TITLE
Add container mulled-v2-7803e51b23b85114950c72f337ef7aa3cece9346:c663ef96c2853df5a17365044ea01c6bbaa4100b.

### DIFF
--- a/combinations/mulled-v2-7803e51b23b85114950c72f337ef7aa3cece9346:c663ef96c2853df5a17365044ea01c6bbaa4100b-0.tsv
+++ b/combinations/mulled-v2-7803e51b23b85114950c72f337ef7aa3cece9346:c663ef96c2853df5a17365044ea01c6bbaa4100b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=1.2.4,scikit-image=0.21,numpy=1.26.4,tifffile=2024.6.18	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7803e51b23b85114950c72f337ef7aa3cece9346:c663ef96c2853df5a17365044ea01c6bbaa4100b

**Packages**:
- pandas=1.2.4
- scikit-image=0.21
- numpy=1.26.4
- tifffile=2024.6.18
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- points2binaryimage.xml

Generated with Planemo.