### PR TITLE
Add container mulled-v2-a93cfc3f9a394b95c60890563d52b7a0745733b1:fa81bccecff16f6596249e136629aea6f6cfbf61.

### DIFF
--- a/combinations/mulled-v2-a93cfc3f9a394b95c60890563d52b7a0745733b1:fa81bccecff16f6596249e136629aea6f6cfbf61-0.tsv
+++ b/combinations/mulled-v2-a93cfc3f9a394b95c60890563d52b7a0745733b1:fa81bccecff16f6596249e136629aea6f6cfbf61-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-tsenat=0.99.24,r-optparse=1.8.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a93cfc3f9a394b95c60890563d52b7a0745733b1:fa81bccecff16f6596249e136629aea6f6cfbf61

**Packages**:
- r-tsenat=0.99.24
- r-optparse=1.8.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tsenat.xml

Generated with Planemo.