### PR TITLE
Add container mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:4eaf25c5eadecd9f8fbdef66e48da7968d87a0ec.

### DIFF
--- a/combinations/mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:4eaf25c5eadecd9f8fbdef66e48da7968d87a0ec-0.tsv
+++ b/combinations/mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:4eaf25c5eadecd9f8fbdef66e48da7968d87a0ec-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+biopython=1.84,snpeff=5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2104de94fc3275c05faf3d41165a700b6e0c9ef9:4eaf25c5eadecd9f8fbdef66e48da7968d87a0ec

**Packages**:
- biopython=1.84
- snpeff=5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snpEff_create_db.xml

Generated with Planemo.