### PR TITLE
Add container mulled-v2-8e9cbaa9bc8b8b308b9197a76268e1439bbd2a2f:9c8cbf5e91c8a21db4785b4fd7f1bfe7bd8d5f7f.

### DIFF
--- a/combinations/mulled-v2-8e9cbaa9bc8b8b308b9197a76268e1439bbd2a2f:9c8cbf5e91c8a21db4785b4fd7f1bfe7bd8d5f7f-0.tsv
+++ b/combinations/mulled-v2-8e9cbaa9bc8b8b308b9197a76268e1439bbd2a2f:9c8cbf5e91c8a21db4785b4fd7f1bfe7bd8d5f7f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+omark=0.3.1,sqlite=3.40.0,libsqlite=3.40.0,ete3=3.1.3,omamer=2.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8e9cbaa9bc8b8b308b9197a76268e1439bbd2a2f:9c8cbf5e91c8a21db4785b4fd7f1bfe7bd8d5f7f

**Packages**:
- omark=0.3.1
- sqlite=3.40.0
- libsqlite=3.40.0
- ete3=3.1.3
- omamer=2.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- omark.xml

Generated with Planemo.