### PR TITLE
Add container mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:2171fd88baa23ce98f8ea9356091915af02e9f1b.

### DIFF
--- a/combinations/mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:2171fd88baa23ce98f8ea9356091915af02e9f1b-0.tsv
+++ b/combinations/mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:2171fd88baa23ce98f8ea9356091915af02e9f1b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2025.1.31,ncbi-datasets-cli=17.1.0,unzip=6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b650e948b670d2a9572fce3fa2b2356a30083af7:2171fd88baa23ce98f8ea9356091915af02e9f1b

**Packages**:
- ca-certificates=2025.1.31
- ncbi-datasets-cli=17.1.0
- unzip=6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.