### PR TITLE
Add container mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:bfb4728c3e55636df44cdea729ad0ff6cf2cb25e.

### DIFF
--- a/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:bfb4728c3e55636df44cdea729ad0ff6cf2cb25e-0.tsv
+++ b/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:bfb4728c3e55636df44cdea729ad0ff6cf2cb25e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.12,sed=4.7,umi_tools=1.1.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:bfb4728c3e55636df44cdea729ad0ff6cf2cb25e

**Packages**:
- samtools=1.12
- sed=4.7
- umi_tools=1.1.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_counts.xml

Generated with Planemo.