### PR TITLE
Add container mmseqs2:17-b804f.

### DIFF
--- a/combinations/mmseqs2:17-b804f-0.tsv
+++ b/combinations/mmseqs2:17-b804f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mmseqs2=17-b804f	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mmseqs2:17-b804f

**Packages**:
- mmseqs2=17-b804f
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_mmseqs2_download.xml
- mmseqs2_easy_linclust_clustering.xml
- mmseqs2_taxonomy_assignment.xml

Generated with Planemo.