### PR TITLE
Add container mulled-v2-787a0b21e84c9df924e255f01d228ca21ebe4b1b:69806f67abe941aaf18ae917b83582fe45395ee7.

### DIFF
--- a/combinations/mulled-v2-787a0b21e84c9df924e255f01d228ca21ebe4b1b:69806f67abe941aaf18ae917b83582fe45395ee7-0.tsv
+++ b/combinations/mulled-v2-787a0b21e84c9df924e255f01d228ca21ebe4b1b:69806f67abe941aaf18ae917b83582fe45395ee7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,fa2=0.3.5,pynndescent=0.5.13,scanorama=1.7.4,anndata=0.10.3,scipy=1.14.1,numpy=1.26.4,bbknn=1.6.0,statsmodels=0.14.2,scanpy=1.10.2,harmonypy=0.0.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-787a0b21e84c9df924e255f01d228ca21ebe4b1b:69806f67abe941aaf18ae917b83582fe45395ee7

**Packages**:
- pandas=2.2.2
- fa2=0.3.5
- pynndescent=0.5.13
- scanorama=1.7.4
- anndata=0.10.3
- scipy=1.14.1
- numpy=1.26.4
- bbknn=1.6.0
- statsmodels=0.14.2
- scanpy=1.10.2
- harmonypy=0.0.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- remove_confounders.xml

Generated with Planemo.