### PR TITLE
Add container mulled-v2-b1b8c30bd00323e39b4dfd974ad68bbe8cd0fbb8:a48463b5b6eaf8e5a84e066cfb47f5b813ceabf7.

### DIFF
--- a/combinations/mulled-v2-b1b8c30bd00323e39b4dfd974ad68bbe8cd0fbb8:a48463b5b6eaf8e5a84e066cfb47f5b813ceabf7-0.tsv
+++ b/combinations/mulled-v2-b1b8c30bd00323e39b4dfd974ad68bbe8cd0fbb8:a48463b5b6eaf8e5a84e066cfb47f5b813ceabf7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+isoplot=1.3.1,zlib=1.3.1,jinja2=3.0.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b1b8c30bd00323e39b4dfd974ad68bbe8cd0fbb8:a48463b5b6eaf8e5a84e066cfb47f5b813ceabf7

**Packages**:
- isoplot=1.3.1
- zlib=1.3.1
- jinja2=3.0.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- isoplot.xml

Generated with Planemo.