### PR TITLE
Add container mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1301b5b2d7a262e3260acaef4392863cb62ec20f.

### DIFF
--- a/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1301b5b2d7a262e3260acaef4392863cb62ec20f-0.tsv
+++ b/combinations/mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1301b5b2d7a262e3260acaef4392863cb62ec20f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+yak=0.1,hifiasm=0.25.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-36ba0d5590c58fd8485272d70f458149cdb6dd94:1301b5b2d7a262e3260acaef4392863cb62ec20f

**Packages**:
- yak=0.1
- hifiasm=0.25.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hifiasm.xml

Generated with Planemo.