### PR TITLE
Add container mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:f530d7f34897a5d73323709ecd46dddcbeaccc7b.

### DIFF
--- a/combinations/mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:f530d7f34897a5d73323709ecd46dddcbeaccc7b-0.tsv
+++ b/combinations/mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:f530d7f34897a5d73323709ecd46dddcbeaccc7b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+fasttree=2.1.9,frogs=4.2.0,r-base=4.1.2,mafft=7.525,r-phangorn=2.7.0,r-essentials=4.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-912842e2727ae25e6e8f7f2cb82656c8d9f3acaa:f530d7f34897a5d73323709ecd46dddcbeaccc7b

**Packages**:
- fasttree=2.1.9
- frogs=4.2.0
- r-base=4.1.2
- mafft=7.525
- r-phangorn=2.7.0
- r-essentials=4.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tree.xml

Generated with Planemo.