### PR TITLE
Add container mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:1a103753035f88a24c96445c18730d8b367cdba1.

### DIFF
--- a/combinations/mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:1a103753035f88a24c96445c18730d8b367cdba1-0.tsv
+++ b/combinations/mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:1a103753035f88a24c96445c18730d8b367cdba1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+itsx=1.1.2,frogs=4.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5032d217dde9b91bd06825e6db0646de94947f10:1a103753035f88a24c96445c18730d8b367cdba1

**Packages**:
- itsx=1.1.2
- frogs=4.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- itsx.xml

Generated with Planemo.