### PR TITLE
Add container mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:21c15b141cbb0ce7b5034ce79de4a29c939d0db0.

### DIFF
--- a/combinations/mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:21c15b141cbb0ce7b5034ce79de4a29c939d0db0-0.tsv
+++ b/combinations/mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:21c15b141cbb0ce7b5034ce79de4a29c939d0db0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,umi_tools=1.1.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:21c15b141cbb0ce7b5034ce79de4a29c939d0db0

**Packages**:
- samtools=1.21
- umi_tools=1.1.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_group.xml
- umi-tools_dedup.xml

Generated with Planemo.