### PR TITLE
Add container mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:ae0d5b56a45b922b5d5da5492ceed934fc78aabc.

### DIFF
--- a/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:ae0d5b56a45b922b5d5da5492ceed934fc78aabc-0.tsv
+++ b/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:ae0d5b56a45b922b5d5da5492ceed934fc78aabc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+staramr=0.12.2,mlst=2.33.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:ae0d5b56a45b922b5d5da5492ceed934fc78aabc

**Packages**:
- staramr=0.12.2
- mlst=2.33.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- staramr_search.xml

Generated with Planemo.