### PR TITLE
Add container mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:6d5a29576c13586f87b84b78efe067678df1b1f5.

### DIFF
--- a/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:6d5a29576c13586f87b84b78efe067678df1b1f5-0.tsv
+++ b/combinations/mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:6d5a29576c13586f87b84b78efe067678df1b1f5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+umi_tools=1.1.6,sed=4.7,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-452184f0fcbe6b0806405adb8f0b3873a7bd70a8:6d5a29576c13586f87b84b78efe067678df1b1f5

**Packages**:
- umi_tools=1.1.6
- sed=4.7
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- umi-tools_group.xml
- umi-tools_dedup.xml
- umi-tools_extract.xml
- umi-tools_counts.xml
- umi-tools_whitelist.xml

Generated with Planemo.