### PR TITLE
Add container mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:50ab68ba10d46709b933a6eb7c8c675a855272ac.

### DIFF
--- a/combinations/mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:50ab68ba10d46709b933a6eb7c8c675a855272ac-0.tsv
+++ b/combinations/mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:50ab68ba10d46709b933a6eb7c8c675a855272ac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+irma=1.2.0,python=3.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:50ab68ba10d46709b933a6eb7c8c675a855272ac

**Packages**:
- irma=1.2.0
- python=3.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- irma.xml

Generated with Planemo.