### PR TITLE
Add container mulled-v2-ccf608c410f6e43d9c108bd347f2a04b3c7d2609:186a246b06098f9bb4ac819e24c77a817f8f39f7.

### DIFF
--- a/combinations/mulled-v2-ccf608c410f6e43d9c108bd347f2a04b3c7d2609:186a246b06098f9bb4ac819e24c77a817f8f39f7-0.tsv
+++ b/combinations/mulled-v2-ccf608c410f6e43d9c108bd347f2a04b3c7d2609:186a246b06098f9bb4ac819e24c77a817f8f39f7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+infernal=1.1.5,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ccf608c410f6e43d9c108bd347f2a04b3c7d2609:186a246b06098f9bb4ac819e24c77a817f8f39f7

**Packages**:
- infernal=1.1.5
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cmpress.xml
- cmsearch.xml
- cmbuild.xml
- cmscan.xml
- cmstat.xml
- cmalign.xml

Generated with Planemo.