### PR TITLE
Add container mulled-v2-8fbf36e6bbd4328bc806daafb84cc9d095953f18:e5f2ef2526f7c81cc116bae9d2e2271b438c791c.

### DIFF
--- a/combinations/mulled-v2-8fbf36e6bbd4328bc806daafb84cc9d095953f18:e5f2ef2526f7c81cc116bae9d2e2271b438c791c-0.tsv
+++ b/combinations/mulled-v2-8fbf36e6bbd4328bc806daafb84cc9d095953f18:e5f2ef2526f7c81cc116bae9d2e2271b438c791c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samestr=1.2025.111,samtools=0.1.19,zstd=1.5.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8fbf36e6bbd4328bc806daafb84cc9d095953f18:e5f2ef2526f7c81cc116bae9d2e2271b438c791c

**Packages**:
- samestr=1.2025.111
- samtools=0.1.19
- zstd=1.5.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- samestr_merge.xml
- samestr_compare.xml
- samestr_summarize.xml
- samestr_convert.xml
- samestr_filter.xml
- samestr_extract.xml
- samestr_stats.xml

Generated with Planemo.