### PR TITLE
Add Sigprofiler packages combinations to hash.tsv

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -646,3 +646,4 @@ khmer=3.0.0a3,sourmash=4.8.3
 ncbi-datasets-cli=15.11.0,samtools=1.18,unzip=6.0
 quarto=1.6.41,r-pathosurveilr=0.3.1
 ncbi-datasets-cli=16.0.0,samtools=1.18,unzip=6.0
+pandas=2.2.3,sigprofilermatrixgenerator=1.3.3,sigprofilerextractor=1.2.1


### PR DESCRIPTION
Added Python `Sigprofiler` packages to `hash.tsv` to create a mulled container to use by nf-core pipeline:
`pandas=2.2.3,sigprofilermatrixgenerator=1.3.3,sigprofilerextractor=1.2.1`