### PR TITLE
Add container mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:f3e3c0c496c06c95a4d202840c4eaf0d3022c731.

### DIFF
--- a/combinations/mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:f3e3c0c496c06c95a4d202840c4eaf0d3022c731-0.tsv
+++ b/combinations/mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:f3e3c0c496c06c95a4d202840c4eaf0d3022c731-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,tabpfn=2.0.3,matplotlib=3.9.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:f3e3c0c496c06c95a4d202840c4eaf0d3022c731

**Packages**:
- pandas=2.2.2
- tabpfn=2.0.3
- matplotlib=3.9.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tabpfn.xml

Generated with Planemo.