### PR TITLE
Add container mulled-v2-344874846f44224e5f0b7b741eacdddffe895d1e:18b85f3601be544332a791bb9625777e740ff376.

### DIFF
--- a/combinations/mulled-v2-344874846f44224e5f0b7b741eacdddffe895d1e:18b85f3601be544332a791bb9625777e740ff376-0.tsv
+++ b/combinations/mulled-v2-344874846f44224e5f0b7b741eacdddffe895d1e:18b85f3601be544332a791bb9625777e740ff376-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=3.0.3,numpy=2.4.6	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-344874846f44224e5f0b7b741eacdddffe895d1e:18b85f3601be544332a791bb9625777e740ff376

**Packages**:
- pandas=3.0.3
- numpy=2.4.6
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stratified_block_randomization.xml

Generated with Planemo.