### PR TITLE
Add container mulled-v2-2ee70ce3f78ef8d82793ced4935f87f1aa932abb:380ea6ccbd09d76d822cfd2cb7c95e4ddb02d1f3.

### DIFF
--- a/combinations/mulled-v2-2ee70ce3f78ef8d82793ced4935f87f1aa932abb:380ea6ccbd09d76d822cfd2cb7c95e4ddb02d1f3-0.tsv
+++ b/combinations/mulled-v2-2ee70ce3f78ef8d82793ced4935f87f1aa932abb:380ea6ccbd09d76d822cfd2cb7c95e4ddb02d1f3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mummer=3.23,scikit-learn=1.1.3,bowtie2=2.5.4,vrhyme=1.1.0,bwa-mem2=2.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2ee70ce3f78ef8d82793ced4935f87f1aa932abb:380ea6ccbd09d76d822cfd2cb7c95e4ddb02d1f3

**Packages**:
- mummer=3.23
- scikit-learn=1.1.3
- bowtie2=2.5.4
- vrhyme=1.1.0
- bwa-mem2=2.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vrhyme.xml

Generated with Planemo.