### PR TITLE
Add container mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:0bc797e29821b2eebc018f34e7bf5f2327d13510.

### DIFF
--- a/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:0bc797e29821b2eebc018f34e7bf5f2327d13510-0.tsv
+++ b/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:0bc797e29821b2eebc018f34e7bf5f2327d13510-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+vcfanno=0.3.6,samtools=1.22,tabix=1.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:0bc797e29821b2eebc018f34e7bf5f2327d13510

**Packages**:
- vcfanno=0.3.6
- samtools=1.22
- tabix=1.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vcfanno.xml

Generated with Planemo.