### PR TITLE
Add container mulled-v2-246fc669eb0142dd62cf0f0ec4b761254a70ce2c:904c83c0b2a930c7755376460737fea99b050c23.

### DIFF
--- a/combinations/mulled-v2-246fc669eb0142dd62cf0f0ec4b761254a70ce2c:904c83c0b2a930c7755376460737fea99b050c23-0.tsv
+++ b/combinations/mulled-v2-246fc669eb0142dd62cf0f0ec4b761254a70ce2c:904c83c0b2a930c7755376460737fea99b050c23-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sambamba=1.0.1,samblaster=0.1.26	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-246fc669eb0142dd62cf0f0ec4b761254a70ce2c:904c83c0b2a930c7755376460737fea99b050c23

**Packages**:
- sambamba=1.0.1
- samblaster=0.1.26
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- samblaster.xml

Generated with Planemo.