### PR TITLE
Add container mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:4642a9c3de25114f8d4e48d1b76ab32b5ad84a5c.

### DIFF
--- a/combinations/mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:4642a9c3de25114f8d4e48d1b76ab32b5ad84a5c-0.tsv
+++ b/combinations/mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:4642a9c3de25114f8d4e48d1b76ab32b5ad84a5c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+omark=0.3.1,omamer=2.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d9277739fc5d6f1fcf3a88d873ddad655b36739c:4642a9c3de25114f8d4e48d1b76ab32b5ad84a5c

**Packages**:
- omark=0.3.1
- omamer=2.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- omark.xml

Generated with Planemo.