### PR TITLE
Add container mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:3ce44c9e658f3086fb31ddf84fb7a4525cb61e2d.

### DIFF
--- a/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:3ce44c9e658f3086fb31ddf84fb7a4525cb61e2d-0.tsv
+++ b/combinations/mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:3ce44c9e658f3086fb31ddf84fb7a4525cb61e2d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie2=2.5.4,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c742dccc9d8fabfcff2af0d8d6799dbc711366cf:3ce44c9e658f3086fb31ddf84fb7a4525cb61e2d

**Packages**:
- bowtie2=2.5.4
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bowtie2_wrapper.xml

Generated with Planemo.