### PR TITLE
Add container mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:6c79643c4a432c89ddff35bfcb565602eabc84ba.

### DIFF
--- a/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:6c79643c4a432c89ddff35bfcb565602eabc84ba-0.tsv
+++ b/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:6c79643c4a432c89ddff35bfcb565602eabc84ba-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,freebayes=1.3.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:6c79643c4a432c89ddff35bfcb565602eabc84ba

**Packages**:
- samtools=1.21
- freebayes=1.3.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- leftalign.xml

Generated with Planemo.