### PR TITLE
Add container mulled-v2-1bd7c143fec0659638fb990d05ec2cc030bd8b61:5e5fabd7791103627626559e2040833490206e65.

### DIFF
--- a/combinations/mulled-v2-1bd7c143fec0659638fb990d05ec2cc030bd8b61:5e5fabd7791103627626559e2040833490206e65-0.tsv
+++ b/combinations/mulled-v2-1bd7c143fec0659638fb990d05ec2cc030bd8b61:5e5fabd7791103627626559e2040833490206e65-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreprofiler=1.1.4,blast=2.16.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1bd7c143fec0659638fb990d05ec2cc030bd8b61:5e5fabd7791103627626559e2040833490206e65

**Packages**:
- coreprofiler=1.1.4
- blast=2.16.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_build_coreprofiler_download.xml

Generated with Planemo.