### PR TITLE
Add container mulled-v2-6d7bfd94b486889b7c682c29c819307ed96403e5:888ea6aeaba0e48d19567965041dd37b92307a30.

### DIFF
--- a/combinations/mulled-v2-6d7bfd94b486889b7c682c29c819307ed96403e5:888ea6aeaba0e48d19567965041dd37b92307a30-0.tsv
+++ b/combinations/mulled-v2-6d7bfd94b486889b7c682c29c819307ed96403e5:888ea6aeaba0e48d19567965041dd37b92307a30-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+umap-learn=0.5.6,pandas=2.2.2,fa2=0.3.5,louvain=0.8.2,anndata=0.10.3,scikit-learn=1.5.1,scipy=1.14.1,numpy=1.26.4,statsmodels=0.14.2,leidenalg=0.10.2,scanpy=1.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6d7bfd94b486889b7c682c29c819307ed96403e5:888ea6aeaba0e48d19567965041dd37b92307a30

**Packages**:
- umap-learn=0.5.6
- pandas=2.2.2
- fa2=0.3.5
- louvain=0.8.2
- anndata=0.10.3
- scikit-learn=1.5.1
- scipy=1.14.1
- numpy=1.26.4
- statsmodels=0.14.2
- leidenalg=0.10.2
- scanpy=1.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cluster_reduce_dimension.xml

Generated with Planemo.