### PR TITLE
Add container mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:4ab5ef7e7fecabca366d95a706cf908cafe21f68.

### DIFF
--- a/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:4ab5ef7e7fecabca366d95a706cf908cafe21f68-0.tsv
+++ b/combinations/mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:4ab5ef7e7fecabca366d95a706cf908cafe21f68-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,subread=2.0.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-27fa4b32e71813fff6e1a10b01866abba2fc4c6d:4ab5ef7e7fecabca366d95a706cf908cafe21f68

**Packages**:
- samtools=1.21
- subread=2.0.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- featurecounts.xml

Generated with Planemo.