### PR TITLE
Add container mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:4961ae0ac35d39f9d6f2f46be69750f9700239bf.

### DIFF
--- a/combinations/mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:4961ae0ac35d39f9d6f2f46be69750f9700239bf-0.tsv
+++ b/combinations/mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:4961ae0ac35d39f9d6f2f46be69750f9700239bf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mummer4=4.0.0,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:4961ae0ac35d39f9d6f2f46be69750f9700239bf

**Packages**:
- mummer4=4.0.0
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- dnadiff.xml
- show-coords.xml
- delta-filter.xml

Generated with Planemo.