### PR TITLE
Add container mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:c387e0c198d1aba22fc8958e9216175e416b89a5.

### DIFF
--- a/combinations/mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:c387e0c198d1aba22fc8958e9216175e416b89a5-0.tsv
+++ b/combinations/mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:c387e0c198d1aba22fc8958e9216175e416b89a5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.1.2,r-essentials=4.1,fasttree=2.1.9,frogs=4.2.0,mafft=7.407,r-phangorn=2.7.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:c387e0c198d1aba22fc8958e9216175e416b89a5

**Packages**:
- r-base=4.1.2
- r-essentials=4.1
- fasttree=2.1.9
- frogs=4.2.0
- mafft=7.407
- r-phangorn=2.7.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tree.xml

Generated with Planemo.