### PR TITLE
Add container mulled-v2-d7b6982b52f20b35fcbe3a2dcac917d683d5f7d9:b930e6f571df26dd2c39bd73ae465ec307858a15.

### DIFF
--- a/combinations/mulled-v2-d7b6982b52f20b35fcbe3a2dcac917d683d5f7d9:b930e6f571df26dd2c39bd73ae465ec307858a15-0.tsv
+++ b/combinations/mulled-v2-d7b6982b52f20b35fcbe3a2dcac917d683d5f7d9:b930e6f571df26dd2c39bd73ae465ec307858a15-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+emboss=6.6.0,perl=5.26	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d7b6982b52f20b35fcbe3a2dcac917d683d5f7d9:b930e6f571df26dd2c39bd73ae465ec307858a15

**Packages**:
- emboss=6.6.0
- perl=5.26
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- emboss_needleall.xml
- emboss_needle.xml

Generated with Planemo.