### PR TITLE
Add container mulled-v2-bddec11518ad9f663452ca2d476c114735687122:1bc9545319dfeab88abf4a5886e3175f77723897.

### DIFF
--- a/combinations/mulled-v2-bddec11518ad9f663452ca2d476c114735687122:1bc9545319dfeab88abf4a5886e3175f77723897-0.tsv
+++ b/combinations/mulled-v2-bddec11518ad9f663452ca2d476c114735687122:1bc9545319dfeab88abf4a5886e3175f77723897-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+nbconvert=7.16.6,oda-api=1.2.33,astroquery=0.4.10,astropy=6.1.4,matplotlib=3.10.1,ipython=9.1.0,wget=1.21.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-bddec11518ad9f663452ca2d476c114735687122:1bc9545319dfeab88abf4a5886e3175f77723897

**Packages**:
- nbconvert=7.16.6
- oda-api=1.2.33
- astroquery=0.4.10
- astropy=6.1.4
- matplotlib=3.10.1
- ipython=9.1.0
- wget=1.21.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- desi_legacy_survey_astro_tool.xml

Generated with Planemo.