### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d0f58009340306913795c79d3c664ad9dcd2eb3c.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d0f58009340306913795c79d3c664ad9dcd2eb3c-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d0f58009340306913795c79d3c664ad9dcd2eb3c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2026.2.25,ncbi-datasets-cli=18.23.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d0f58009340306913795c79d3c664ad9dcd2eb3c

**Packages**:
- ca-certificates=2026.2.25
- ncbi-datasets-cli=18.23.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_gene.xml
- datasets_genome.xml

Generated with Planemo.