### PR TITLE
Add container mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:d2c9084da1e6388973f20cd5d2839fad19105fbb.

### DIFF
--- a/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:d2c9084da1e6388973f20cd5d2839fad19105fbb-0.tsv
+++ b/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:d2c9084da1e6388973f20cd5d2839fad19105fbb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,subread=2.0.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:d2c9084da1e6388973f20cd5d2839fad19105fbb

**Packages**:
- samtools=1.21
- subread=2.0.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- featurecounts.xml

Generated with Planemo.