### PR TITLE
Add container mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:408c88e1fe5139767f1e8a96a19834cb5f9e27f4.

### DIFF
--- a/combinations/mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:408c88e1fe5139767f1e8a96a19834cb5f9e27f4-0.tsv
+++ b/combinations/mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:408c88e1fe5139767f1e8a96a19834cb5f9e27f4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyarrow=24.0.0,pandas=3.0.2,scipy=1.17.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f5bcc49db2e8d41c3472bc591a910399d68ee50e:408c88e1fe5139767f1e8a96a19834cb5f9e27f4

**Packages**:
- pyarrow=24.0.0
- pandas=3.0.2
- scipy=1.17.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- table_scipy_interpolate.xml

Generated with Planemo.