### PR TITLE
Add container mulled-v2-71fbe7efab895583dedab68da2f0aacd2a35dac1:a3cca2e92e1ae97e6da0256e169b7b12bfd5bae6.

### DIFF
--- a/combinations/mulled-v2-71fbe7efab895583dedab68da2f0aacd2a35dac1:a3cca2e92e1ae97e6da0256e169b7b12bfd5bae6-0.tsv
+++ b/combinations/mulled-v2-71fbe7efab895583dedab68da2f0aacd2a35dac1:a3cca2e92e1ae97e6da0256e169b7b12bfd5bae6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+picrust2=2.5.1,ete3=3.1.2,frogs=4.2.0,dendropy=4.5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-71fbe7efab895583dedab68da2f0aacd2a35dac1:a3cca2e92e1ae97e6da0256e169b7b12bfd5bae6

**Packages**:
- picrust2=2.5.1
- ete3=3.1.2
- frogs=4.2.0
- dendropy=4.5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- frogsfunc_placeseqs.xml

Generated with Planemo.