### PR TITLE
Add container mulled-v2-514dd537987f595682240a62de760db8ecc8c063:25fdc6bead79cda69f6a8aff4cd73e7eca9afb8e.

### DIFF
--- a/combinations/mulled-v2-514dd537987f595682240a62de760db8ecc8c063:25fdc6bead79cda69f6a8aff4cd73e7eca9afb8e-0.tsv
+++ b/combinations/mulled-v2-514dd537987f595682240a62de760db8ecc8c063:25fdc6bead79cda69f6a8aff4cd73e7eca9afb8e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.22,tasmanian-mismatch=1.0.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-514dd537987f595682240a62de760db8ecc8c063:25fdc6bead79cda69f6a8aff4cd73e7eca9afb8e

**Packages**:
- samtools=1.22
- tasmanian-mismatch=1.0.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- Tasmanian.xml

Generated with Planemo.