### PR TITLE
Add container mulled-v2-4e837765962273925eea842460b6126125401ba6:9e5687184d2dd469ea3f70a7b3b9e32cc4541b9c.

### DIFF
--- a/combinations/mulled-v2-4e837765962273925eea842460b6126125401ba6:9e5687184d2dd469ea3f70a7b3b9e32cc4541b9c-0.tsv
+++ b/combinations/mulled-v2-4e837765962273925eea842460b6126125401ba6:9e5687184d2dd469ea3f70a7b3b9e32cc4541b9c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.13,kraken2=2.1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4e837765962273925eea842460b6126125401ba6:9e5687184d2dd469ea3f70a7b3b9e32cc4541b9c

**Packages**:
- python=3.13
- kraken2=2.1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kraken2_build_database.xml

Generated with Planemo.