### PR TITLE
Add container mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:22f20548506c9e5a7df453ef57af56e7da0d1af2.

### DIFF
--- a/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:22f20548506c9e5a7df453ef57af56e7da0d1af2-0.tsv
+++ b/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:22f20548506c9e5a7df453ef57af56e7da0d1af2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+openai=2.31.0,python=3.12,pyyaml=6.0.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:22f20548506c9e5a7df453ef57af56e7da0d1af2

**Packages**:
- openai=2.31.0
- python=3.12
- pyyaml=6.0.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- llm_hub.xml

Generated with Planemo.