### PR TITLE
Add container mulled-v2-4e32b9c9f94525939b8d33d44debe6410d25df28:5b6e75f46c304478d00548ca00896f9b1b8d1e37.

### DIFF
--- a/combinations/mulled-v2-4e32b9c9f94525939b8d33d44debe6410d25df28:5b6e75f46c304478d00548ca00896f9b1b8d1e37-0.tsv
+++ b/combinations/mulled-v2-4e32b9c9f94525939b8d33d44debe6410d25df28:5b6e75f46c304478d00548ca00896f9b1b8d1e37-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bwa=0.7.18,mummer=3.23,scikit-learn=1.2.2,bowtie2=2.5.4,vrhyme=1.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4e32b9c9f94525939b8d33d44debe6410d25df28:5b6e75f46c304478d00548ca00896f9b1b8d1e37

**Packages**:
- bwa=0.7.18
- mummer=3.23
- scikit-learn=1.2.2
- bowtie2=2.5.4
- vrhyme=1.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vrhyme.xml

Generated with Planemo.