### PR TITLE
Add container mulled-v2-39f74662834bd287fbb0de4c90168baef5d87181:d2b47535cf3c87fc09b3230705d95d1b75995e31.

### DIFF
--- a/combinations/mulled-v2-39f74662834bd287fbb0de4c90168baef5d87181:d2b47535cf3c87fc09b3230705d95d1b75995e31-0.tsv
+++ b/combinations/mulled-v2-39f74662834bd287fbb0de4c90168baef5d87181:d2b47535cf3c87fc09b3230705d95d1b75995e31-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-ptxqc=1.1.2,tar=1.34	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-39f74662834bd287fbb0de4c90168baef5d87181:d2b47535cf3c87fc09b3230705d95d1b75995e31

**Packages**:
- r-ptxqc=1.1.2
- tar=1.34
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ptxqc.xml

Generated with Planemo.