### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:69fa599a3a1dde52aa80aa866da3a6e6ea8ee72b.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:69fa599a3a1dde52aa80aa866da3a6e6ea8ee72b-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:69fa599a3a1dde52aa80aa866da3a6e6ea8ee72b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2026.5.20,ncbi-datasets-cli=18.29.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:69fa599a3a1dde52aa80aa866da3a6e6ea8ee72b

**Packages**:
- ca-certificates=2026.5.20
- ncbi-datasets-cli=18.29.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.