### PR TITLE
Add biocontainer for `unzip=6.0,tar=1.34,findutils=4.10.0`

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -927,3 +927,4 @@ r-rmarkdown=2.29,r-yaml=2.3.10,r-tidyr=1.3.1,r-data.table=1.17.8,r-knitr=1.50,r-
 bioconductor-resolve=1.8.0,bioconductor-bsgenome.hsapiens.ucsc.hg38=1.4.5,r-patchwork=1.3.1
 gawk=5.0.1,snpeff=5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	2
 r-base=4.3.3,bioconductor-rtracklayer=1.62.0,r-optparse=1.7.4,r-dplyr=1.1.4,r-stringr=1.5.1,r-plyr=1.8.9,r-data.table=1.15.2,coreutils=9.5,r-argparse=2.2.2,r-tidyverse=2.0.0
+unzip=6.0,tar=1.34,findutils=4.10.0


### PR DESCRIPTION
Create biocontainer for unzip tool in Galaxy, as motivated here:
https://github.com/BMCV/galaxy-image-analysis/pull/158#discussion_r2404397184