### PR TITLE
Add container mulled-v2-32f09a9c4e9f3b38caeebbe1955deedb903a851e:d349240a8d5b46f0fcda8cfcbfc7a6de5db886f3.

### DIFF
--- a/combinations/mulled-v2-32f09a9c4e9f3b38caeebbe1955deedb903a851e:d349240a8d5b46f0fcda8cfcbfc7a6de5db886f3-0.tsv
+++ b/combinations/mulled-v2-32f09a9c4e9f3b38caeebbe1955deedb903a851e:d349240a8d5b46f0fcda8cfcbfc7a6de5db886f3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ipython=9.1.0,matplotlib=3.9.2,astropy=5.3,pandas=2.2.3,gammapy=1.2,oda-api=1.2.37	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-32f09a9c4e9f3b38caeebbe1955deedb903a851e:d349240a8d5b46f0fcda8cfcbfc7a6de5db886f3

**Packages**:
- ipython=9.1.0
- matplotlib=3.9.2
- astropy=5.3
- pandas=2.2.3
- gammapy=1.2
- oda-api=1.2.37
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- plot_tools_astro_tool.xml

Generated with Planemo.