### PR TITLE
Add container mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:4aff614678cdb4148839deb33790b3f304a862bd.

### DIFF
--- a/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:4aff614678cdb4148839deb33790b3f304a862bd-0.tsv
+++ b/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:4aff614678cdb4148839deb33790b3f304a862bd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,cutesv=2.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:4aff614678cdb4148839deb33790b3f304a862bd

**Packages**:
- samtools=1.21
- cutesv=2.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cutesv.xml

Generated with Planemo.