### PR TITLE
Add container mulled-v2-16ed29cb9dad9eb6da055eb8f254c43cbad4eeb0:9c0a579c3a5099ce5691f17952f4725df3dcc592.

### DIFF
--- a/combinations/mulled-v2-16ed29cb9dad9eb6da055eb8f254c43cbad4eeb0:9c0a579c3a5099ce5691f17952f4725df3dcc592-0.tsv
+++ b/combinations/mulled-v2-16ed29cb9dad9eb6da055eb8f254c43cbad4eeb0:9c0a579c3a5099ce5691f17952f4725df3dcc592-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pillow=11.0.0,numpy=2.1.2,tifffile=2024.9.20,giatools=0.3.1,scikit-image=0.24.0,scikit-learn=1.5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-16ed29cb9dad9eb6da055eb8f254c43cbad4eeb0:9c0a579c3a5099ce5691f17952f4725df3dcc592

**Packages**:
- pillow=11.0.0
- numpy=2.1.2
- tifffile=2024.9.20
- giatools=0.3.1
- scikit-image=0.24.0
- scikit-learn=1.5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- color_deconvolution.xml

Generated with Planemo.