### PR TITLE
Add container mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee18060512b4798b44304ab578153ae98183923.

### DIFF
--- a/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee18060512b4798b44304ab578153ae98183923-0.tsv
+++ b/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee18060512b4798b44304ab578153ae98183923-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+staramr=0.11.0,mlst=2.23.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:cee18060512b4798b44304ab578153ae98183923

**Packages**:
- staramr=0.11.0
- mlst=2.23.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- staramr_search.xml

Generated with Planemo.