### PR TITLE
Add container mulled-v2-5f28b0ccab8cf32bdd9ef8be14f9a0b2c5ce05fc:04669bbc8075d379946c0244b0e6f86cbd1e5041.

### DIFF
--- a/combinations/mulled-v2-5f28b0ccab8cf32bdd9ef8be14f9a0b2c5ce05fc:04669bbc8075d379946c0244b0e6f86cbd1e5041-0.tsv
+++ b/combinations/mulled-v2-5f28b0ccab8cf32bdd9ef8be14f9a0b2c5ce05fc:04669bbc8075d379946c0244b0e6f86cbd1e5041-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+numpy=1.26.0,pycocotools=2.0.11,opencv=4.13.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-5f28b0ccab8cf32bdd9ef8be14f9a0b2c5ce05fc:04669bbc8075d379946c0244b0e6f86cbd1e5041

**Packages**:
- numpy=1.26.0
- pycocotools=2.0.11
- opencv=4.13.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- coco_annotation_visualizer.xml

Generated with Planemo.