### PR TITLE
Add container mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:8a963cbae44deda2d2445ad15e8474277f154d68.

### DIFF
--- a/combinations/mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:8a963cbae44deda2d2445ad15e8474277f154d68-0.tsv
+++ b/combinations/mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:8a963cbae44deda2d2445ad15e8474277f154d68-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+panaroo=1.8.0,clustalo=1.2.4,prank=251117	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d0a31f0595153d696783e255901e79d6f9e26a7b:8a963cbae44deda2d2445ad15e8474277f154d68

**Packages**:
- panaroo=1.8.0
- clustalo=1.2.4
- prank=251117
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- panaroo.xml

Generated with Planemo.