### PR TITLE
Add container mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:023cceb1722b5d7c6e872dc9c68e6f27a8d5f28e.

### DIFF
--- a/combinations/mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:023cceb1722b5d7c6e872dc9c68e6f27a8d5f28e-0.tsv
+++ b/combinations/mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:023cceb1722b5d7c6e872dc9c68e6f27a8d5f28e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.13,samtools=1.18,star=2.7.11b	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2f4d4e7150bfb28621e88e8148cc0d0a8d93258c:023cceb1722b5d7c6e872dc9c68e6f27a8d5f28e

**Packages**:
- gzip=1.13
- samtools=1.18
- star=2.7.11b
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rna_star_index_builder.xml
- rg_rnaStar.xml
- rg_rnaStarSolo.xml

Generated with Planemo.