### PR TITLE
Add container mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:3c105da4d67d06f07258877601300e0bc838ec50.

### DIFF
--- a/combinations/mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:3c105da4d67d06f07258877601300e0bc838ec50-0.tsv
+++ b/combinations/mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:3c105da4d67d06f07258877601300e0bc838ec50-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mapseq=2.1.1b,perl=5.26	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fbf84c6272d44e70132097b36e69754ec327de70:3c105da4d67d06f07258877601300e0bc838ec50

**Packages**:
- mapseq=2.1.1b
- perl=5.26
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mapseq.xml

Generated with Planemo.