### PR TITLE
Add container mulled-v2-63feb106b58570bb035d9cc78b5ae437b57ee23d:7320344769cb3a7383b2da4aa6c4cf6e510303e0.

### DIFF
--- a/combinations/mulled-v2-63feb106b58570bb035d9cc78b5ae437b57ee23d:7320344769cb3a7383b2da4aa6c4cf6e510303e0-0.tsv
+++ b/combinations/mulled-v2-63feb106b58570bb035d9cc78b5ae437b57ee23d:7320344769cb3a7383b2da4aa6c4cf6e510303e0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+lexicmap=0.8.0,file=5.46	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-63feb106b58570bb035d9cc78b5ae437b57ee23d:7320344769cb3a7383b2da4aa6c4cf6e510303e0

**Packages**:
- lexicmap=0.8.0
- file=5.46
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- lexicmap-index.xml
- lexicmap.xml

Generated with Planemo.