### PR TITLE
Add container mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:0d475137c7b4a90f78eb30ca5558a1c24cc397cb.

### DIFF
--- a/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:0d475137c7b4a90f78eb30ca5558a1c24cc397cb-0.tsv
+++ b/combinations/mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:0d475137c7b4a90f78eb30ca5558a1c24cc397cb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.22,freebayes=1.3.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dc422f74572321627996aa5f1ae09bb26455f9de:0d475137c7b4a90f78eb30ca5558a1c24cc397cb

**Packages**:
- samtools=1.22
- freebayes=1.3.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- leftalign.xml

Generated with Planemo.