### PR TITLE
Add container mulled-v2-4f658947f2dcf92b56aabbcd88f865ae3b66b28d:3173a8c8166c6d0717af222356f88229b21103e2.

### DIFF
--- a/combinations/mulled-v2-4f658947f2dcf92b56aabbcd88f865ae3b66b28d:3173a8c8166c6d0717af222356f88229b21103e2-0.tsv
+++ b/combinations/mulled-v2-4f658947f2dcf92b56aabbcd88f865ae3b66b28d:3173a8c8166c6d0717af222356f88229b21103e2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12,ivar=1.4.4,samtools=1.22,sed=4.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4f658947f2dcf92b56aabbcd88f865ae3b66b28d:3173a8c8166c6d0717af222356f88229b21103e2

**Packages**:
- python=3.12
- ivar=1.4.4
- samtools=1.22
- sed=4.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ivar_filtervariants.xml
- ivar_consensus.xml
- ivar_variants.xml

Generated with Planemo.