### PR TITLE
Add container mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9dae9a894f9fcbd5b40695e4d949510c452e97cf.

### DIFF
--- a/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9dae9a894f9fcbd5b40695e4d949510c452e97cf-0.tsv
+++ b/combinations/mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9dae9a894f9fcbd5b40695e4d949510c452e97cf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fonts-conda-ecosystem=1,busco=5.8.0,tar=1.34	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-56c8d09b0ac51f7574338061d18e5f093358768e:9dae9a894f9fcbd5b40695e4d949510c452e97cf

**Packages**:
- fonts-conda-ecosystem=1
- busco=5.8.0
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.