### PR TITLE
Add container mulled-v2-ab04367255ba863615857ce6162768d59b8b22da:9068e0201249415387d16bf8587c9965999e1e2f.

### DIFF
--- a/combinations/mulled-v2-ab04367255ba863615857ce6162768d59b8b22da:9068e0201249415387d16bf8587c9965999e1e2f-0.tsv
+++ b/combinations/mulled-v2-ab04367255ba863615857ce6162768d59b8b22da:9068e0201249415387d16bf8587c9965999e1e2f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+setuptools=82.0.1,psauron=1.1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-ab04367255ba863615857ce6162768d59b8b22da:9068e0201249415387d16bf8587c9965999e1e2f

**Packages**:
- setuptools=82.0.1
- psauron=1.1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- psauron.xml

Generated with Planemo.