### PR TITLE
Add container mulled-v2-1464b0d9f1828d61e720d77779a9000de79e269b:f34dc82747dc456dd1308474035a450eff64c380.

### DIFF
--- a/combinations/mulled-v2-1464b0d9f1828d61e720d77779a9000de79e269b:f34dc82747dc456dd1308474035a450eff64c380-0.tsv
+++ b/combinations/mulled-v2-1464b0d9f1828d61e720d77779a9000de79e269b:f34dc82747dc456dd1308474035a450eff64c380-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+giatools=0.4.1,scikit-image=0.25.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1464b0d9f1828d61e720d77779a9000de79e269b:f34dc82747dc456dd1308474035a450eff64c380

**Packages**:
- giatools=0.4.1
- scikit-image=0.25.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- auto_threshold.xml

Generated with Planemo.