### PR TITLE
Add container mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:fb1f797a7d4e136b225aa4ec47657d70fe768eac.

### DIFF
--- a/combinations/mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:fb1f797a7d4e136b225aa4ec47657d70fe768eac-0.tsv
+++ b/combinations/mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:fb1f797a7d4e136b225aa4ec47657d70fe768eac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12,primer3-py=2.0.3,seqfold=0.7.17,varvamp=1.2.1,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:fb1f797a7d4e136b225aa4ec47657d70fe768eac

**Packages**:
- python=3.12
- primer3-py=2.0.3
- seqfold=0.7.17
- varvamp=1.2.1
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- varvamp.xml

Generated with Planemo.