### PR TITLE
Add container mulled-v2-9a77e1e1e1503dae8a7085d12eb5afe06e3c9bf0:654f1cb2ef41124dbbc36811f2e25e0342b3c334.

### DIFF
--- a/combinations/mulled-v2-9a77e1e1e1503dae8a7085d12eb5afe06e3c9bf0:654f1cb2ef41124dbbc36811f2e25e0342b3c334-0.tsv
+++ b/combinations/mulled-v2-9a77e1e1e1503dae8a7085d12eb5afe06e3c9bf0:654f1cb2ef41124dbbc36811f2e25e0342b3c334-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+make=4.4.1,fermi2=r204	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9a77e1e1e1503dae8a7085d12eb5afe06e3c9bf0:654f1cb2ef41124dbbc36811f2e25e0342b3c334

**Packages**:
- make=4.4.1
- fermi2=r204
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- fermi2.xml

Generated with Planemo.