### PR TITLE
Add container mulled-v2-7cb285c963dc9e30d0568865f3c9016522d66ec3:f17782674e8582cdfee163f4a172d52b5b926c28.

### DIFF
--- a/combinations/mulled-v2-7cb285c963dc9e30d0568865f3c9016522d66ec3:f17782674e8582cdfee163f4a172d52b5b926c28-0.tsv
+++ b/combinations/mulled-v2-7cb285c963dc9e30d0568865f3c9016522d66ec3:f17782674e8582cdfee163f4a172d52b5b926c28-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+parallel=20250622,gawk=5.3.1,freebayes=1.3.10,coreutils=9.5,samtools=1.22,grep=3.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7cb285c963dc9e30d0568865f3c9016522d66ec3:f17782674e8582cdfee163f4a172d52b5b926c28

**Packages**:
- parallel=20250622
- gawk=5.3.1
- freebayes=1.3.10
- coreutils=9.5
- samtools=1.22
- grep=3.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freebayes.xml

Generated with Planemo.