### PR TITLE
Add container mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:c77d1768040073f81237a5d69dc71f023e597a21.

### DIFF
--- a/combinations/mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:c77d1768040073f81237a5d69dc71f023e597a21-0.tsv
+++ b/combinations/mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:c77d1768040073f81237a5d69dc71f023e597a21-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=16.42.0,unzip=6.0,ca-certificates=2025.1.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:c77d1768040073f81237a5d69dc71f023e597a21

**Packages**:
- ncbi-datasets-cli=16.42.0
- unzip=6.0
- ca-certificates=2025.1.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.