### PR TITLE
Add container mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:868e195f26a5b9b98af841423faef4052e50d640.

### DIFF
--- a/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:868e195f26a5b9b98af841423faef4052e50d640-0.tsv
+++ b/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:868e195f26a5b9b98af841423faef4052e50d640-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.3.1,parallel=20250422,samtools=1.22,freebayes=1.3.10	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:868e195f26a5b9b98af841423faef4052e50d640

**Packages**:
- gawk=5.3.1
- parallel=20250422
- samtools=1.22
- freebayes=1.3.10
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freebayes.xml

Generated with Planemo.