### PR TITLE
Add container mulled-v2-bcdf8a1757607ebe4b8dbe37b2ef3c1e44de7775:feba6e3ca5bf8d6ecc25f45db6dc60698e107e4a.

### DIFF
--- a/combinations/mulled-v2-bcdf8a1757607ebe4b8dbe37b2ef3c1e44de7775:feba6e3ca5bf8d6ecc25f45db6dc60698e107e4a-0.tsv
+++ b/combinations/mulled-v2-bcdf8a1757607ebe4b8dbe37b2ef3c1e44de7775:feba6e3ca5bf8d6ecc25f45db6dc60698e107e4a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-pgxrpi=1.2.0,bioconductor-genomicranges=1.58.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-bcdf8a1757607ebe4b8dbe37b2ef3c1e44de7775:feba6e3ca5bf8d6ecc25f45db6dc60698e107e4a

**Packages**:
- bioconductor-pgxrpi=1.2.0
- bioconductor-genomicranges=1.58.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pgx_freqplot.xml

Generated with Planemo.