### PR TITLE
Add container mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:e5ca00551d84762eb2368107df8381af0a62bfcc.

### DIFF
--- a/combinations/mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:e5ca00551d84762eb2368107df8381af0a62bfcc-0.tsv
+++ b/combinations/mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:e5ca00551d84762eb2368107df8381af0a62bfcc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,cnvkit=0.9.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:e5ca00551d84762eb2368107df8381af0a62bfcc

**Packages**:
- samtools=1.21
- cnvkit=0.9.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- call.xml
- scatter.xml
- reference.xml
- bed.xml
- nexus_ogt.xml
- sex.xml
- cdt.xml
- jtv.xml
- diagram.xml
- batch.xml
- heatmap.xml
- genemetrics.xml
- target.xml
- autobin.xml
- antitarget.xml
- segmetrics.xml
- breaks.xml
- coverage.xml
- theta.xml
- seg.xml
- segment.xml
- vcf.xml
- fix.xml
- access.xml
- nexus_basic.xml

Generated with Planemo.