### PR TITLE
Add container mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:2e46245564afd53ca91be97af8a8342cffad1312.

### DIFF
--- a/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:2e46245564afd53ca91be97af8a8342cffad1312-0.tsv
+++ b/combinations/mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:2e46245564afd53ca91be97af8a8342cffad1312-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyyaml=6.0.1,jbrowse2=2.17.0,bcbio-gff=0.7.1,biopython=1.82,findutils=4.6.0,tabix=1.11,hictk=1.0.0,zip=3.0,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7c1118c363d59676a7626322b826de7dc8da5c1a:2e46245564afd53ca91be97af8a8342cffad1312

**Packages**:
- pyyaml=6.0.1
- jbrowse2=2.17.0
- bcbio-gff=0.7.1
- biopython=1.82
- findutils=4.6.0
- tabix=1.11
- hictk=1.0.0
- zip=3.0
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- jbrowse2.xml

Generated with Planemo.