### PR TITLE
Add container mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:3d149313609b57e12258e200fa0cd8d63cd6021c.

### DIFF
--- a/combinations/mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:3d149313609b57e12258e200fa0cd8d63cd6021c-0.tsv
+++ b/combinations/mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:3d149313609b57e12258e200fa0cd8d63cd6021c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gnuplot=5.4.10,mummer4=4.0.0,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:3d149313609b57e12258e200fa0cd8d63cd6021c

**Packages**:
- gnuplot=5.4.10
- mummer4=4.0.0
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mummerplot.xml
- mummer.xml
- nucmer.xml

Generated with Planemo.