### PR TITLE
Add container mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:c34272f3efd623dcefb153ede57a0914c0468d3c.

### DIFF
--- a/combinations/mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:c34272f3efd623dcefb153ede57a0914c0468d3c-0.tsv
+++ b/combinations/mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:c34272f3efd623dcefb153ede57a0914c0468d3c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.80,cooler=0.10.2,hicstuff=3.1.5	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:c34272f3efd623dcefb153ede57a0914c0468d3c

**Packages**:
- biopython=1.80
- cooler=0.10.2
- hicstuff=3.1.5
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- hicstuff_pipeline.xml

Generated with Planemo.