### PR TITLE
Add container r-raceid:0.4.1.

### DIFF
--- a/combinations/r-raceid:0.4.1-0.tsv
+++ b/combinations/r-raceid:0.4.1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-raceid=0.4.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: r-raceid:0.4.1

**Packages**:
- r-raceid=0.4.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- raceid_inspectclusters.xml
- raceid_trajectory.xml
- raceid_filtnormconf.xml
- raceid_inspecttrajectories.xml
- raceid_clustering.xml

Generated with Planemo.