### PR TITLE
Add container mulled-v2-fced158e7dff1134da4e0ae0b792fd3e92517eb3:ed5cb2cb7bc1aeb85d3e0ad6d0b0806b863c29d0.

### DIFF
--- a/combinations/mulled-v2-fced158e7dff1134da4e0ae0b792fd3e92517eb3:ed5cb2cb7bc1aeb85d3e0ad6d0b0806b863c29d0-0.tsv
+++ b/combinations/mulled-v2-fced158e7dff1134da4e0ae0b792fd3e92517eb3:ed5cb2cb7bc1aeb85d3e0ad6d0b0806b863c29d0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bc=1.07.1,genform=r8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fced158e7dff1134da4e0ae0b792fd3e92517eb3:ed5cb2cb7bc1aeb85d3e0ad6d0b0806b863c29d0

**Packages**:
- bc=1.07.1
- genform=r8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- genform.xml

Generated with Planemo.