### PR TITLE
Add container mulled-v2-ee351bcffe679239ab5b7f280bb28e9009aa138c:ede13f3dff8a2d811394359dcdc7a4bf12bb0ca9.

### DIFF
--- a/combinations/mulled-v2-ee351bcffe679239ab5b7f280bb28e9009aa138c:ede13f3dff8a2d811394359dcdc7a4bf12bb0ca9-0.tsv
+++ b/combinations/mulled-v2-ee351bcffe679239ab5b7f280bb28e9009aa138c:ede13f3dff8a2d811394359dcdc7a4bf12bb0ca9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+cutadapt=2.10,vsearch=2.17.0,frogs=4.2.0,flash=1.2.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ee351bcffe679239ab5b7f280bb28e9009aa138c:ede13f3dff8a2d811394359dcdc7a4bf12bb0ca9

**Packages**:
- cutadapt=2.10
- vsearch=2.17.0
- frogs=4.2.0
- flash=1.2.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- preprocess.xml

Generated with Planemo.