### PR TITLE
Add container mulled-v2-ce3293c76b8e4416b4b996803fe910eba13e802e:6855c57a79cb76b87d19f465afeb149b60715dff.

### DIFF
--- a/combinations/mulled-v2-ce3293c76b8e4416b4b996803fe910eba13e802e:6855c57a79cb76b87d19f465afeb149b60715dff-0.tsv
+++ b/combinations/mulled-v2-ce3293c76b8e4416b4b996803fe910eba13e802e:6855c57a79cb76b87d19f465afeb149b60715dff-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,seaborn=0.13.2,fa2=0.3.5,anndata=0.10.3,scipy=1.14.1,numpy=1.26.4,statsmodels=0.14.2,python-igraph=0.11.6,scanpy=1.10.2,matplotlib=3.9.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce3293c76b8e4416b4b996803fe910eba13e802e:6855c57a79cb76b87d19f465afeb149b60715dff

**Packages**:
- pandas=2.2.2
- seaborn=0.13.2
- fa2=0.3.5
- anndata=0.10.3
- scipy=1.14.1
- numpy=1.26.4
- statsmodels=0.14.2
- python-igraph=0.11.6
- scanpy=1.10.2
- matplotlib=3.9.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plot.xml

Generated with Planemo.