### PR TITLE
Add container mulled-v2-0341c0b96cc0354564c0fbe7d3ebc16cdeaa736d:8bc75ff7692d684238c5afc8524f83107ff5b5bc.

### DIFF
--- a/combinations/mulled-v2-0341c0b96cc0354564c0fbe7d3ebc16cdeaa736d:8bc75ff7692d684238c5afc8524f83107ff5b5bc-0.tsv
+++ b/combinations/mulled-v2-0341c0b96cc0354564c0fbe7d3ebc16cdeaa736d:8bc75ff7692d684238c5afc8524f83107ff5b5bc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mira=3.4.1.1,python=3.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0341c0b96cc0354564c0fbe7d3ebc16cdeaa736d:8bc75ff7692d684238c5afc8524f83107ff5b5bc

**Packages**:
- mira=3.4.1.1
- python=3.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mira.xml

Generated with Planemo.