### PR TITLE
Add container mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:13cb094652ca3545f1222369061ebe2902cd22a3.

### DIFF
--- a/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:13cb094652ca3545f1222369061ebe2902cd22a3-0.tsv
+++ b/combinations/mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:13cb094652ca3545f1222369061ebe2902cd22a3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+abyss=2.3.10,bwa=0.7.18	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0c37e2cabbea75a32163b1262c3dc18ab9d7600e:13cb094652ca3545f1222369061ebe2902cd22a3

**Packages**:
- abyss=2.3.10
- bwa=0.7.18
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- abyss-pe.xml

Generated with Planemo.