### PR TITLE
Add container mulled-v2-5e77ff0de122d54903ee570c7157b187edb5e4d4:28f84869f2279604e3e12092cf5684cec0f95424.

### DIFF
--- a/combinations/mulled-v2-5e77ff0de122d54903ee570c7157b187edb5e4d4:28f84869f2279604e3e12092cf5684cec0f95424-0.tsv
+++ b/combinations/mulled-v2-5e77ff0de122d54903ee570c7157b187edb5e4d4:28f84869f2279604e3e12092cf5684cec0f95424-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+parallel=20250822,htslib=1.22.1,coreutils=9.5,samtools=1.22.1,bcftools=1.22,snp-pileup=0.6.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5e77ff0de122d54903ee570c7157b187edb5e4d4:28f84869f2279604e3e12092cf5684cec0f95424

**Packages**:
- parallel=20250822
- htslib=1.22.1
- coreutils=9.5
- samtools=1.22.1
- bcftools=1.22
- snp-pileup=0.6.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snp_pileup_for_facets.xml

Generated with Planemo.