### PR TITLE
Add container mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:12de2c1b48f30f1fdcfde79a3bc6a8e934f58e05.

### DIFF
--- a/combinations/mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:12de2c1b48f30f1fdcfde79a3bc6a8e934f58e05-0.tsv
+++ b/combinations/mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:12de2c1b48f30f1fdcfde79a3bc6a8e934f58e05-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pretextsnapshot=0.0.4,rename=1.601	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:12de2c1b48f30f1fdcfde79a3bc6a8e934f58e05

**Packages**:
- pretextsnapshot=0.0.4
- rename=1.601
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pretext_snapshot.xml

Generated with Planemo.