### PR TITLE
Add container mulled-v2-edc873ef89b6ac7e909b663f407ebed401281e4c:6ff123ce72fa88eaea4a5bde099fa80a09a299f3.

### DIFF
--- a/combinations/mulled-v2-edc873ef89b6ac7e909b663f407ebed401281e4c:6ff123ce72fa88eaea4a5bde099fa80a09a299f3-0.tsv
+++ b/combinations/mulled-v2-edc873ef89b6ac7e909b663f407ebed401281e4c:6ff123ce72fa88eaea4a5bde099fa80a09a299f3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+libgfortran=3.0.0,r-asics=1.0.1,r-batch=1.1_4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-edc873ef89b6ac7e909b663f407ebed401281e4c:6ff123ce72fa88eaea4a5bde099fa80a09a299f3

**Packages**:
- libgfortran=3.0.0
- r-asics=1.0.1
- r-batch=1.1_4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- asics_xml.xml

Generated with Planemo.