### PR TITLE
Added rmats 4.1.2 + r-base 4.0 combination

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -652,3 +652,4 @@ r-ctree=1.1.0,r-viber=1.0.0,r-mobster=0.1.1,r-dplyr=1.1.4,r-ggplot2=3.5.2,r-cli=
 r-viber=1.0.0,r-cnaqc=1.1.2,r-dplyr=1.1.4,r-ggplot2=3.5.2,r-tidyverse=2.0.0,r-cli=3.6.5,r-ggpubr=0.6.0
 minimap2=2.29,samtools=1.22
 r-mobster=0.1.1,r-cnaqc=1.1.2,r-dplyr=1.1.4,r-ggplot2=3.5.2,r-cli=3.6.5
+rmats=4.1.2,r-base=4.0


### PR DESCRIPTION
So [rmats 4.1.2](https://toolshed.g2.bx.psu.edu/repository?repository_id=59945452e1ba836a) can run in a biocontainer.