### PR TITLE
Add container mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:0acf29b7af055df92463e6a5d83f86524ba80281.

### DIFF
--- a/combinations/mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:0acf29b7af055df92463e6a5d83f86524ba80281-0.tsv
+++ b/combinations/mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:0acf29b7af055df92463e6a5d83f86524ba80281-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ucsc-blat=445,proteinortho=6.3.4,diamond=2.1.8,last=1519,blast=2.15.0,mmseqs2=16.747c6	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:0acf29b7af055df92463e6a5d83f86524ba80281

**Packages**:
- ucsc-blat=445
- proteinortho=6.3.4
- diamond=2.1.8
- last=1519
- blast=2.15.0
- mmseqs2=16.747c6
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho.xml
- proteinortho_grab_proteins.xml
- proteinortho_summary.xml

Generated with Planemo.