### PR TITLE
Add container mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:8f3ad900103a4eb7fde71bb8b4841b1f18683f3f.

### DIFF
--- a/combinations/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:8f3ad900103a4eb7fde71bb8b4841b1f18683f3f-0.tsv
+++ b/combinations/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:8f3ad900103a4eb7fde71bb8b4841b1f18683f3f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.22,bwa-mem2=2.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:8f3ad900103a4eb7fde71bb8b4841b1f18683f3f

**Packages**:
- samtools=1.22
- bwa-mem2=2.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bwa-mem2.xml

Generated with Planemo.