### PR TITLE
Add container mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:71ac32d991a15b36d275b8338fe9a13ee2a68f51.

### DIFF
--- a/combinations/mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:71ac32d991a15b36d275b8338fe9a13ee2a68f51-0.tsv
+++ b/combinations/mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:71ac32d991a15b36d275b8338fe9a13ee2a68f51-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.5,perl=5.32	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:71ac32d991a15b36d275b8338fe9a13ee2a68f51

**Packages**:
- coreutils=9.5
- perl=5.32
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- easyjoin.xml

Generated with Planemo.