### PR TITLE
Add container mulled-v2-1e3e0772adb0b9c6b9989f3539de1f514d24743d:47e4ee06763cb34141dd1ff19fdcbf6a816d678c.

### DIFF
--- a/combinations/mulled-v2-1e3e0772adb0b9c6b9989f3539de1f514d24743d:47e4ee06763cb34141dd1ff19fdcbf6a816d678c-0.tsv
+++ b/combinations/mulled-v2-1e3e0772adb0b9c6b9989f3539de1f514d24743d:47e4ee06763cb34141dd1ff19fdcbf6a816d678c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-tidyverse=2.0.0,r-patchwork=1.3.0,r-base64=2.0.2,bioconductor-genomicranges=1.58.0,r-formattable=0.2.1,r-here=1.0.1,bioconductor-biostrings=2.74.0,r-kableextra=1.4.0,r-pdftools=3.5.0,bioconductor-gmoviz=1.18.0,r-janitor=2.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e3e0772adb0b9c6b9989f3539de1f514d24743d:47e4ee06763cb34141dd1ff19fdcbf6a816d678c

**Packages**:
- r-tidyverse=2.0.0
- r-patchwork=1.3.0
- r-base64=2.0.2
- bioconductor-genomicranges=1.58.0
- r-formattable=0.2.1
- r-here=1.0.1
- bioconductor-biostrings=2.74.0
- r-kableextra=1.4.0
- r-pdftools=3.5.0
- bioconductor-gmoviz=1.18.0
- r-janitor=2.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- phitk.xml

Generated with Planemo.