### PR TITLE
Add container mulled-v2-dacce7cabbf0b7eb94af3fc6002ef8d06f6831a8:c8abb9085820a5ba9fc84cadccee7a40a64acafc.

### DIFF
--- a/combinations/mulled-v2-dacce7cabbf0b7eb94af3fc6002ef8d06f6831a8:c8abb9085820a5ba9fc84cadccee7a40a64acafc-0.tsv
+++ b/combinations/mulled-v2-dacce7cabbf0b7eb94af3fc6002ef8d06f6831a8:c8abb9085820a5ba9fc84cadccee7a40a64acafc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+eastr-cpp=2.1.1,bowtie2=2.5.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-dacce7cabbf0b7eb94af3fc6002ef8d06f6831a8:c8abb9085820a5ba9fc84cadccee7a40a64acafc

**Packages**:
- eastr-cpp=2.1.1
- bowtie2=2.5.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- eastr.xml

Generated with Planemo.