### PR TITLE
Add container mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:0f862c589fc95bcef32fecaa39ca79a7f5b2abf1.

### DIFF
--- a/combinations/mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:0f862c589fc95bcef32fecaa39ca79a7f5b2abf1-0.tsv
+++ b/combinations/mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:0f862c589fc95bcef32fecaa39ca79a7f5b2abf1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyarrow=18.0.0,scipy=1.14.1,pandas=2.2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:0f862c589fc95bcef32fecaa39ca79a7f5b2abf1

**Packages**:
- pyarrow=18.0.0
- scipy=1.14.1
- pandas=2.2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- table_scipy_interpolate.xml

Generated with Planemo.