### PR TITLE
Add container mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:fcad3a0cda829b4d1d70f2d6025c80a814d6a8ee.

### DIFF
--- a/combinations/mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:fcad3a0cda829b4d1d70f2d6025c80a814d6a8ee-0.tsv
+++ b/combinations/mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:fcad3a0cda829b4d1d70f2d6025c80a814d6a8ee-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.3.1,coreutils=8.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:fcad3a0cda829b4d1d70f2d6025c80a814d6a8ee

**Packages**:
- gawk=5.3.1
- coreutils=8.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- compare.xml

Generated with Planemo.