### PR TITLE
Add container mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:a32944906fa8dc652ab92bc8cd09c1bdc13f3f6f.

### DIFF
--- a/combinations/mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:a32944906fa8dc652ab92bc8cd09c1bdc13f3f6f-0.tsv
+++ b/combinations/mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:a32944906fa8dc652ab92bc8cd09c1bdc13f3f6f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sed=4.8,diffutils=3.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-12f89f6aa51aca9d79a6e704ba7eeab231e53671:a32944906fa8dc652ab92bc8cd09c1bdc13f3f6f

**Packages**:
- sed=4.8
- diffutils=3.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- diff.xml

Generated with Planemo.