### PR TITLE
Add container mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:d49eff09e2efa6202d8d8b3660e4f1171d7e558b.

### DIFF
--- a/combinations/mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:d49eff09e2efa6202d8d8b3660e4f1171d7e558b-0.tsv
+++ b/combinations/mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:d49eff09e2efa6202d8d8b3660e4f1171d7e558b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-recetox-waveica=0.2.0,r-dplyr=1.0.10,r-arrow=8.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:d49eff09e2efa6202d8d8b3660e4f1171d7e558b

**Packages**:
- r-recetox-waveica=0.2.0
- r-dplyr=1.0.10
- r-arrow=8.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- waveica.xml

Generated with Planemo.