### PR TITLE
Add container mulled-v2-01023c27ff0dac92bb638ea16195dce5be06409e:a9a883584aa3d8a716fd62b28db6b09c2aae8c50.

### DIFF
--- a/combinations/mulled-v2-01023c27ff0dac92bb638ea16195dce5be06409e:a9a883584aa3d8a716fd62b28db6b09c2aae8c50-0.tsv
+++ b/combinations/mulled-v2-01023c27ff0dac92bb638ea16195dce5be06409e:a9a883584aa3d8a716fd62b28db6b09c2aae8c50-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,fa2=0.3.5,magic-impute=3.0.0,anndata=0.10.3,scipy=1.14.1,numpy=1.26.4,statsmodels=0.14.2,scanpy=1.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-01023c27ff0dac92bb638ea16195dce5be06409e:a9a883584aa3d8a716fd62b28db6b09c2aae8c50

**Packages**:
- pandas=2.2.2
- fa2=0.3.5
- magic-impute=3.0.0
- anndata=0.10.3
- scipy=1.14.1
- numpy=1.26.4
- statsmodels=0.14.2
- scanpy=1.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- normalize.xml

Generated with Planemo.