### PR TITLE
Added cpt_gffparser 1.2.2 mulled with python 3.9 and biopython 1.81.

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -654,3 +654,4 @@ minimap2=2.29,samtools=1.22
 r-mobster=0.1.1,r-cnaqc=1.1.2,r-dplyr=1.1.4,r-ggplot2=3.5.2,r-cli=3.6.5
 rmats=4.1.2,r-base=4.0
 r-arrow=19.0.1,bioconductor-xcms=3.22.0,r-ramclustr=1.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0
+cpt_gffparser=1.2.2,python=3.9,biopython=1.81


### PR DESCRIPTION
For `toolshed.g2.bx.psu.edu/repos/cpt/cpt_gff_extract_seq/edu.tamu.cpt.gff3.export_seq/19.1.0.0`

Which has [requirements](https://github.com/TAMU-CPT/CPT-ToolshedSource/blob/main/macros.xml#L4-L6):
```
            <requirement type="package" version="3.9">python</requirement>
            <requirement type="package" version="1.81">biopython</requirement>
            <requirement type="package" version="1.2.2">cpt_gffparser</requirement>
```


Thanks in advance!