### PR TITLE
Add container mulled-v2-7659558cb19fdc912d0cd19e19bf435130b46160:87a8bb04f733cb6f18f6b98efe33ef26ee46e137.

### DIFF
--- a/combinations/mulled-v2-7659558cb19fdc912d0cd19e19bf435130b46160:87a8bb04f733cb6f18f6b98efe33ef26ee46e137-0.tsv
+++ b/combinations/mulled-v2-7659558cb19fdc912d0cd19e19bf435130b46160:87a8bb04f733cb6f18f6b98efe33ef26ee46e137-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-rjson=0.2.21,bioconductor-genomicfeatures=1.52.1,bioconductor-apeglm=1.22.1,r-gplots=3.1.3,bioconductor-rhdf5=2.44.0,r-base64enc=0.1_3,r-ashr=2.2_63,bioconductor-tximport=1.28.0,r-pheatmap=1.0.12,r-getopt=1.20.3,r-ggrepel=0.9.3,bioconductor-deseq2=1.40.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-7659558cb19fdc912d0cd19e19bf435130b46160:87a8bb04f733cb6f18f6b98efe33ef26ee46e137

**Packages**:
- r-rjson=0.2.21
- bioconductor-genomicfeatures=1.52.1
- bioconductor-apeglm=1.22.1
- r-gplots=3.1.3
- bioconductor-rhdf5=2.44.0
- r-base64enc=0.1_3
- r-ashr=2.2_63
- bioconductor-tximport=1.28.0
- r-pheatmap=1.0.12
- r-getopt=1.20.3
- r-ggrepel=0.9.3
- bioconductor-deseq2=1.40.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deseq2.xml

Generated with Planemo.