### PR TITLE
Add container mulled-v2-c1b3fb8d65939f32d50572bdd73ec6004384d251:972421d156ee01893ec10710f08c59251fc2b8f5.

### DIFF
--- a/combinations/mulled-v2-c1b3fb8d65939f32d50572bdd73ec6004384d251:972421d156ee01893ec10710f08c59251fc2b8f5-0.tsv
+++ b/combinations/mulled-v2-c1b3fb8d65939f32d50572bdd73ec6004384d251:972421d156ee01893ec10710f08c59251fc2b8f5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+unzip=6.0,rioxarray=0.22.0,spatialdata=0.7.3,spatialdata-plot=0.4.0,zip=3.0,spatialdata-io=0.7.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c1b3fb8d65939f32d50572bdd73ec6004384d251:972421d156ee01893ec10710f08c59251fc2b8f5

**Packages**:
- unzip=6.0
- rioxarray=0.22.0
- spatialdata=0.7.3
- spatialdata-plot=0.4.0
- zip=3.0
- spatialdata-io=0.7.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- spatialdata_io.xml
- spatialdata_plot.xml
- spatialdata_operation.xml

Generated with Planemo.