### PR TITLE
Add container mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:3242e0cd595556c58f9a4a8e19b88f0e41978244.

### DIFF
--- a/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:3242e0cd595556c58f9a4a8e19b88f0e41978244-0.tsv
+++ b/combinations/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:3242e0cd595556c58f9a4a8e19b88f0e41978244-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.9,deeptools=3.5.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:3242e0cd595556c58f9a4a8e19b88f0e41978244

**Packages**:
- samtools=1.9
- deeptools=3.5.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bamCoverage.xml
- computeMatrix.xml
- plotHeatmap.xml
- bigwigAverage.xml
- plotCoverage.xml
- plotEnrichment.xml
- plotProfiler.xml
- bamCompare.xml
- bamPEFragmentSize.xml
- estimateReadFiltering.xml
- plotCorrelation.xml
- multiBamSummary.xml
- alignmentSieve.xml
- plotFingerprint.xml
- bigwigCompare.xml
- multiBigwigSummary.xml
- computeMatrixOperations.xml
- correctGCBias.xml
- computeGCBias.xml
- plotPCA.xml

Generated with Planemo.