### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:de59eb55823f92de2ed23b94c0a4749ceaad7895.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:de59eb55823f92de2ed23b94c0a4749ceaad7895-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:de59eb55823f92de2ed23b94c0a4749ceaad7895-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=18.5.1,ca-certificates=2025.8.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:de59eb55823f92de2ed23b94c0a4749ceaad7895

**Packages**:
- ncbi-datasets-cli=18.5.1
- ca-certificates=2025.8.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.