### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:569801f25ac4b9903cc97a107fce58a45f7b8a3a.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:569801f25ac4b9903cc97a107fce58a45f7b8a3a-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:569801f25ac4b9903cc97a107fce58a45f7b8a3a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.13,mosdepth=0.3.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:569801f25ac4b9903cc97a107fce58a45f7b8a3a

**Packages**:
- gzip=1.13
- mosdepth=0.3.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.