### PR TITLE
Add mulled containers for two Galaxy tools

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -947,3 +947,5 @@ r-susier=0.14.2,r-data.table=1.17.8
 samtools=1.21,star=2.7.3a
 gcta=1.94.1,tabix=1.11
 manc_cojo=1.1.0,tabix=1.11
+r-base=4.3.3,bioconductor-deseq2=1.42.0
+python=3.11,scipy=1.12.0


### PR DESCRIPTION
Adds two multi-package combinations needed by new goeckslab Galaxy Tool Shed wrappers proposed for usegalaxy.org:
- `r-base=4.3.3,bioconductor-deseq2=1.42.0` for `rds_to_tabular`
- `python=3.11,scipy=1.12.0` for `mann_whitney_wilcoxon`

Expected mulled image names:

- `mulled-v2-41bbad535d3eb2bb8d0e67367667731e94f5483f:e38821766cc2fb5c5477d875a6a53b70e04abe48`
- `mulled-v2-fe50b754e7a37519324a60af3d3b47973f3d508a:89e1eadc37e12c57b982ce133833c41bfdf72da8`