### PR TITLE
Add container mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:1d7bc6d978694f62c136e63e0739b0630c28bf9c.

### DIFF
--- a/combinations/mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:1d7bc6d978694f62c136e63e0739b0630c28bf9c-0.tsv
+++ b/combinations/mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:1d7bc6d978694f62c136e63e0739b0630c28bf9c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.10.1,astropy=6.1.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-310da202c615cd36d0202e6b23c9653dd340854f:1d7bc6d978694f62c136e63e0739b0630c28bf9c

**Packages**:
- matplotlib=3.10.1
- astropy=6.1.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fits2bitmap.xml

Generated with Planemo.