### PR TITLE
Add container mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:a051413bc263c7d2ce69b9c33661d4c1439aa8f0.

### DIFF
--- a/combinations/mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:a051413bc263c7d2ce69b9c33661d4c1439aa8f0-0.tsv
+++ b/combinations/mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:a051413bc263c7d2ce69b9c33661d4c1439aa8f0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+umi_tools=1.1.6,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-509311a44630c01d9cb7d2ac5727725f51ea43af:a051413bc263c7d2ce69b9c33661d4c1439aa8f0

**Packages**:
- umi_tools=1.1.6
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_group.xml
- umi-tools_dedup.xml

Generated with Planemo.