### PR TITLE
Add container mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:8bcb0142e35622d92e3078819e1f3f8114bdbd8b.

### DIFF
--- a/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:8bcb0142e35622d92e3078819e1f3f8114bdbd8b-0.tsv
+++ b/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:8bcb0142e35622d92e3078819e1f3f8114bdbd8b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,parallel=20250222,freebayes=1.3.9,gawk=5.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:8bcb0142e35622d92e3078819e1f3f8114bdbd8b

**Packages**:
- samtools=1.21
- parallel=20250222
- freebayes=1.3.9
- gawk=5.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freebayes.xml

Generated with Planemo.