### PR TITLE
Add container mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:93baaa4c4a89ca7357226f466179a12c847b8b22.

### DIFF
--- a/combinations/mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:93baaa4c4a89ca7357226f466179a12c847b8b22-0.tsv
+++ b/combinations/mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:93baaa4c4a89ca7357226f466179a12c847b8b22-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-stringr=1.4.0,r-tidyr=1.0.2,r-batch=1.1_5,r-dplyr=0.8.3,r-openxlsx=4.0.17,r-ggplot2=3.2.1,r-stringi=1,r-curl=3.3,r-jsonlite=1.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-48a5ecb46295b2249de521d707f77cd60e08d56b:93baaa4c4a89ca7357226f466179a12c847b8b22

**Packages**:
- r-stringr=1.4.0
- r-tidyr=1.0.2
- r-batch=1.1_5
- r-dplyr=0.8.3
- r-openxlsx=4.0.17
- r-ggplot2=3.2.1
- r-stringi=1
- r-curl=3.3
- r-jsonlite=1.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- annotationRmn2D_xml.xml

Generated with Planemo.