### PR TITLE
Add container mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:785af8aa735e847dc2f997dfd8149ed97a1e6a48.

### DIFF
--- a/combinations/mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:785af8aa735e847dc2f997dfd8149ed97a1e6a48-0.tsv
+++ b/combinations/mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:785af8aa735e847dc2f997dfd8149ed97a1e6a48-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scikit-image=0.24.0,pillow=11.0.0,numpy=2.1.2,tifffile=2024.9.20,scikit-learn=1.5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-085184fb5cc473383b88b71a2a31a7cf4332864c:785af8aa735e847dc2f997dfd8149ed97a1e6a48

**Packages**:
- scikit-image=0.24.0
- pillow=11.0.0
- numpy=2.1.2
- tifffile=2024.9.20
- scikit-learn=1.5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- color_deconvolution.xml

Generated with Planemo.