### PR TITLE
Update SVDB 2.8.2 with bcftools 

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -616,4 +616,4 @@ r-seqinr=4.2_36,r-digest=0.6.37,r-rlist=0.4.6.2,r-tiledb=0.30.0
 r-seqinr=4.2_36,r-digest=0.6.37,r-rlist=0.4.6.2,r-tiledb=0.30.0,bioconductor-biocgenerics=0.48.1,bioconductor-biostrings=2.70.1,r-optparse=1.7.5,r-rmarkdown=2.28
 r-pafr=0.0.2,r-viridislite=0.4.2,r-data.table=1.15.4,r-yaml=2.3.10,r-ggplot2=3.5.1,r-gtools=3.9.5
 mechanize=0.2.5
-svdb=2.8.1,bcftools=1.21
+svdb=2.8.2,bcftools=1.21


### PR DESCRIPTION
Hi, 

I missed that the latest SVDB version was actually 2.8.2. 