### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:e3bfc7564ee6d5ea644b86546950744584eaeeca.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:e3bfc7564ee6d5ea644b86546950744584eaeeca-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:e3bfc7564ee6d5ea644b86546950744584eaeeca-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=18.24.0,ca-certificates=2026.4.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:e3bfc7564ee6d5ea644b86546950744584eaeeca

**Packages**:
- ncbi-datasets-cli=18.24.0
- ca-certificates=2026.4.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_gene.xml
- datasets_genome.xml

Generated with Planemo.