### PR TITLE
Add container mulled-v2-3543acda36d43dae727ac63c9c09ca2735486af8:c38e0d7112b7d154c0f7b79d662baac3beae9fd4.

### DIFF
--- a/combinations/mulled-v2-3543acda36d43dae727ac63c9c09ca2735486af8:c38e0d7112b7d154c0f7b79d662baac3beae9fd4-0.tsv
+++ b/combinations/mulled-v2-3543acda36d43dae727ac63c9c09ca2735486af8:c38e0d7112b7d154c0f7b79d662baac3beae9fd4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+psy-maps=1.4.2,python=3,psy-reg=1.4.0,netcdf4=1.6.5,psyplot=1.4.3,matplotlib=3.9.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3543acda36d43dae727ac63c9c09ca2735486af8:c38e0d7112b7d154c0f7b79d662baac3beae9fd4

**Packages**:
- psy-maps=1.4.2
- python=3
- psy-reg=1.4.0
- netcdf4=1.6.5
- psyplot=1.4.3
- matplotlib=3.9.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- psy-maps.xml

Generated with Planemo.