### PR TITLE
Add container mulled-v2-9709dab452f832c86ec61229241988aa205b26f0:f3cc72b36c9bbd646e4d2d1946c2e5b5818c11d2.

### DIFF
--- a/combinations/mulled-v2-9709dab452f832c86ec61229241988aa205b26f0:f3cc72b36c9bbd646e4d2d1946c2e5b5818c11d2-0.tsv
+++ b/combinations/mulled-v2-9709dab452f832c86ec61229241988aa205b26f0:f3cc72b36c9bbd646e4d2d1946c2e5b5818c11d2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+augustus=@VERSION@,maker=2.31.10	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9709dab452f832c86ec61229241988aa205b26f0:f3cc72b36c9bbd646e4d2d1946c2e5b5818c11d2

**Packages**:
- augustus=@VERSION@
- maker=2.31.10
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- augustus_training.xml

Generated with Planemo.