### PR TITLE
Add container mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:a1a6689c6324dd1862d1511a1acf88023051a4c6.

### DIFF
--- a/combinations/mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:a1a6689c6324dd1862d1511a1acf88023051a4c6-0.tsv
+++ b/combinations/mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:a1a6689c6324dd1862d1511a1acf88023051a4c6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gnuplot=6.0.4,mummer4=4.0.1,samtools=1.23.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-373539cd51d908b0ef4294c9cff8015be7cf2072:a1a6689c6324dd1862d1511a1acf88023051a4c6

**Packages**:
- gnuplot=6.0.4
- mummer4=4.0.1
- samtools=1.23.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mummer.xml
- nucmer.xml
- mummerplot.xml

Generated with Planemo.