### PR TITLE
Add container mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:27c6fb6e8989a08d05ecdcf8b340f9a71163e882.

### DIFF
--- a/combinations/mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:27c6fb6e8989a08d05ecdcf8b340f9a71163e882-0.tsv
+++ b/combinations/mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:27c6fb6e8989a08d05ecdcf8b340f9a71163e882-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ncbi-amrfinderplus=4.2.7,pandas=2.3.3,python=3.11.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2d89def15ec5f0c75249c2ee4ca452038958f94e:27c6fb6e8989a08d05ecdcf8b340f9a71163e882

**Packages**:
- ncbi-amrfinderplus=4.2.7
- pandas=2.3.3
- python=3.11.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- data_manager_build_amrfinderplus.xml

Generated with Planemo.