### PR TITLE
Add container astropy:6.1.7.

### DIFF
--- a/combinations/astropy:6.1.7-0.tsv
+++ b/combinations/astropy:6.1.7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+astropy=6.1.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: astropy:6.1.7

**Packages**:
- astropy=6.1.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fits2table.xml
- fitsinfo.xml

Generated with Planemo.