### PR TITLE
add container for MetaMS 1.24.0

### DIFF
--- a/combinations/mulled-v2-13689448941d2fa411fb434d22e02e348bcc7f30:2808f9c6fa509fa6f3cea7ab758e7eb872f609f0.tsv
+++ b/combinations/mulled-v2-13689448941d2fa411fb434d22e02e348bcc7f30:2808f9c6fa509fa6f3cea7ab758e7eb872f609f0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-metams=1.24.0,r-batch=1.1_5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
In my transition from conda to containers I'm left with a few dozens (51) conda environments. I plan to try to create containers for them, one-by-one. 

The first one is for https://toolshed.g2.bx.psu.edu/repos/yguitton/metams_rungc/file/93508ea69eb5 

I checked with `planemo test --biocontainers`