### PR TITLE
Add container mulled-v2-2fd74e3493b0020103978a97b5da3e93c6ab6215:040758def5dffb95afd521482a269ad57e5b2f61.

### DIFF
--- a/combinations/mulled-v2-2fd74e3493b0020103978a97b5da3e93c6ab6215:040758def5dffb95afd521482a269ad57e5b2f61-0.tsv
+++ b/combinations/mulled-v2-2fd74e3493b0020103978a97b5da3e93c6ab6215:040758def5dffb95afd521482a269ad57e5b2f61-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-spectra=1.12.0,bioconductor-msbackendmsp=1.6.0,r-purrr=1.0.2,r-envipat=2.6,bioconductor-metabocoreutils=1.10.0,r-stringr=1.5.1,r-readr=2.1.5,r-tidyr=1.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2fd74e3493b0020103978a97b5da3e93c6ab6215:040758def5dffb95afd521482a269ad57e5b2f61

**Packages**:
- bioconductor-spectra=1.12.0
- bioconductor-msbackendmsp=1.6.0
- r-purrr=1.0.2
- r-envipat=2.6
- bioconductor-metabocoreutils=1.10.0
- r-stringr=1.5.1
- r-readr=2.1.5
- r-tidyr=1.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- isolib.xml

Generated with Planemo.