### PR TITLE
Add a container with snpsift and tabix

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -646,3 +646,4 @@ khmer=3.0.0a3,sourmash=4.8.3
 ncbi-datasets-cli=15.11.0,samtools=1.18,unzip=6.0
 quarto=1.6.41,r-pathosurveilr=0.3.1
 ncbi-datasets-cli=16.0.0,samtools=1.18,unzip=6.0
+snpsift=5.2,tabix=1.11


### PR DESCRIPTION
Adding a container with snpsift 5.2 and tabix 1.11, this would be useful to be able to compress and index the output VCF from snpsift.