### PR TITLE
Add container mulled-v2-cee752f30ef966723b763d33a32f2c49681d2cd5:5f908e3f061200bab71402e6560066285458b79f.

### DIFF
--- a/combinations/mulled-v2-cee752f30ef966723b763d33a32f2c49681d2cd5:5f908e3f061200bab71402e6560066285458b79f-0.tsv
+++ b/combinations/mulled-v2-cee752f30ef966723b763d33a32f2c49681d2cd5:5f908e3f061200bab71402e6560066285458b79f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tar=1.34,python-wget=3.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cee752f30ef966723b763d33a32f2c49681d2cd5:5f908e3f061200bab71402e6560066285458b79f

**Packages**:
- tar=1.34
- python-wget=3.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- motus_db_fetcher.xml

Generated with Planemo.