### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0a12df11191bb85ed0840efef5b86d2367199d79.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0a12df11191bb85ed0840efef5b86d2367199d79-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0a12df11191bb85ed0840efef5b86d2367199d79-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hifiasm=0.24.0,yak=0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:0a12df11191bb85ed0840efef5b86d2367199d79

**Packages**:
- hifiasm=0.24.0
- yak=0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.