### PR TITLE
Add container mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:6d5de92e647715f65170e63dc4db9b4a02c826b4.

### DIFF
--- a/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:6d5de92e647715f65170e63dc4db9b4a02c826b4-0.tsv
+++ b/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:6d5de92e647715f65170e63dc4db9b4a02c826b4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+jbrowse2=2.15.4,findutils=4.6.0,samtools=1.21,bcbio-gff=0.7.1,pyyaml=6.0.1,tabix=1.11,zip=3.0,biopython=1.82,hictk=1.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:6d5de92e647715f65170e63dc4db9b4a02c826b4

**Packages**:
- jbrowse2=2.15.4
- findutils=4.6.0
- samtools=1.21
- bcbio-gff=0.7.1
- pyyaml=6.0.1
- tabix=1.11
- zip=3.0
- biopython=1.82
- hictk=1.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- jbrowse2.xml

Generated with Planemo.