### PR TITLE
Add container mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:c8f7d79f3e92596dfadf13f26748e38689a161fc.

### DIFF
--- a/combinations/mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:c8f7d79f3e92596dfadf13f26748e38689a161fc-0.tsv
+++ b/combinations/mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:c8f7d79f3e92596dfadf13f26748e38689a161fc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+panaroo=1.7.0,prank=251117,clustalo=1.2.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:c8f7d79f3e92596dfadf13f26748e38689a161fc

**Packages**:
- panaroo=1.7.0
- prank=251117
- clustalo=1.2.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- panaroo.xml

Generated with Planemo.