### PR TITLE
Add container mulled-v2-82ec636d394ebdd53cc58ea66f0110cd4e9ed507:fd2f6f38ed2ef914708503f7f9d881f4ed59e2da.

### DIFF
--- a/combinations/mulled-v2-82ec636d394ebdd53cc58ea66f0110cd4e9ed507:fd2f6f38ed2ef914708503f7f9d881f4ed59e2da-0.tsv
+++ b/combinations/mulled-v2-82ec636d394ebdd53cc58ea66f0110cd4e9ed507:fd2f6f38ed2ef914708503f7f9d881f4ed59e2da-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.10,bokeh=3.7.3,pandas=2.2.3,numpy=2.2.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-82ec636d394ebdd53cc58ea66f0110cd4e9ed507:fd2f6f38ed2ef914708503f7f9d881f4ed59e2da

**Packages**:
- python=3.10
- bokeh=3.7.3
- pandas=2.2.3
- numpy=2.2.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- heatmap.xml

Generated with Planemo.