### PR TITLE
Add container mulled-v2-8dd65c41aa60fd4f2507c47beb8ea8dadcf1c96c:b45228bcd45ddb3859e7ade6d71c72e80bb55d59.

### DIFF
--- a/combinations/mulled-v2-8dd65c41aa60fd4f2507c47beb8ea8dadcf1c96c:b45228bcd45ddb3859e7ade6d71c72e80bb55d59-0.tsv
+++ b/combinations/mulled-v2-8dd65c41aa60fd4f2507c47beb8ea8dadcf1c96c:b45228bcd45ddb3859e7ade6d71c72e80bb55d59-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+picrust2=2.5.1,ete3=3.1.2,frogs=4.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8dd65c41aa60fd4f2507c47beb8ea8dadcf1c96c:b45228bcd45ddb3859e7ade6d71c72e80bb55d59

**Packages**:
- picrust2=2.5.1
- ete3=3.1.2
- frogs=4.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- frogsfunc_pathways.xml
- frogsfunc_functions.xml

Generated with Planemo.