### PR TITLE
Add container mulled-v2-cafc589522afd600e06b8bbf6d88159aa82337be:860b42436a8b5539422faeeae4ff0c81e1e4e200.

### DIFF
--- a/combinations/mulled-v2-cafc589522afd600e06b8bbf6d88159aa82337be:860b42436a8b5539422faeeae4ff0c81e1e4e200-0.tsv
+++ b/combinations/mulled-v2-cafc589522afd600e06b8bbf6d88159aa82337be:860b42436a8b5539422faeeae4ff0c81e1e4e200-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+jbrowse2=3.6.5,tabix=1.11,python=3.13.7,requests=2.32.5,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-cafc589522afd600e06b8bbf6d88159aa82337be:860b42436a8b5539422faeeae4ff0c81e1e4e200

**Packages**:
- jbrowse2=3.6.5
- tabix=1.11
- python=3.13.7
- requests=2.32.5
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- jbrowse2.xml

Generated with Planemo.