### PR TITLE
Add container mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:a29061eb7f4ee9b0a20a1b8dfbcc7c44341d8703.

### DIFF
--- a/combinations/mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:a29061eb7f4ee9b0a20a1b8dfbcc7c44341d8703-0.tsv
+++ b/combinations/mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:a29061eb7f4ee9b0a20a1b8dfbcc7c44341d8703-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+wget=1.21.4,jq=1.7.1,curl=8.12.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-199ad9308705cae5d3cf964d59a53551b5a8b131:a29061eb7f4ee9b0a20a1b8dfbcc7c44341d8703

**Packages**:
- wget=1.21.4
- jq=1.7.1
- curl=8.12.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- biaftplink.xml

Generated with Planemo.