### PR TITLE
Add container mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:032e116eb776b70b0c2134c93b4ae97374a9e225.

### DIFF
--- a/combinations/mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:032e116eb776b70b0c2134c93b4ae97374a9e225-0.tsv
+++ b/combinations/mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:032e116eb776b70b0c2134c93b4ae97374a9e225-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+blast=2.16.0,frogs=4.2.0,emboss=6.6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e37245461f78d975eb456c9ac9b680be43ec17fb:032e116eb776b70b0c2134c93b4ae97374a9e225

**Packages**:
- blast=2.16.0
- frogs=4.2.0
- emboss=6.6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- taxonomic_affiliation.xml

Generated with Planemo.