### PR TITLE
Add container xtb:6.7.1.

### DIFF
--- a/combinations/xtb:6.7.1-0.tsv
+++ b/combinations/xtb:6.7.1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+xtb=6.7.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: xtb:6.7.1

**Packages**:
- xtb=6.7.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- xtb_molecular_optimization.xml

Generated with Planemo.