### PR TITLE
Add container mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:11b4ef95ca2d13784331874c0a89cbf0a9119e2e.

### DIFF
--- a/combinations/mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:11b4ef95ca2d13784331874c0a89cbf0a9119e2e-0.tsv
+++ b/combinations/mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:11b4ef95ca2d13784331874c0a89cbf0a9119e2e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.1.2,r-essentials=4.1,r-plotly=4.9.3,bioconductor-phyloseq=1.38.0,frogs=4.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5a447d16e5284b651c01727693c5b9561cddaa3c:11b4ef95ca2d13784331874c0a89cbf0a9119e2e

**Packages**:
- r-base=4.1.2
- r-essentials=4.1
- r-plotly=4.9.3
- bioconductor-phyloseq=1.38.0
- frogs=4.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- phyloseq_composition.xml
- phyloseq_structure.xml

Generated with Planemo.