### PR TITLE
add container for metams 2.1.1

### DIFF
--- a/combinations/mulled-v2-8e43efd53951b49bbcd3d50a883c93ef9038a927:51a49b963d243ab8961ab7a9d9dd698d7c1c5386.tsv
+++ b/combinations/mulled-v2-8e43efd53951b49bbcd3d50a883c93ef9038a927:51a49b963d243ab8961ab7a9d9dd698d7c1c5386.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-metams=1.8.0,bioconductor-xcms=1.46.0,r-batch=1.1_4,r-base=3.4.1,libgfortran=3.0.0,libgfortran4=7.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
https://toolshed.g2.bx.psu.edu/repos/yguitton/metams_rungc/file/c75532b75ba1

needed to add r-base=3.4.1,libgfortran=3.0.0,libgfortran4=7.5.0 to get this running