### PR TITLE
Add container saqc:2.6.0.

### DIFF
--- a/combinations/saqc:2.6.0-0.tsv
+++ b/combinations/saqc:2.6.0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+saqc=2.6.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: saqc:2.6.0

**Packages**:
- saqc=2.6.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- saqc.xml
- saqc_executor.xml

Generated with Planemo.