### PR TITLE
Add container mulled-v2-dac2e1051d9ab7cafa5886d54af6ec7501d022a1:feef1a020224b3bdc79d7e2d24e875db02889be4.

### DIFF
--- a/combinations/mulled-v2-dac2e1051d9ab7cafa5886d54af6ec7501d022a1:feef1a020224b3bdc79d7e2d24e875db02889be4-0.tsv
+++ b/combinations/mulled-v2-dac2e1051d9ab7cafa5886d54af6ec7501d022a1:feef1a020224b3bdc79d7e2d24e875db02889be4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+groot=1.1.2,python=3.12,ca-certificates=2024.6.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dac2e1051d9ab7cafa5886d54af6ec7501d022a1:feef1a020224b3bdc79d7e2d24e875db02889be4

**Packages**:
- groot=1.1.2
- python=3.12
- ca-certificates=2024.6.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_groot_database_downloader.xml

Generated with Planemo.