### PR TITLE
Add container mulled-v2-c63d5cf2360c8f7c4487a19d138a2adaf7b6e45b:5988a6de40b66d8b72e7aef1f382853beccb446d.

### DIFF
--- a/combinations/mulled-v2-c63d5cf2360c8f7c4487a19d138a2adaf7b6e45b:5988a6de40b66d8b72e7aef1f382853beccb446d-0.tsv
+++ b/combinations/mulled-v2-c63d5cf2360c8f7c4487a19d138a2adaf7b6e45b:5988a6de40b66d8b72e7aef1f382853beccb446d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+quicktree=2.5,hmmer=3.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c63d5cf2360c8f7c4487a19d138a2adaf7b6e45b:5988a6de40b66d8b72e7aef1f382853beccb446d

**Packages**:
- quicktree=2.5
- hmmer=3.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- quicktree.xml

Generated with Planemo.