### PR TITLE
Add container mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:8f05b4eb496282f69844abeac98c94002c5c386e.

### DIFF
--- a/combinations/mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:8f05b4eb496282f69844abeac98c94002c5c386e-0.tsv
+++ b/combinations/mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:8f05b4eb496282f69844abeac98c94002c5c386e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.5,ghostscript=10.07.0,ribotaper=1.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-21e330745b12778ed001ec44affe2860ffe714c2:8f05b4eb496282f69844abeac98c94002c5c386e

**Packages**:
- coreutils=9.5
- ghostscript=10.07.0
- ribotaper=1.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- ribotaper_part1_create_annotation_files.xml
- ribotaper_part3_main.xml
- ribotaper_part2_create_metaplots.xml

Generated with Planemo.