### PR TITLE
Add container mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:c0ba8ec647a34d671566564643ea55f193dd1628.

### DIFF
--- a/combinations/mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:c0ba8ec647a34d671566564643ea55f193dd1628-0.tsv
+++ b/combinations/mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:c0ba8ec647a34d671566564643ea55f193dd1628-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+last=1519,mmseqs2=16.747c6,ucsc-blat=445,proteinortho=6.3.5,diamond=2.1.8,blast=2.15.0	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:c0ba8ec647a34d671566564643ea55f193dd1628

**Packages**:
- last=1519
- mmseqs2=16.747c6
- ucsc-blat=445
- proteinortho=6.3.5
- diamond=2.1.8
- blast=2.15.0
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- proteinortho.xml
- proteinortho_summary.xml
- proteinortho_grab_proteins.xml

Generated with Planemo.