### PR TITLE
add container for pjbriggs/trimmomatic/0.39+galaxy0

### DIFF
--- a/combinations/mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:a437643b60572fbc5c7737540884479b6a925b80-0.tsv
+++ b/combinations/mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:a437643b60572fbc5c7737540884479b6a925b80-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+trimmomatic=0.39,coreutils=8.25	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
can not be built due to strict repo priority
which may be fixed in https://github.com/galaxyproject/galaxy/pull/19425

we can leave this open .. in the meantime I will use a mapping resolver to the container for version `0.39+galaxy2`: 
`mulled-v2-e1a6ade46756da3bd8ceef31e6d2e7645f383a87:cc0d0a81b925169f595fa865742dc6e1e836f3cc-0`