### PR TITLE
Add container mulled-v2-76f1ae7601969630dc3438b950f824ee728c342f:f9c5fde74b73d3d6b03b9ac6e65c8e39394c8f93.

### DIFF
--- a/combinations/mulled-v2-76f1ae7601969630dc3438b950f824ee728c342f:f9c5fde74b73d3d6b03b9ac6e65c8e39394c8f93-0.tsv
+++ b/combinations/mulled-v2-76f1ae7601969630dc3438b950f824ee728c342f:f9c5fde74b73d3d6b03b9ac6e65c8e39394c8f93-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=0.1.19,mira=4.0.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-76f1ae7601969630dc3438b950f824ee728c342f:f9c5fde74b73d3d6b03b9ac6e65c8e39394c8f93

**Packages**:
- samtools=0.1.19
- mira=4.0.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mira4_mapping.xml
- mira4_de_novo.xml

Generated with Planemo.