### PR TITLE
Add container mulled-v2-9c5223a92f8c7d9a2be8954bff99baf686bc7adb:51cbb5aa2d33a9210d35943c6ea8f2ffe289585c.

### DIFF
--- a/combinations/mulled-v2-9c5223a92f8c7d9a2be8954bff99baf686bc7adb:51cbb5aa2d33a9210d35943c6ea8f2ffe289585c-0.tsv
+++ b/combinations/mulled-v2-9c5223a92f8c7d9a2be8954bff99baf686bc7adb:51cbb5aa2d33a9210d35943c6ea8f2ffe289585c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+alphagenome=0.6.1,cyvcf2=0.31.4,pandas=2.3.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9c5223a92f8c7d9a2be8954bff99baf686bc7adb:51cbb5aa2d33a9210d35943c6ea8f2ffe289585c

**Packages**:
- alphagenome=0.6.1
- cyvcf2=0.31.4
- pandas=2.3.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- alphagenome_variant_scorer.xml
- alphagenome_ism_scanner.xml
- alphagenome_interval_predictor.xml
- alphagenome_variant_effect.xml
- alphagenome_sequence_predictor.xml

Generated with Planemo.