### PR TITLE
Add container mulled-v2-5ab22bce50c3ef06dcba7de769e6366ad3df6250:2d3e54cd8bd150dbd2e4456f4738abba19aae8b3.

### DIFF
--- a/combinations/mulled-v2-5ab22bce50c3ef06dcba7de769e6366ad3df6250:2d3e54cd8bd150dbd2e4456f4738abba19aae8b3-0.tsv
+++ b/combinations/mulled-v2-5ab22bce50c3ef06dcba7de769e6366ad3df6250:2d3e54cd8bd150dbd2e4456f4738abba19aae8b3-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+parallel=20250822,snp-pileup=0.6.2,htslib=1.22.1,samtools=1.22.1,bcftools=1.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5ab22bce50c3ef06dcba7de769e6366ad3df6250:2d3e54cd8bd150dbd2e4456f4738abba19aae8b3

**Packages**:
- parallel=20250822
- snp-pileup=0.6.2
- htslib=1.22.1
- samtools=1.22.1
- bcftools=1.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snp_pileup_for_facets.xml

Generated with Planemo.