### PR TITLE
Add container mulled-v2-2f91ab08f37d30aab3a3c4c23f4f3da52179cdc5:1d15faca962e6962eac4f6f58725529b291936b6.

### DIFF
--- a/combinations/mulled-v2-2f91ab08f37d30aab3a3c4c23f4f3da52179cdc5:1d15faca962e6962eac4f6f58725529b291936b6-0.tsv
+++ b/combinations/mulled-v2-2f91ab08f37d30aab3a3c4c23f4f3da52179cdc5:1d15faca962e6962eac4f6f58725529b291936b6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-canyonb=0.9.3,r-logger=0.4.0,r-r.utils=2.13.0,r-base=4.3.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2f91ab08f37d30aab3a3c4c23f4f3da52179cdc5:1d15faca962e6962eac4f6f58725529b291936b6

**Packages**:
- r-canyonb=0.9.3
- r-logger=0.4.0
- r-r.utils=2.13.0
- r-base=4.3.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- canyonb.xml

Generated with Planemo.