### PR TITLE
Add container mulled-v2-c355466644a287e15c49ec6a68682483411451af:8bc4c8632dccefd42fa2e86105ddc3f739ef343f.

### DIFF
--- a/combinations/mulled-v2-c355466644a287e15c49ec6a68682483411451af:8bc4c8632dccefd42fa2e86105ddc3f739ef343f-0.tsv
+++ b/combinations/mulled-v2-c355466644a287e15c49ec6a68682483411451af:8bc4c8632dccefd42fa2e86105ddc3f739ef343f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-svglite=2.1.0,r-reshape2=1.4.4,r-ggplot2=3.5.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c355466644a287e15c49ec6a68682483411451af:8bc4c8632dccefd42fa2e86105ddc3f739ef343f

**Packages**:
- r-svglite=2.1.0
- r-reshape2=1.4.4
- r-ggplot2=3.5.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ggplot_violin.xml
- ggplot_histogram.xml

Generated with Planemo.