### PR TITLE
Add container mulled-v2-f44eb8f8fd694df8f5d103351c6e7f6816bd9bb1:a06a12e18332de5a030bf1ab1353c17d8448cd90.

### DIFF
--- a/combinations/mulled-v2-f44eb8f8fd694df8f5d103351c6e7f6816bd9bb1:a06a12e18332de5a030bf1ab1353c17d8448cd90-0.tsv
+++ b/combinations/mulled-v2-f44eb8f8fd694df8f5d103351c6e7f6816bd9bb1:a06a12e18332de5a030bf1ab1353c17d8448cd90-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sed=4.9,grep=3.11,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f44eb8f8fd694df8f5d103351c6e7f6816bd9bb1:a06a12e18332de5a030bf1ab1353c17d8448cd90

**Packages**:
- sed=4.9
- grep=3.11
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sorter.xml

Generated with Planemo.