### PR TITLE
Add container mulled-v2-93fc34fa2990ce1797e6c144aa35aa91bd7f46c6:12c2c812c49d58573ffbf3d10e6f7ff986d24a69.

### DIFF
--- a/combinations/mulled-v2-93fc34fa2990ce1797e6c144aa35aa91bd7f46c6:12c2c812c49d58573ffbf3d10e6f7ff986d24a69-0.tsv
+++ b/combinations/mulled-v2-93fc34fa2990ce1797e6c144aa35aa91bd7f46c6:12c2c812c49d58573ffbf3d10e6f7ff986d24a69-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sep=1.4.1,ipython=9.4.0,matplotlib=3.10.3,wget=1.21.4,oda-api=1.2.33,tifffile=2025.6.11,astropy=6.1.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-93fc34fa2990ce1797e6c144aa35aa91bd7f46c6:12c2c812c49d58573ffbf3d10e6f7ff986d24a69

**Packages**:
- sep=1.4.1
- ipython=9.4.0
- matplotlib=3.10.3
- wget=1.21.4
- oda-api=1.2.33
- tifffile=2025.6.11
- astropy=6.1.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- source_extractor_astro_tool.xml

Generated with Planemo.