### PR TITLE
Add container mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:3baae7e0c5235f74b43a7823e40ff9ca2130f9f0.

### DIFF
--- a/combinations/mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:3baae7e0c5235f74b43a7823e40ff9ca2130f9f0-0.tsv
+++ b/combinations/mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:3baae7e0c5235f74b43a7823e40ff9ca2130f9f0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-igraph=2.3.0,r-e1071=1.7_17,king=2.3.2,r-kinship2=1.9.6.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fc6fbb861b7ab752d6c2db37c46cc659c8de1fc3:3baae7e0c5235f74b43a7823e40ff9ca2130f9f0

**Packages**:
- r-igraph=2.3.0
- r-e1071=1.7_17
- king=2.3.2
- r-kinship2=1.9.6.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- king.xml

Generated with Planemo.