### PR TITLE
Add container mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:e912f21e8a1a985bf6e29f00c68c4b2e33663529.

### DIFF
--- a/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:e912f21e8a1a985bf6e29f00c68c4b2e33663529-0.tsv
+++ b/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:e912f21e8a1a985bf6e29f00c68c4b2e33663529-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+cutesv=2.1.3,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:e912f21e8a1a985bf6e29f00c68c4b2e33663529

**Packages**:
- cutesv=2.1.3
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cutesv.xml

Generated with Planemo.