### PR TITLE
Add container mulled-v2-dd0d56fca333e733d78aed634f994cb26ddfab15:76bed4f71a1cf4b5f0f32e012dc1bfd97feed0b7.

### DIFF
--- a/combinations/mulled-v2-dd0d56fca333e733d78aed634f994cb26ddfab15:76bed4f71a1cf4b5f0f32e012dc1bfd97feed0b7-0.tsv
+++ b/combinations/mulled-v2-dd0d56fca333e733d78aed634f994cb26ddfab15:76bed4f71a1cf4b5f0f32e012dc1bfd97feed0b7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+matplotlib=3.9.4,python=3.12.11,oda-api=1.2.41,astropy=6.1.4,nbformat=5.10.4,xmltodict=0.14.2,nbconvert=7.16.6,ligo.skymap=2.4.0,hop-client=0.11.1,ipython=9.4.0,numpy=1.26.4,gcn-kafka=0.3.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dd0d56fca333e733d78aed634f994cb26ddfab15:76bed4f71a1cf4b5f0f32e012dc1bfd97feed0b7

**Packages**:
- matplotlib=3.9.4
- python=3.12.11
- oda-api=1.2.41
- astropy=6.1.4
- nbformat=5.10.4
- xmltodict=0.14.2
- nbconvert=7.16.6
- ligo.skymap=2.4.0
- hop-client=0.11.1
- ipython=9.4.0
- numpy=1.26.4
- gcn-kafka=0.3.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- grb_detection_astro_tool.xml

Generated with Planemo.