### PR TITLE
Add container mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:7e0efd9b7d45c7e6279d0a1a8c773759d988a534.

### DIFF
--- a/combinations/mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:7e0efd9b7d45c7e6279d0a1a8c773759d988a534-0.tsv
+++ b/combinations/mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:7e0efd9b7d45c7e6279d0a1a8c773759d988a534-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.9.12,pytorch=2.4.1,imageio=2.35.1,torchvision=0.19.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c575d3466834972bb675ffdcf85e409386565bb9:7e0efd9b7d45c7e6279d0a1a8c773759d988a534

**Packages**:
- python=3.9.12
- pytorch=2.4.1
- imageio=2.35.1
- torchvision=0.19.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bioimage_inference.xml

Generated with Planemo.