### PR TITLE
Add container mulled-v2-ad62f782ec566fc277dcff1431a7ead35d4018f2:100f47cd1f00e23a9846815dda78604a36dedec9.

### DIFF
--- a/combinations/mulled-v2-ad62f782ec566fc277dcff1431a7ead35d4018f2:100f47cd1f00e23a9846815dda78604a36dedec9-0.tsv
+++ b/combinations/mulled-v2-ad62f782ec566fc277dcff1431a7ead35d4018f2:100f47cd1f00e23a9846815dda78604a36dedec9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+libgfortran=3.0.0,r-matrix=1.2_12,r-reshape2=1.4.3,r-ggplot2=2.2.1,r-batch=1.1_4,r-ptw=1.9_12,r-gridextra=2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ad62f782ec566fc277dcff1431a7ead35d4018f2:100f47cd1f00e23a9846815dda78604a36dedec9

**Packages**:
- libgfortran=3.0.0
- r-matrix=1.2_12
- r-reshape2=1.4.3
- r-ggplot2=2.2.1
- r-batch=1.1_4
- r-ptw=1.9_12
- r-gridextra=2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- NmrPreprocessing_xml.xml

Generated with Planemo.