### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d1e2adf8cc287f551f217f11152685199d08be97.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d1e2adf8cc287f551f217f11152685199d08be97-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d1e2adf8cc287f551f217f11152685199d08be97-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-datasets-cli=18.25.1,ca-certificates=2026.4.22	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:d1e2adf8cc287f551f217f11152685199d08be97

**Packages**:
- ncbi-datasets-cli=18.25.1
- ca-certificates=2026.4.22
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_gene.xml
- datasets_genome.xml

Generated with Planemo.