### PR TITLE
Add container mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:227407156e2d2875d66e9cc282ba559dd9077e68.

### DIFF
--- a/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:227407156e2d2875d66e9cc282ba559dd9077e68-0.tsv
+++ b/combinations/mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:227407156e2d2875d66e9cc282ba559dd9077e68-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gzip=1.14,mosdepth=0.3.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0ce81b0672b34c2cb41c8710f4b31136f1a9fa46:227407156e2d2875d66e9cc282ba559dd9077e68

**Packages**:
- gzip=1.14
- mosdepth=0.3.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mosdepth.xml

Generated with Planemo.