### PR TITLE
Add container galaxy-util:25.0.

### DIFF
--- a/combinations/galaxy-util:25.0-0.tsv
+++ b/combinations/galaxy-util:25.0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+galaxy-util=25.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: galaxy-util:25.0

**Packages**:
- galaxy-util=25.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tar_to_directory.xml
- archive_to_directory.xml

Generated with Planemo.