### PR TITLE
Add container mulled-v2-563828372df1367b256221c9b4c7b4f59deaca54:6c8fee03a3d032ae28b023756afd8bfabbf8d381.

### DIFF
--- a/combinations/mulled-v2-563828372df1367b256221c9b4c7b4f59deaca54:6c8fee03a3d032ae28b023756afd8bfabbf8d381-0.tsv
+++ b/combinations/mulled-v2-563828372df1367b256221c9b4c7b4f59deaca54:6c8fee03a3d032ae28b023756afd8bfabbf8d381-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sed=4.7,freyja=2.0.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-563828372df1367b256221c9b4c7b4f59deaca54:6c8fee03a3d032ae28b023756afd8bfabbf8d381

**Packages**:
- sed=4.7
- freyja=2.0.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- freyja_demix.xml

Generated with Planemo.