### PR TITLE
Add container mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:5db89bdd60ff5db645e44dda6ec57bc27ee5586d.

### DIFF
--- a/combinations/mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:5db89bdd60ff5db645e44dda6ec57bc27ee5586d-0.tsv
+++ b/combinations/mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:5db89bdd60ff5db645e44dda6ec57bc27ee5586d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gffcompare=0.12.10,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ce255c943c73ee5f015e7cdb5fdeb00b61b126cb:5db89bdd60ff5db645e44dda6ec57bc27ee5586d

**Packages**:
- gffcompare=0.12.10
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- gffcompare.xml

Generated with Planemo.