### PR TITLE
Add container mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:6a4ab77d91b765aabec93d72a2c9858491aaad58.

### DIFF
--- a/combinations/mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:6a4ab77d91b765aabec93d72a2c9858491aaad58-0.tsv
+++ b/combinations/mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:6a4ab77d91b765aabec93d72a2c9858491aaad58-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tifffile=2024.7.24,giatools=0.4.0,numpy=2.2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4b113da51cc8adbc9a79baf6c7c613ff34cde372:6a4ab77d91b765aabec93d72a2c9858491aaad58

**Packages**:
- tifffile=2024.7.24
- giatools=0.4.0
- numpy=2.2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- split_image.xml

Generated with Planemo.