### PR TITLE
Add container mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:d3f902d20494f7a19ebff1d136a174c38247b5c9.

### DIFF
--- a/combinations/mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:d3f902d20494f7a19ebff1d136a174c38247b5c9-0.tsv
+++ b/combinations/mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:d3f902d20494f7a19ebff1d136a174c38247b5c9-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.2.2,matplotlib=3.9.2,tabpfn=7.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7fd74fdcb1b3c3fc01e277c09980cd24fe0377ce:d3f902d20494f7a19ebff1d136a174c38247b5c9

**Packages**:
- pandas=2.2.2
- matplotlib=3.9.2
- tabpfn=7.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tabpfn.xml

Generated with Planemo.