### PR TITLE
Add container mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:1bfaad044dc62b5c71c6fc126e8641a3ed784281.

### DIFF
--- a/combinations/mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:1bfaad044dc62b5c71c6fc126e8641a3ed784281-0.tsv
+++ b/combinations/mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:1bfaad044dc62b5c71c6fc126e8641a3ed784281-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+chewbbaca=3.3.10,blast=2.15.0,fasttree=2.1.11,zip=3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-58ff1c91afa06f4c18f00148a958b53acd57145b:1bfaad044dc62b5c71c6fc126e8641a3ed784281

**Packages**:
- chewbbaca=3.3.10
- blast=2.15.0
- fasttree=2.1.11
- zip=3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- DownloadSchema.xml
- AlleleCall.xml
- JoinProfiles.xml
- AlleleCallEvaluator.xml
- NSStats.xml
- CreateSchema.xml
- ExtractCgMLST.xml
- PrepExternalSchema.xml

Generated with Planemo.