### PR TITLE
Add container mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:794687d8f950afa5813de3ed38128e9d87482dd0.

### DIFF
--- a/combinations/mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:794687d8f950afa5813de3ed38128e9d87482dd0-0.tsv
+++ b/combinations/mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:794687d8f950afa5813de3ed38128e9d87482dd0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.23.1,rasusa=4.0.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:794687d8f950afa5813de3ed38128e9d87482dd0

**Packages**:
- samtools=1.23.1
- rasusa=4.0.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rasusa.xml

Generated with Planemo.