### PR TITLE
Add container mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:545de0817726354df110aebb329d141491c3eb8a.

### DIFF
--- a/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:545de0817726354df110aebb329d141491c3eb8a-0.tsv
+++ b/combinations/mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:545de0817726354df110aebb329d141491c3eb8a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandoc=3.5,cojac=0.9.3,gmp=6.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fb33265f59b60b2245277d1ce84ed3d06012c921:545de0817726354df110aebb329d141491c3eb8a

**Packages**:
- pandoc=3.5
- cojac=0.9.3
- gmp=6.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_pubmut.xml

Generated with Planemo.