### PR TITLE
Add container mulled-v2-e940c1f12fba10a75ceee176c296cc77bf2d22e8:04c43ed8546dd49053996a6fdc92188190753b6b.

### DIFF
--- a/combinations/mulled-v2-e940c1f12fba10a75ceee176c296cc77bf2d22e8:04c43ed8546dd49053996a6fdc92188190753b6b-0.tsv
+++ b/combinations/mulled-v2-e940c1f12fba10a75ceee176c296cc77bf2d22e8:04c43ed8546dd49053996a6fdc92188190753b6b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.0.1,snpeff=5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e940c1f12fba10a75ceee176c296cc77bf2d22e8:04c43ed8546dd49053996a6fdc92188190753b6b

**Packages**:
- gawk=5.0.1
- snpeff=5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snpeff_get_chr_names.xml

Generated with Planemo.