### PR TITLE
Add container mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0c0b4e92b893be7d7557c57045fdf4e57ee2dc0c.

### DIFF
--- a/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0c0b4e92b893be7d7557c57045fdf4e57ee2dc0c-0.tsv
+++ b/combinations/mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0c0b4e92b893be7d7557c57045fdf4e57ee2dc0c-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+openai=2.41.0,pyyaml=6.0.3,python=3.12	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1ec6000e599b4e96a97cd02c3969707f792ed0d0:0c0b4e92b893be7d7557c57045fdf4e57ee2dc0c

**Packages**:
- openai=2.41.0
- pyyaml=6.0.3
- python=3.12
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- llm_hub.xml

Generated with Planemo.