### PR TITLE
Add container mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:de2082c5ae83f54b66cab8c76132fe73f5e29e43.

### DIFF
--- a/combinations/mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:de2082c5ae83f54b66cab8c76132fe73f5e29e43-0.tsv
+++ b/combinations/mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:de2082c5ae83f54b66cab8c76132fe73f5e29e43-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+panaroo=1.5.2,prank=170427,clustalo=1.2.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:de2082c5ae83f54b66cab8c76132fe73f5e29e43

**Packages**:
- panaroo=1.5.2
- prank=170427
- clustalo=1.2.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- panaroo.xml

Generated with Planemo.