### PR TITLE
Add container mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:af6eea407d408c9459ae19ad447137ff11ab989f.

### DIFF
--- a/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:af6eea407d408c9459ae19ad447137ff11ab989f-0.tsv
+++ b/combinations/mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:af6eea407d408c9459ae19ad447137ff11ab989f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+vcfanno=0.3.7,tabix=1.11,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1c7ead01006ee6e0ad164b238136e2f618fa5b31:af6eea407d408c9459ae19ad447137ff11ab989f

**Packages**:
- vcfanno=0.3.7
- tabix=1.11
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vcfanno.xml

Generated with Planemo.