### PR TITLE
Add container mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:65bf9642268b955becbb7dfa17bbbdc97119800c.

### DIFF
--- a/combinations/mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:65bf9642268b955becbb7dfa17bbbdc97119800c-0.tsv
+++ b/combinations/mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:65bf9642268b955becbb7dfa17bbbdc97119800c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12,seqfold=0.7.17,primer3-py=2.0.3,varvamp=1.2.2,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-511e23bfd2e92e72c894528955fd2884b4d08d90:65bf9642268b955becbb7dfa17bbbdc97119800c

**Packages**:
- python=3.12
- seqfold=0.7.17
- primer3-py=2.0.3
- varvamp=1.2.2
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- varvamp.xml

Generated with Planemo.