### PR TITLE
Add container mulled-v2-a2703e1f6cf62ef239195803ebccf4ed3ce114b5:9b9946bc0011d37c923c1ac06c1213a8ed7f68e1.

### DIFF
--- a/combinations/mulled-v2-a2703e1f6cf62ef239195803ebccf4ed3ce114b5:9b9946bc0011d37c923c1ac06c1213a8ed7f68e1-0.tsv
+++ b/combinations/mulled-v2-a2703e1f6cf62ef239195803ebccf4ed3ce114b5:9b9946bc0011d37c923c1ac06c1213a8ed7f68e1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+astropy=6.1.7,tifffile=2025.6.11,ipython=9.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a2703e1f6cf62ef239195803ebccf4ed3ce114b5:9b9946bc0011d37c923c1ac06c1213a8ed7f68e1

**Packages**:
- astropy=6.1.7
- tifffile=2025.6.11
- ipython=9.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fits2tiff_astro_tool.xml

Generated with Planemo.