### PR TITLE
Add container mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:554912fb4663b66a7db92472d73ef2d27ab8ae27.

### DIFF
--- a/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:554912fb4663b66a7db92472d73ef2d27ab8ae27-0.tsv
+++ b/combinations/mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:554912fb4663b66a7db92472d73ef2d27ab8ae27-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mlst=2.33.1,staramr=0.12.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-30758c5e2be407d6bbf2570c832fb245e8488634:554912fb4663b66a7db92472d73ef2d27ab8ae27

**Packages**:
- mlst=2.33.1
- staramr=0.12.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- staramr_search.xml

Generated with Planemo.