### PR TITLE
Add container mulled-v2-12bc9d6e0eff0644d9a35d8b37c178f49423c819:a78d022ec748c9125b995330a93dfff590990cd7.

### DIFF
--- a/combinations/mulled-v2-12bc9d6e0eff0644d9a35d8b37c178f49423c819:a78d022ec748c9125b995330a93dfff590990cd7-0.tsv
+++ b/combinations/mulled-v2-12bc9d6e0eff0644d9a35d8b37c178f49423c819:a78d022ec748c9125b995330a93dfff590990cd7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+louvain=0.8.2,muon=0.1.6,mofapy2=0.7.2,leidenalg=0.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-12bc9d6e0eff0644d9a35d8b37c178f49423c819:a78d022ec748c9125b995330a93dfff590990cd7

**Packages**:
- louvain=0.8.2
- muon=0.1.6
- mofapy2=0.7.2
- leidenalg=0.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plot_muon.xml
- mudata_import_export.xml
- preprocess_muon.xml
- cluster_analyze_embed_muon.xml

Generated with Planemo.