### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:6ab2354949a364161f3658adcaadeac1f4205fec.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:6ab2354949a364161f3658adcaadeac1f4205fec-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:6ab2354949a364161f3658adcaadeac1f4205fec-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mosdepth=0.3.11,gzip=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:6ab2354949a364161f3658adcaadeac1f4205fec

**Packages**:
- mosdepth=0.3.11
- gzip=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.