### PR TITLE
Add container mulled-v2-b63b6277c1547c8fbbef71582adb7d2600a09ae9:efb81ae875a11b9fed1bc29414b159e4a1d22bfd.

### DIFF
--- a/combinations/mulled-v2-b63b6277c1547c8fbbef71582adb7d2600a09ae9:efb81ae875a11b9fed1bc29414b159e4a1d22bfd-0.tsv
+++ b/combinations/mulled-v2-b63b6277c1547c8fbbef71582adb7d2600a09ae9:efb81ae875a11b9fed1bc29414b159e4a1d22bfd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+snpeff=5.2,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b63b6277c1547c8fbbef71582adb7d2600a09ae9:efb81ae875a11b9fed1bc29414b159e4a1d22bfd

**Packages**:
- snpeff=5.2
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- snpEff.xml

Generated with Planemo.