### PR TITLE
Add container mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:0104cbff0efe4cdeee2d436e5743eb041eb30c45.

### DIFF
--- a/combinations/mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:0104cbff0efe4cdeee2d436e5743eb041eb30c45-0.tsv
+++ b/combinations/mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:0104cbff0efe4cdeee2d436e5743eb041eb30c45-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+swarm=3.0.0,frogs=4.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-adfff4092b8562ca6afcc0f64e1e34b11e0d641d:0104cbff0efe4cdeee2d436e5743eb041eb30c45

**Packages**:
- swarm=3.0.0
- frogs=4.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- clustering.xml

Generated with Planemo.