### PR TITLE
Add container mulled-v2-4eea244974a53a81efc346a4fa9bdfd103e1c9df:e8360df15ed14ce0294477d85f8763fa15108270.

### DIFF
--- a/combinations/mulled-v2-4eea244974a53a81efc346a4fa9bdfd103e1c9df:e8360df15ed14ce0294477d85f8763fa15108270-0.tsv
+++ b/combinations/mulled-v2-4eea244974a53a81efc346a4fa9bdfd103e1c9df:e8360df15ed14ce0294477d85f8763fa15108270-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fonts-conda-ecosystem=1,tar=1.34,busco=5.8.0,sepp=4.5.5,augustus=3.5.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4eea244974a53a81efc346a4fa9bdfd103e1c9df:e8360df15ed14ce0294477d85f8763fa15108270

**Packages**:
- fonts-conda-ecosystem=1
- tar=1.34
- busco=5.8.0
- sepp=4.5.5
- augustus=3.5.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- busco.xml

Generated with Planemo.