### PR TITLE
Add container mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:9e155f397f11b50a23622c970d66631d469a80c1.

### DIFF
--- a/combinations/mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:9e155f397f11b50a23622c970d66631d469a80c1-0.tsv
+++ b/combinations/mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:9e155f397f11b50a23622c970d66631d469a80c1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+cojac=0.9.3,viramp-hub=0.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f4a413ca70d0e5f2a55189adec0b98162f2ad143:9e155f397f11b50a23622c970d66631d469a80c1

**Packages**:
- cojac=0.9.3
- viramp-hub=0.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cooc_mutbamscan.xml

Generated with Planemo.