### PR TITLE
Add container mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:fb7815727568468669305138a3b09931f99c3e79.

### DIFF
--- a/combinations/mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:fb7815727568468669305138a3b09931f99c3e79-0.tsv
+++ b/combinations/mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:fb7815727568468669305138a3b09931f99c3e79-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+netcdf4=1.6.0,python=3,xarray=2025.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fa33253068ab0311b689e40af52c6414735f6f36:fb7815727568468669305138a3b09931f99c3e79

**Packages**:
- netcdf4=1.6.0
- python=3
- xarray=2025.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xarray_import_data.xml

Generated with Planemo.