### PR TITLE
Add container mulled-v2-d949b65291b606d8e7a0dae05fe0839832b1bc1a:1d631724c654af9043a194646ca6a4aa3016579f.

### DIFF
--- a/combinations/mulled-v2-d949b65291b606d8e7a0dae05fe0839832b1bc1a:1d631724c654af9043a194646ca6a4aa3016579f-0.tsv
+++ b/combinations/mulled-v2-d949b65291b606d8e7a0dae05fe0839832b1bc1a:1d631724c654af9043a194646ca6a4aa3016579f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+parallel=20250422,fastspar=1.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d949b65291b606d8e7a0dae05fe0839832b1bc1a:1d631724c654af9043a194646ca6a4aa3016579f

**Packages**:
- parallel=20250422
- fastspar=1.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fastspar_pvalues.xml

Generated with Planemo.