### PR TITLE
Add container mulled-v2-dad95157f1e6ebaffc641a09503d0100710a1765:4dccdbb26cdfad6bb44e3adebe06dce653024d66.

### DIFF
--- a/combinations/mulled-v2-dad95157f1e6ebaffc641a09503d0100710a1765:4dccdbb26cdfad6bb44e3adebe06dce653024d66-0.tsv
+++ b/combinations/mulled-v2-dad95157f1e6ebaffc641a09503d0100710a1765:4dccdbb26cdfad6bb44e3adebe06dce653024d66-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ivar=1.4.4,viramp-hub=0.1.0,samtools=1.22,sed=4.9,python=3.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dad95157f1e6ebaffc641a09503d0100710a1765:4dccdbb26cdfad6bb44e3adebe06dce653024d66

**Packages**:
- ivar=1.4.4
- viramp-hub=0.1.0
- samtools=1.22
- sed=4.9
- python=3.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ivar_trim.xml
- ivar_removereads.xml

Generated with Planemo.