### PR TITLE
Add container mulled-v2-754a47f7005ac2c33e46ba3a97ef68abb6ef71f8:aac2489b1179db17f28c2868c3a8e41d4474683a.

### DIFF
--- a/combinations/mulled-v2-754a47f7005ac2c33e46ba3a97ef68abb6ef71f8:aac2489b1179db17f28c2868c3a8e41d4474683a-0.tsv
+++ b/combinations/mulled-v2-754a47f7005ac2c33e46ba3a97ef68abb6ef71f8:aac2489b1179db17f28c2868c3a8e41d4474683a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bedtools=2.31.1,quast=5.3.0,bwa=0.7.18,perl-gd=2.76	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-754a47f7005ac2c33e46ba3a97ef68abb6ef71f8:aac2489b1179db17f28c2868c3a8e41d4474683a

**Packages**:
- bedtools=2.31.1
- quast=5.3.0
- bwa=0.7.18
- perl-gd=2.76
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- quast.xml

Generated with Planemo.