### PR TITLE
Add container mulled-v2-f6fcabfe9363af00ef26528e63080d6c2318d453:df8f008d7082adb33952d84a19f3702c7f1b3d57.

### DIFF
--- a/combinations/mulled-v2-f6fcabfe9363af00ef26528e63080d6c2318d453:df8f008d7082adb33952d84a19f3702c7f1b3d57-0.tsv
+++ b/combinations/mulled-v2-f6fcabfe9363af00ef26528e63080d6c2318d453:df8f008d7082adb33952d84a19f3702c7f1b3d57-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scipy=1.12.0,giatools=0.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f6fcabfe9363af00ef26528e63080d6c2318d453:df8f008d7082adb33952d84a19f3702c7f1b3d57

**Packages**:
- scipy=1.12.0
- giatools=0.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- binary2label.xml

Generated with Planemo.