### PR TITLE
Add container mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:4d702b8c3ad3ff53c6023de86a21af7cf31defda.

### DIFF
--- a/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:4d702b8c3ad3ff53c6023de86a21af7cf31defda-0.tsv
+++ b/combinations/mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:4d702b8c3ad3ff53c6023de86a21af7cf31defda-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+stringtie=3.0.3,samtools=1.22.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-704aee0c18e3278557ac3bedcbb7986e3913f703:4d702b8c3ad3ff53c6023de86a21af7cf31defda

**Packages**:
- stringtie=3.0.3
- samtools=1.22.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- stringtie_merge.xml
- stringtie.xml

Generated with Planemo.