### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:5654e1dba5874b51df43cdbdf621acdd60b49ffe.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:5654e1dba5874b51df43cdbdf621acdd60b49ffe-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:5654e1dba5874b51df43cdbdf621acdd60b49ffe-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2026.6.17,ncbi-datasets-cli=18.32.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:5654e1dba5874b51df43cdbdf621acdd60b49ffe

**Packages**:
- ca-certificates=2026.6.17
- ncbi-datasets-cli=18.32.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.