### PR TITLE
Add container mulled-v2-7feffe07e7974577fd2f0e0bb9db85a0475d6c63:908ca4f4450f8e9062958587a17690e415721ef1.

### DIFF
--- a/combinations/mulled-v2-7feffe07e7974577fd2f0e0bb9db85a0475d6c63:908ca4f4450f8e9062958587a17690e415721ef1-0.tsv
+++ b/combinations/mulled-v2-7feffe07e7974577fd2f0e0bb9db85a0475d6c63:908ca4f4450f8e9062958587a17690e415721ef1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+crbeam=1.1.1,gammapy=1.3,minio=7.2.15,scipy=1.11.4,specutils=1.19.0,astroquery=0.4.10,oda-api=1.2.37,unzip=6.0,astropy=5.3,ipython=9.1.0,seaborn=0.13.2,pyarrow=19.0.1,matplotlib=3.9.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7feffe07e7974577fd2f0e0bb9db85a0475d6c63:908ca4f4450f8e9062958587a17690e415721ef1

**Packages**:
- crbeam=1.1.1
- gammapy=1.3
- minio=7.2.15
- scipy=1.11.4
- specutils=1.19.0
- astroquery=0.4.10
- oda-api=1.2.37
- unzip=6.0
- astropy=5.3
- ipython=9.1.0
- seaborn=0.13.2
- pyarrow=19.0.1
- matplotlib=3.9.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- crbeam_astro_tool.xml

Generated with Planemo.