### PR TITLE
Add container mulled-v2-957f50dd6bc76d5be423d2c095534446b66fdae7:15ed3c3289780d1102388d3b8c43f6a5be1c0329.

### DIFF
--- a/combinations/mulled-v2-957f50dd6bc76d5be423d2c095534446b66fdae7:15ed3c3289780d1102388d3b8c43f6a5be1c0329-0.tsv
+++ b/combinations/mulled-v2-957f50dd6bc76d5be423d2c095534446b66fdae7:15ed3c3289780d1102388d3b8c43f6a5be1c0329-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rasterio=1.3.10,numpy=1.26.3,matplotlib=3.8.4,trends_earth_algorithms=2.1.14,trends_earth_schemas=2.1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-957f50dd6bc76d5be423d2c095534446b66fdae7:15ed3c3289780d1102388d3b8c43f6a5be1c0329

**Packages**:
- rasterio=1.3.10
- numpy=1.26.3
- matplotlib=3.8.4
- trends_earth_algorithms=2.1.14
- trends_earth_schemas=2.1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- landcover_subindic.xml

Generated with Planemo.