### PR TITLE
Add a container with minimap2 v2.29 and samtools v1.22

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -646,3 +646,4 @@ khmer=3.0.0a3,sourmash=4.8.3
 ncbi-datasets-cli=15.11.0,samtools=1.18,unzip=6.0
 quarto=1.6.41,r-pathosurveilr=0.3.1
 ncbi-datasets-cli=16.0.0,samtools=1.18,unzip=6.0
+minimap2=2.29,samtools=1.22


### PR DESCRIPTION
Adding a container with minimap2 v2.29 and samtools v1.22, to convert minimap2 SAM output to BAM inside the same container (and use the most recent versions of both tools).