### PR TITLE
Add container mulled-v2-c73f721f1e734aecbc8dd22b07a7e2e9a68f1776:28136675ea759d08f7ac6beacb3adacfe4f8e4da.

### DIFF
--- a/combinations/mulled-v2-c73f721f1e734aecbc8dd22b07a7e2e9a68f1776:28136675ea759d08f7ac6beacb3adacfe4f8e4da-0.tsv
+++ b/combinations/mulled-v2-c73f721f1e734aecbc8dd22b07a7e2e9a68f1776:28136675ea759d08f7ac6beacb3adacfe4f8e4da-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-argparse=2.2.5,htslib=1.22.1,coreutils=9.5,snp-pileup=0.6.2,bcftools=1.22,parallel=20250822,r-facets=0.6.2,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c73f721f1e734aecbc8dd22b07a7e2e9a68f1776:28136675ea759d08f7ac6beacb3adacfe4f8e4da

**Packages**:
- r-argparse=2.2.5
- htslib=1.22.1
- coreutils=9.5
- snp-pileup=0.6.2
- bcftools=1.22
- parallel=20250822
- r-facets=0.6.2
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- facets_analysis.xml
- snp_pileup_for_facets.xml

Generated with Planemo.