### PR TITLE
Add container mulled-v2-c088e889f37070cea21e65601fdb903dcbe63d91:e31f776eacd5989d6414d032cdf7521c76697622.

### DIFF
--- a/combinations/mulled-v2-c088e889f37070cea21e65601fdb903dcbe63d91:e31f776eacd5989d6414d032cdf7521c76697622-0.tsv
+++ b/combinations/mulled-v2-c088e889f37070cea21e65601fdb903dcbe63d91:e31f776eacd5989d6414d032cdf7521c76697622-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xgboost=3.0.0,datasets=3.6.0,cleanlab=2.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c088e889f37070cea21e65601fdb903dcbe63d91:e31f776eacd5989d6414d032cdf7521c76697622

**Packages**:
- xgboost=3.0.0
- datasets=3.6.0
- cleanlab=2.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cleanlab_issue_handler.xml

Generated with Planemo.