### PR TITLE
Add container mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:253ae2f8aef348ad55da82735119b7989642e812.

### DIFF
--- a/combinations/mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:253ae2f8aef348ad55da82735119b7989642e812-0.tsv
+++ b/combinations/mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:253ae2f8aef348ad55da82735119b7989642e812-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gffcompare=0.12.9,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:253ae2f8aef348ad55da82735119b7989642e812

**Packages**:
- gffcompare=0.12.9
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- gffcompare.xml

Generated with Planemo.