### PR TITLE
Add container mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0f51d2179c8201723ccfbc185d3aa95071afe628.

### DIFF
--- a/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0f51d2179c8201723ccfbc185d3aa95071afe628-0.tsv
+++ b/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0f51d2179c8201723ccfbc185d3aa95071afe628-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12,openai=2.36.0,pyyaml=6.0.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0f51d2179c8201723ccfbc185d3aa95071afe628

**Packages**:
- python=3.12
- openai=2.36.0
- pyyaml=6.0.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- llm_hub.xml

Generated with Planemo.