### PR TITLE
Add container mulled-v2-0df183b841e99009662386012e97e80cdcedcf0d:d052f67c17c679923ccaa8dc6cbdd40453093311.

### DIFF
--- a/combinations/mulled-v2-0df183b841e99009662386012e97e80cdcedcf0d:d052f67c17c679923ccaa8dc6cbdd40453093311-0.tsv
+++ b/combinations/mulled-v2-0df183b841e99009662386012e97e80cdcedcf0d:d052f67c17c679923ccaa8dc6cbdd40453093311-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bioconductor-biosigner=1.38.0,r-batch=1.1_5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0df183b841e99009662386012e97e80cdcedcf0d:d052f67c17c679923ccaa8dc6cbdd40453093311

**Packages**:
- bioconductor-biosigner=1.38.0
- r-batch=1.1_5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- biosigner_config.xml

Generated with Planemo.