### PR TITLE
Add container mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:99b64d5011f6d6d4975441bc9df1b9b390ce50fa.

### DIFF
--- a/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:99b64d5011f6d6d4975441bc9df1b9b390ce50fa-0.tsv
+++ b/combinations/mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:99b64d5011f6d6d4975441bc9df1b9b390ce50fa-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+constellations=0.1.12,pangolin-data=1.38,csvtk=0.37.0,minimap2=2.30,ucsc-fatovcf=482,grep=3.12,scorpio=0.3.19,usher=0.6.6,pangolin=4.4,gofasta=1.2.3	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dd29a726a518ab18d2113433052947ad2389bdcd:99b64d5011f6d6d4975441bc9df1b9b390ce50fa

**Packages**:
- constellations=0.1.12
- pangolin-data=1.38
- csvtk=0.37.0
- minimap2=2.30
- ucsc-fatovcf=482
- grep=3.12
- scorpio=0.3.19
- usher=0.6.6
- pangolin=4.4
- gofasta=1.2.3
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- pangolin.xml

Generated with Planemo.