### PR TITLE
Add container mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:bd996097b6dd518cf788ddd6c586fb23d039cb9c.

### DIFF
--- a/combinations/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:bd996097b6dd518cf788ddd6c586fb23d039cb9c-0.tsv
+++ b/combinations/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:bd996097b6dd518cf788ddd6c586fb23d039cb9c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,bwa=0.7.19	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:bd996097b6dd518cf788ddd6c586fb23d039cb9c

**Packages**:
- samtools=1.21
- bwa=0.7.19
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bwa.xml
- bwa-mem.xml

Generated with Planemo.