### PR TITLE
Add container mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:b411340b52d82a9c276d87c7a3dcffc880be762f.

### DIFF
--- a/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:b411340b52d82a9c276d87c7a3dcffc880be762f-0.tsv
+++ b/combinations/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:b411340b52d82a9c276d87c7a3dcffc880be762f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.23.1,minimap2=2.31	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:b411340b52d82a9c276d87c7a3dcffc880be762f

**Packages**:
- samtools=1.23.1
- minimap2=2.31
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- minimap2.xml

Generated with Planemo.