### PR TITLE
Add container mulled-v2-c065c08e9c5cd202e9d9480f7e05eaf729ff62f8:ec0d390a9971f6760d20b66c055a14e8bdb5d379.

### DIFF
--- a/combinations/mulled-v2-c065c08e9c5cd202e9d9480f7e05eaf729ff62f8:ec0d390a9971f6760d20b66c055a14e8bdb5d379-0.tsv
+++ b/combinations/mulled-v2-c065c08e9c5cd202e9d9480f7e05eaf729ff62f8:ec0d390a9971f6760d20b66c055a14e8bdb5d379-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ipapy2=1.3.0,fastparquet=2024.11.0,pyarrow=19.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c065c08e9c5cd202e9d9480f7e05eaf729ff62f8:ec0d390a9971f6760d20b66c055a14e8bdb5d379

**Packages**:
- ipapy2=1.3.0
- fastparquet=2024.11.0
- pyarrow=19.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ipapy2_MS1_annotation.xml
- ipapy2_map_isotope_patterns.xml
- ipapy2_MS2_annotation.xml
- ipapy2_compute_all_adducts.xml
- ipapy2_gibbs_sampler_add.xml
- ipapy2_gibbs_sampler.xml
- ipapy2_clustering.xml
- ipapy2_compute_bio.xml

Generated with Planemo.