### PR TITLE
container for old featurecounts version

### DIFF
--- a/combinations/subread:1.4.6p5-0.tsv
+++ b/combinations/subread:1.4.6p5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+subread=1.4.6p5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
https://toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/file/de2c5e5a206c

can still be built, `planemo test` past locally