### PR TITLE
Add container mulled-v2-ed394a41569faf19621452857d938e813eac902d:d3102c7bab93cd939285cfc60ff14b2aef34f211.

### DIFF
--- a/combinations/mulled-v2-ed394a41569faf19621452857d938e813eac902d:d3102c7bab93cd939285cfc60ff14b2aef34f211-0.tsv
+++ b/combinations/mulled-v2-ed394a41569faf19621452857d938e813eac902d:d3102c7bab93cd939285cfc60ff14b2aef34f211-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,psycopg2=2.9.9,sqlalchemy=2.0.37	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ed394a41569faf19621452857d938e813eac902d:d3102c7bab93cd939285cfc60ff14b2aef34f211

**Packages**:
- pandas=2.2.2
- psycopg2=2.9.9
- sqlalchemy=2.0.37
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- get_projects.xml

Generated with Planemo.