### PR TITLE
Add container mulled-v2-52598611df8c265d21359b981de9f38b67cc8768:308ab183e39464686be65ee0dedf8f8680f57efa.

### DIFF
--- a/combinations/mulled-v2-52598611df8c265d21359b981de9f38b67cc8768:308ab183e39464686be65ee0dedf8f8680f57efa-0.tsv
+++ b/combinations/mulled-v2-52598611df8c265d21359b981de9f38b67cc8768:308ab183e39464686be65ee0dedf8f8680f57efa-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freebayes=1.3.10,coreutils=9.5,samtools=1.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-52598611df8c265d21359b981de9f38b67cc8768:308ab183e39464686be65ee0dedf8f8680f57efa

**Packages**:
- freebayes=1.3.10
- coreutils=9.5
- samtools=1.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- leftalign.xml

Generated with Planemo.