### PR TITLE
Add container mulled-v2-7a407d02e5cdb08ceaad5b125da833026292af1a:d937d67ba578113e308814a552e9ec1b021e0a47.

### DIFF
--- a/combinations/mulled-v2-7a407d02e5cdb08ceaad5b125da833026292af1a:d937d67ba578113e308814a552e9ec1b021e0a47-0.tsv
+++ b/combinations/mulled-v2-7a407d02e5cdb08ceaad5b125da833026292af1a:d937d67ba578113e308814a552e9ec1b021e0a47-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+freetype=2.13.3,imagemagick=7.1.2-2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7a407d02e5cdb08ceaad5b125da833026292af1a:d937d67ba578113e308814a552e9ec1b021e0a47

**Packages**:
- freetype=2.13.3
- imagemagick=7.1.2-2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- compare.xml
- montage.xml
- convert.xml

Generated with Planemo.