### PR TITLE
Add container mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:78754a499f6e5cc996747efee1184e85ef53b8ce.

### DIFF
--- a/combinations/mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:78754a499f6e5cc996747efee1184e85ef53b8ce-0.tsv
+++ b/combinations/mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:78754a499f6e5cc996747efee1184e85ef53b8ce-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sortmerna=4.4.0,samtools=1.23.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d466c5c2c348e2ce1bc850ec97116b3d6eb99d43:78754a499f6e5cc996747efee1184e85ef53b8ce

**Packages**:
- sortmerna=4.4.0
- samtools=1.23.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- sortmerna.xml

Generated with Planemo.