### PR TITLE
Add container mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:ff7936237410a0d66fbc61709d6845d668b18149.

### DIFF
--- a/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:ff7936237410a0d66fbc61709d6845d668b18149-0.tsv
+++ b/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:ff7936237410a0d66fbc61709d6845d668b18149-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+umi_tools=1.1.6,samtools=1.12,sed=4.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:ff7936237410a0d66fbc61709d6845d668b18149

**Packages**:
- umi_tools=1.1.6
- samtools=1.12
- sed=4.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_counts.xml

Generated with Planemo.