### PR TITLE
Add container mulled-v2-819e05210fb662adfb4a40367b9019baa520896f:ce1c900c611268b837b12b887b62dc5e02ee1f55.

### DIFF
--- a/combinations/mulled-v2-819e05210fb662adfb4a40367b9019baa520896f:ce1c900c611268b837b12b887b62dc5e02ee1f55-0.tsv
+++ b/combinations/mulled-v2-819e05210fb662adfb4a40367b9019baa520896f:ce1c900c611268b837b12b887b62dc5e02ee1f55-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.7.2,seaborn=0.13.2,biopython=1.83,requests=2.32.3,rnaformer=0.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-819e05210fb662adfb4a40367b9019baa520896f:ce1c900c611268b837b12b887b62dc5e02ee1f55

**Packages**:
- matplotlib=3.7.2
- seaborn=0.13.2
- biopython=1.83
- requests=2.32.3
- rnaformer=0.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- infer_rnaformer.xml

Generated with Planemo.