### PR TITLE
Add container mulled-v2-e1decbc76b42983dd623e78c3339748ee210467d:8eb9770cc6967b040c941daefa5be8934c16ae78.

### DIFF
--- a/combinations/mulled-v2-e1decbc76b42983dd623e78c3339748ee210467d:8eb9770cc6967b040c941daefa5be8934c16ae78-0.tsv
+++ b/combinations/mulled-v2-e1decbc76b42983dd623e78c3339748ee210467d:8eb9770cc6967b040c941daefa5be8934c16ae78-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.1.2,r-essentials=4.1,bioconductor-phyloseq=1.38.0,frogs=4.2.0,r-optparse=1.6.6,bioconductor-deseq2=1.34.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e1decbc76b42983dd623e78c3339748ee210467d:8eb9770cc6967b040c941daefa5be8934c16ae78

**Packages**:
- r-base=4.1.2
- r-essentials=4.1
- bioconductor-phyloseq=1.38.0
- frogs=4.2.0
- r-optparse=1.6.6
- bioconductor-deseq2=1.34.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deseq2_preprocess.xml

Generated with Planemo.