### PR TITLE
Add container mulled-v2-33dcf431b5ace1b87639e30c0879530c41dac2df:f30ede53b501941ae1d59a6c7e8f850c46db88d5.

### DIFF
--- a/combinations/mulled-v2-33dcf431b5ace1b87639e30c0879530c41dac2df:f30ede53b501941ae1d59a6c7e8f850c46db88d5-0.tsv
+++ b/combinations/mulled-v2-33dcf431b5ace1b87639e30c0879530c41dac2df:f30ede53b501941ae1d59a6c7e8f850c46db88d5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-scp=1.16.0,bioconductor-scater=1.34.0,bioconductor-qfeatures=1.16.0,r-ggplot2=3.5.1,bioconductor-impute=1.80.0,bioconductor-sva=3.54.0,bioconductor-limma=3.62.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-33dcf431b5ace1b87639e30c0879530c41dac2df:f30ede53b501941ae1d59a6c7e8f850c46db88d5

**Packages**:
- bioconductor-scp=1.16.0
- bioconductor-scater=1.34.0
- bioconductor-qfeatures=1.16.0
- r-ggplot2=3.5.1
- bioconductor-impute=1.80.0
- bioconductor-sva=3.54.0
- bioconductor-limma=3.62.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bioconductor_scp.xml

Generated with Planemo.