### PR TITLE
Add container mulled-v2-faf39a849844225d3e8e207461b41267d626ea2c:28d93c720a3f8d81e77088e242ed05a32d5aaeff.

### DIFF
--- a/combinations/mulled-v2-faf39a849844225d3e8e207461b41267d626ea2c:28d93c720a3f8d81e77088e242ed05a32d5aaeff-0.tsv
+++ b/combinations/mulled-v2-faf39a849844225d3e8e207461b41267d626ea2c:28d93c720a3f8d81e77088e242ed05a32d5aaeff-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.11,sylph-tax=1.2.0,sylph=0.8.1,pandas=2.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-faf39a849844225d3e8e207461b41267d626ea2c:28d93c720a3f8d81e77088e242ed05a32d5aaeff

**Packages**:
- python=3.11
- sylph-tax=1.2.0
- sylph=0.8.1
- pandas=2.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sylph_profile.xml

Generated with Planemo.