### PR TITLE
Add container mulled-v2-bddec11518ad9f663452ca2d476c114735687122:39f51d362721d94bf68285581d8705868504bcf9.

### DIFF
--- a/combinations/mulled-v2-bddec11518ad9f663452ca2d476c114735687122:39f51d362721d94bf68285581d8705868504bcf9-0.tsv
+++ b/combinations/mulled-v2-bddec11518ad9f663452ca2d476c114735687122:39f51d362721d94bf68285581d8705868504bcf9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+oda-api=1.2.33,astroquery=0.4.10,nbconvert=7.16.6,matplotlib=3.10.3,wget=1.21.4,astropy=6.1.4,ipython=9.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-bddec11518ad9f663452ca2d476c114735687122:39f51d362721d94bf68285581d8705868504bcf9

**Packages**:
- oda-api=1.2.33
- astroquery=0.4.10
- nbconvert=7.16.6
- matplotlib=3.10.3
- wget=1.21.4
- astropy=6.1.4
- ipython=9.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- desi_legacy_survey_astro_tool.xml

Generated with Planemo.