### PR TITLE
Add container mulled-v2-10e67826a934a9099f4e9dc612671cb555fd16eb:c1a5e1187c9f8950c1e81f8c29e803564374ef91.

### DIFF
--- a/combinations/mulled-v2-10e67826a934a9099f4e9dc612671cb555fd16eb:c1a5e1187c9f8950c1e81f8c29e803564374ef91-0.tsv
+++ b/combinations/mulled-v2-10e67826a934a9099f4e9dc612671cb555fd16eb:c1a5e1187c9f8950c1e81f8c29e803564374ef91-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+unzip=6.0,xraylarch=0.9.81,numpy=1.26.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-10e67826a934a9099f4e9dc612671cb555fd16eb:c1a5e1187c9f8950c1e81f8c29e803564374ef91

**Packages**:
- unzip=6.0
- xraylarch=0.9.81
- numpy=1.26.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- larch_extract_group.xml

Generated with Planemo.