### PR TITLE
Add container mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:6d7fcfbbcd32cf6c34208183c95483b9ef8b41ca.

### DIFF
--- a/combinations/mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:6d7fcfbbcd32cf6c34208183c95483b9ef8b41ca-0.tsv
+++ b/combinations/mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:6d7fcfbbcd32cf6c34208183c95483b9ef8b41ca-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ucsc-bedgraphtobigwig=482,pytrf=1.5.0,python=3.12.3,pyfastx=2.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4614f8b3a5255c4e5ecbc78c1cfaf24d744b06ab:6d7fcfbbcd32cf6c34208183c95483b9ef8b41ca

**Packages**:
- ucsc-bedgraphtobigwig=482
- pytrf=1.5.0
- python=3.12.3
- pyfastx=2.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- microsatbed.xml

Generated with Planemo.