### PR TITLE
Add container mulled-v2-324f00fcc905f12684c8db4efa59ce690b349b3f:bde8e359af13cc7a433cdcafc0e78c9126c518d6.

### DIFF
--- a/combinations/mulled-v2-324f00fcc905f12684c8db4efa59ce690b349b3f:bde8e359af13cc7a433cdcafc0e78c9126c518d6-0.tsv
+++ b/combinations/mulled-v2-324f00fcc905f12684c8db4efa59ce690b349b3f:bde8e359af13cc7a433cdcafc0e78c9126c518d6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyyaml=6.0.3,openpyxl=3.1.5,aoptk=0.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-324f00fcc905f12684c8db4efa59ce690b349b3f:bde8e359af13cc7a433cdcafc0e78c9126c518d6

**Packages**:
- pyyaml=6.0.3
- openpyxl=3.1.5
- aoptk=0.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- aoptk_finalize_output.xml

Generated with Planemo.