### PR TITLE
Add container mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:f940b183105e9ea25be202edd1a984553cec587a.

### DIFF
--- a/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:f940b183105e9ea25be202edd1a984553cec587a-0.tsv
+++ b/combinations/mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:f940b183105e9ea25be202edd1a984553cec587a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+requests=2.32.3,python=3.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ffdffc678ef7e057a54c6e2a990ebda211c39d9c:f940b183105e9ea25be202edd1a984553cec587a

**Packages**:
- requests=2.32.3
- python=3.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- get_genetree.xml
- get_feature_info.xml
- get_sequences.xml

Generated with Planemo.