### PR TITLE
Add container mulled-v2-a13d161f6b4e0a6cd4909292ec5589809f738977:1320b49fc28f6356ae5d733f10749fa4a13a6d9f.

### DIFF
--- a/combinations/mulled-v2-a13d161f6b4e0a6cd4909292ec5589809f738977:1320b49fc28f6356ae5d733f10749fa4a13a6d9f-0.tsv
+++ b/combinations/mulled-v2-a13d161f6b4e0a6cd4909292ec5589809f738977:1320b49fc28f6356ae5d733f10749fa4a13a6d9f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib-base=3.9.4,statsmodels=0.14.4,pandas=2.2.3,python-kaleido=0.2.1,scipy=1.13.1,plotly=6.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a13d161f6b4e0a6cd4909292ec5589809f738977:1320b49fc28f6356ae5d733f10749fa4a13a6d9f

**Packages**:
- matplotlib-base=3.9.4
- statsmodels=0.14.4
- pandas=2.2.3
- python-kaleido=0.2.1
- scipy=1.13.1
- plotly=6.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- maplot.xml

Generated with Planemo.