### PR TITLE
Add container mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:a3a6ee248c9d2f2546e9df574d9a47022bfb2c25.

### DIFF
--- a/combinations/mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:a3a6ee248c9d2f2546e9df574d9a47022bfb2c25-0.tsv
+++ b/combinations/mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:a3a6ee248c9d2f2546e9df574d9a47022bfb2c25-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-phyloseq=1.38.0,r-base=4.1.2,frogs=4.2.0,r-essentials=4.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a821c4bea66cea804ac87bc19faa8423889aba86:a3a6ee248c9d2f2546e9df574d9a47022bfb2c25

**Packages**:
- bioconductor-phyloseq=1.38.0
- r-base=4.1.2
- frogs=4.2.0
- r-essentials=4.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- phyloseq_manova.xml
- phyloseq_alpha_diversity.xml
- phyloseq_clustering.xml
- phyloseq_import_data.xml

Generated with Planemo.