### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:eb64751e7f6c9ccf8fd3964a0aa344596f85961b.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:eb64751e7f6c9ccf8fd3964a0aa344596f85961b-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:eb64751e7f6c9ccf8fd3964a0aa344596f85961b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2026.5.20,ncbi-datasets-cli=18.28.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:eb64751e7f6c9ccf8fd3964a0aa344596f85961b

**Packages**:
- ca-certificates=2026.5.20
- ncbi-datasets-cli=18.28.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_gene.xml
- datasets_genome.xml

Generated with Planemo.