### PR TITLE
Add container mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:3f642c4c7e5090a1aec701b1ea4bdfba6c79ebef.

### DIFF
--- a/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:3f642c4c7e5090a1aec701b1ea4bdfba6c79ebef-0.tsv
+++ b/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:3f642c4c7e5090a1aec701b1ea4bdfba6c79ebef-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12,pyyaml=6.0.3,openai=2.37.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:3f642c4c7e5090a1aec701b1ea4bdfba6c79ebef

**Packages**:
- python=3.12
- pyyaml=6.0.3
- openai=2.37.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- llm_hub.xml

Generated with Planemo.