### PR TITLE
Add container mulled-v2-69b8c006b91a17466bc4676a705cd602fc796277:35e7727d31aeb18c0496ff8ba1c2b4103f9e5f18.

### DIFF
--- a/combinations/mulled-v2-69b8c006b91a17466bc4676a705cd602fc796277:35e7727d31aeb18c0496ff8ba1c2b4103f9e5f18-0.tsv
+++ b/combinations/mulled-v2-69b8c006b91a17466bc4676a705cd602fc796277:35e7727d31aeb18c0496ff8ba1c2b4103f9e5f18-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bowtie2=2.5.4,samestr=1.2025.111	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-69b8c006b91a17466bc4676a705cd602fc796277:35e7727d31aeb18c0496ff8ba1c2b4103f9e5f18

**Packages**:
- bowtie2=2.5.4
- samestr=1.2025.111
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- samestr_db.xml

Generated with Planemo.