### PR TITLE
Add container mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:2cb14bd76cc13911f2498dce228d57e75b84ab29.

### DIFF
--- a/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:2cb14bd76cc13911f2498dce228d57e75b84ab29-0.tsv
+++ b/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:2cb14bd76cc13911f2498dce228d57e75b84ab29-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freebayes=1.3.8,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:2cb14bd76cc13911f2498dce228d57e75b84ab29

**Packages**:
- freebayes=1.3.8
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- leftalign.xml

Generated with Planemo.