### PR TITLE
Add container mulled-v2-f2c828284650a993a9ae95ad0886a156bed411a0:baadf8a076eb042b3a18144ee70d245c15c84715.

### DIFF
--- a/combinations/mulled-v2-f2c828284650a993a9ae95ad0886a156bed411a0:baadf8a076eb042b3a18144ee70d245c15c84715-0.tsv
+++ b/combinations/mulled-v2-f2c828284650a993a9ae95ad0886a156bed411a0:baadf8a076eb042b3a18144ee70d245c15c84715-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+unzip=6.0,wget=1.21.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f2c828284650a993a9ae95ad0886a156bed411a0:baadf8a076eb042b3a18144ee70d245c15c84715

**Packages**:
- unzip=6.0
- wget=1.21.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- phabox_datamanager.xml

Generated with Planemo.