### PR TITLE
Add container mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:e73da4018b655e73d49688df1459789d173d9e88.

### DIFF
--- a/combinations/mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:e73da4018b655e73d49688df1459789d173d9e88-0.tsv
+++ b/combinations/mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:e73da4018b655e73d49688df1459789d173d9e88-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pybigtools=0.2.4,numpy=2.2.3,python=3.12.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f9d19b6473ad16bbc4c3c75acab0a51f2dec82d8:e73da4018b655e73d49688df1459789d173d9e88

**Packages**:
- pybigtools=0.2.4
- numpy=2.2.3
- python=3.12.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bigwig_outlier_bed.xml

Generated with Planemo.