### PR TITLE
Add container mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:01a0c9ec663f64217ceb05c225380e9150d8bc52.

### DIFF
--- a/combinations/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:01a0c9ec663f64217ceb05c225380e9150d8bc52-0.tsv
+++ b/combinations/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:01a0c9ec663f64217ceb05c225380e9150d8bc52-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bwa-mem2=2.2.1,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:01a0c9ec663f64217ceb05c225380e9150d8bc52

**Packages**:
- bwa-mem2=2.2.1
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bwa-mem2.xml

Generated with Planemo.