### PR TITLE
Add container mulled-v2-8928a58943a9e14acea2303602f8fb6e1d732dad:39a0f43d33c5b67745fdb5ddd83d087a68c530db.

### DIFF
--- a/combinations/mulled-v2-8928a58943a9e14acea2303602f8fb6e1d732dad:39a0f43d33c5b67745fdb5ddd83d087a68c530db-0.tsv
+++ b/combinations/mulled-v2-8928a58943a9e14acea2303602f8fb6e1d732dad:39a0f43d33c5b67745fdb5ddd83d087a68c530db-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+krakentools=1.2.1,gzip=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8928a58943a9e14acea2303602f8fb6e1d732dad:39a0f43d33c5b67745fdb5ddd83d087a68c530db

**Packages**:
- krakentools=1.2.1
- gzip=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- extract_kraken_reads.xml

Generated with Planemo.