### PR TITLE
Add container mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:09b31ac360b021b0288af4e8bd493f58ec52e23a.

### DIFF
--- a/combinations/mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:09b31ac360b021b0288af4e8bd493f58ec52e23a-0.tsv
+++ b/combinations/mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:09b31ac360b021b0288af4e8bd493f58ec52e23a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+vsearch=2.17.0,frogs=4.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-71cddb978e5f3315c70a3f17d789573659480a96:09b31ac360b021b0288af4e8bd493f58ec52e23a

**Packages**:
- vsearch=2.17.0
- frogs=4.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- remove_chimera.xml

Generated with Planemo.