### PR TITLE
Add container mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:9da9bcb761d60b6c4cad7f806fcf2bddf9d91ef2.

### DIFF
--- a/combinations/mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:9da9bcb761d60b6c4cad7f806fcf2bddf9d91ef2-0.tsv
+++ b/combinations/mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:9da9bcb761d60b6c4cad7f806fcf2bddf9d91ef2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=4.5.2,r-ggplot2=3.5.2,r-dispersionindicators=0.1.5,r-optparse=1.7.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:9da9bcb761d60b6c4cad7f806fcf2bddf9d91ef2

**Packages**:
- r-base=4.5.2
- r-ggplot2=3.5.2
- r-dispersionindicators=0.1.5
- r-optparse=1.7.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- batch_dispersion.xml

Generated with Planemo.