### PR TITLE
Add container mulled-v2-23293e4ec2c1f2777a1e93de07bdf74b8b228b17:4e005afdf3dc3081e4f2784db3d3f44e735a9dde.

### DIFF
--- a/combinations/mulled-v2-23293e4ec2c1f2777a1e93de07bdf74b8b228b17:4e005afdf3dc3081e4f2784db3d3f44e735a9dde-0.tsv
+++ b/combinations/mulled-v2-23293e4ec2c1f2777a1e93de07bdf74b8b228b17:4e005afdf3dc3081e4f2784db3d3f44e735a9dde-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scanpy=1.10.4,drug2cell=0.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-23293e4ec2c1f2777a1e93de07bdf74b8b228b17:4e005afdf3dc3081e4f2784db3d3f44e735a9dde

**Packages**:
- scanpy=1.10.4
- drug2cell=0.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- drug2cell.xml

Generated with Planemo.