### PR TITLE
Add container mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:b76331420004c8e62c22dac9f1e33c7deee7cecf.

### DIFF
--- a/combinations/mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:b76331420004c8e62c22dac9f1e33c7deee7cecf-0.tsv
+++ b/combinations/mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:b76331420004c8e62c22dac9f1e33c7deee7cecf-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.9.2,pandas=2.2.2,tabpfn=2.0.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:b76331420004c8e62c22dac9f1e33c7deee7cecf

**Packages**:
- matplotlib=3.9.2
- pandas=2.2.2
- tabpfn=2.0.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tabpfn.xml

Generated with Planemo.