### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:8560a6b7521ee456cdc1c45196aae3f3236a29bc.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:8560a6b7521ee456cdc1c45196aae3f3236a29bc-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:8560a6b7521ee456cdc1c45196aae3f3236a29bc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2025.7.14,ncbi-datasets-cli=18.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:8560a6b7521ee456cdc1c45196aae3f3236a29bc

**Packages**:
- ca-certificates=2025.7.14
- ncbi-datasets-cli=18.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.