### PR TITLE
Add container poppler:25.07.0.

### DIFF
--- a/combinations/poppler:25.07.0-0.tsv
+++ b/combinations/poppler:25.07.0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+poppler=25.07.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: poppler:25.07.0

**Packages**:
- poppler=25.07.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pdfimages.xml

Generated with Planemo.