### PR TITLE
Add container mulled-v2-e15f4d05b9fb9094efa8549db09ec3c886f8a552:fda4ccb94660362887b3fc4789adf9dd3b3f1671.

### DIFF
--- a/combinations/mulled-v2-e15f4d05b9fb9094efa8549db09ec3c886f8a552:fda4ccb94660362887b3fc4789adf9dd3b3f1671-0.tsv
+++ b/combinations/mulled-v2-e15f4d05b9fb9094efa8549db09ec3c886f8a552:fda4ccb94660362887b3fc4789adf9dd3b3f1671-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rrmscorer=1.0.11,seaborn-base=0.11.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-e15f4d05b9fb9094efa8549db09ec3c886f8a552:fda4ccb94660362887b3fc4789adf9dd3b3f1671

**Packages**:
- rrmscorer=1.0.11
- seaborn-base=0.11.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- RRMScorer.xml

Generated with Planemo.