### PR TITLE
Add container galaxy-util:23.2.1.

### DIFF
--- a/combinations/galaxy-util:23.2.1-0.tsv
+++ b/combinations/galaxy-util:23.2.1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+galaxy-util=23.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: galaxy-util:23.2.1

**Packages**:
- galaxy-util=23.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tar_to_directory.xml
- archive_to_directory.xml

Generated with Planemo.