### PR TITLE
Add container mulled-v2-ba0fa2569b9c1d280d7fb3b1bf2ad3c0c72d9296:34d0c765d43a43f8968b3d9ffb3ceb9a8cdf6a69.

### DIFF
--- a/combinations/mulled-v2-ba0fa2569b9c1d280d7fb3b1bf2ad3c0c72d9296:34d0c765d43a43f8968b3d9ffb3ceb9a8cdf6a69-0.tsv
+++ b/combinations/mulled-v2-ba0fa2569b9c1d280d7fb3b1bf2ad3c0c72d9296:34d0c765d43a43f8968b3d9ffb3ceb9a8cdf6a69-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+meryl=1.3,tar=1.34,pigz=2.8,merqury=1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ba0fa2569b9c1d280d7fb3b1bf2ad3c0c72d9296:34d0c765d43a43f8968b3d9ffb3ceb9a8cdf6a69

**Packages**:
- meryl=1.3
- tar=1.34
- pigz=2.8
- merqury=1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- print.xml
- arithmetic-kmers.xml
- groups-kmers.xml
- trio-mode.xml
- filter-kmers.xml
- count-kmers.xml
- histogram-kmers.xml

Generated with Planemo.