### PR TITLE
Add container mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:b0769f09cb2aabda061ae0b85925845f3d6c008b.

### DIFF
--- a/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:b0769f09cb2aabda061ae0b85925845f3d6c008b-0.tsv
+++ b/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:b0769f09cb2aabda061ae0b85925845f3d6c008b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+cutesv=2.1.1,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:b0769f09cb2aabda061ae0b85925845f3d6c008b

**Packages**:
- cutesv=2.1.1
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cutesv.xml

Generated with Planemo.