### PR TITLE
Add container mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:37994e55e95bc4cf3094eb31fefbae7df143432d.

### DIFF
--- a/combinations/mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:37994e55e95bc4cf3094eb31fefbae7df143432d-0.tsv
+++ b/combinations/mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:37994e55e95bc4cf3094eb31fefbae7df143432d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tifffile=2024.7.24,numpy=2.2.3,giatools=0.3.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:37994e55e95bc4cf3094eb31fefbae7df143432d

**Packages**:
- tifffile=2024.7.24
- numpy=2.2.3
- giatools=0.3.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- split_image.xml

Generated with Planemo.