### PR TITLE
Add container mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:b4de2951c942c93b5ed20929f2c533ceb2c2c1ad.

### DIFF
--- a/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:b4de2951c942c93b5ed20929f2c533ceb2c2c1ad-0.tsv
+++ b/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:b4de2951c942c93b5ed20929f2c533ceb2c2c1ad-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freebayes=1.3.8,gawk=5.3.1,parallel=20240922,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:b4de2951c942c93b5ed20929f2c533ceb2c2c1ad

**Packages**:
- freebayes=1.3.8
- gawk=5.3.1
- parallel=20240922
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freebayes.xml

Generated with Planemo.