### PR TITLE
Add container mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:e8785983895f39b616bacb2a9f49e9c3d425b62d.

### DIFF
--- a/combinations/mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:e8785983895f39b616bacb2a9f49e9c3d425b62d-0.tsv
+++ b/combinations/mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:e8785983895f39b616bacb2a9f49e9c3d425b62d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+blast=2.16.0,ucsc-blat=481,proteinortho=6.3.6,diamond=2.1.12,last=1639,mmseqs2=17.b804f	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-332a99288bd5d8f1de5b31239a1f78c10719055c:e8785983895f39b616bacb2a9f49e9c3d425b62d

**Packages**:
- blast=2.16.0
- ucsc-blat=481
- proteinortho=6.3.6
- diamond=2.1.12
- last=1639
- mmseqs2=17.b804f
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- proteinortho_summary.xml
- proteinortho_clustering.xml
- proteinortho_grab_proteins.xml
- proteinortho.xml

Generated with Planemo.