### PR TITLE
Add container mulled-v2-62614b7517d4239ee2992071ace96414653de4c9:df0562b1e6b1df6b24149b54d8d16547bbaa061f.

### DIFF
--- a/combinations/mulled-v2-62614b7517d4239ee2992071ace96414653de4c9:df0562b1e6b1df6b24149b54d8d16547bbaa061f-0.tsv
+++ b/combinations/mulled-v2-62614b7517d4239ee2992071ace96414653de4c9:df0562b1e6b1df6b24149b54d8d16547bbaa061f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,fa2=0.3.5,anndata=0.10.3,scipy=1.14.1,numpy=1.26.4,statsmodels=0.14.2,scikit-misc=0.1.4,scrublet=0.2.3,scanpy=1.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-62614b7517d4239ee2992071ace96414653de4c9:df0562b1e6b1df6b24149b54d8d16547bbaa061f

**Packages**:
- pandas=2.2.2
- fa2=0.3.5
- anndata=0.10.3
- scipy=1.14.1
- numpy=1.26.4
- statsmodels=0.14.2
- scikit-misc=0.1.4
- scrublet=0.2.3
- scanpy=1.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- filter.xml

Generated with Planemo.