### PR TITLE
Add container mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:af42272c6a113d792ea2c9bf550aa9839df702fc.

### DIFF
--- a/combinations/mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:af42272c6a113d792ea2c9bf550aa9839df702fc-0.tsv
+++ b/combinations/mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:af42272c6a113d792ea2c9bf550aa9839df702fc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+blast=2.16.0,frogs=4.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce8dd3c5f4359e78f7001d23dbd4af91e1800d54:af42272c6a113d792ea2c9bf550aa9839df702fc

**Packages**:
- blast=2.16.0
- frogs=4.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cluster_filters.xml

Generated with Planemo.