### PR TITLE
Add container mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:45c112c73054a4f4b65bb02e7ff026defeb10959.

### DIFF
--- a/combinations/mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:45c112c73054a4f4b65bb02e7ff026defeb10959-0.tsv
+++ b/combinations/mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:45c112c73054a4f4b65bb02e7ff026defeb10959-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fiji=20240614,gawk=5.3.1,omero-py=5.19.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-86ea4156e37f8d43cc39584ad9e0f0d2872be18b:45c112c73054a4f4b65bb02e7ff026defeb10959

**Packages**:
- fiji=20240614
- gawk=5.3.1
- omero-py=5.19.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- max_projections_stack_and_upload_omero.xml

Generated with Planemo.