### PR TITLE
Add container mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:6990dd7f8572538019b249baafdb4772673d0731.

### DIFF
--- a/combinations/mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:6990dd7f8572538019b249baafdb4772673d0731-0.tsv
+++ b/combinations/mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:6990dd7f8572538019b249baafdb4772673d0731-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mummer4=4.0.1,samtools=1.23.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-94c12e128fff0e4d1d34a43f778cdcdbfaba4960:6990dd7f8572538019b249baafdb4772673d0731

**Packages**:
- mummer4=4.0.1
- samtools=1.23.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- delta-filter.xml
- dnadiff.xml
- show-coords.xml

Generated with Planemo.