### PR TITLE
Add container mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:324947533e7bd7b7ec3dcf9f2b78f33557c8c85e.

### DIFF
--- a/combinations/mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:324947533e7bd7b7ec3dcf9f2b78f33557c8c85e-0.tsv
+++ b/combinations/mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:324947533e7bd7b7ec3dcf9f2b78f33557c8c85e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hicstuff=3.2.3,cooler=0.10.2,biopython=1.84	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-12d331eccbc7161dd3deb559bf75270b926f0e91:324947533e7bd7b7ec3dcf9f2b78f33557c8c85e

**Packages**:
- hicstuff=3.2.3
- cooler=0.10.2
- biopython=1.84
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- hicstuff_pipeline.xml

Generated with Planemo.