### PR TITLE
Add container mulled-v2-c1e55e0cd02a250c731e08abdbc19136321c06b8:41c716dcf216edab9ae9bb87b37930c907ddfb48.

### DIFF
--- a/combinations/mulled-v2-c1e55e0cd02a250c731e08abdbc19136321c06b8:41c716dcf216edab9ae9bb87b37930c907ddfb48-0.tsv
+++ b/combinations/mulled-v2-c1e55e0cd02a250c731e08abdbc19136321c06b8:41c716dcf216edab9ae9bb87b37930c907ddfb48-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-wgcna=1.74,jq=1.6.0,r-igraph=2.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c1e55e0cd02a250c731e08abdbc19136321c06b8:41c716dcf216edab9ae9bb87b37930c907ddfb48

**Packages**:
- r-wgcna=1.74
- jq=1.6.0
- r-igraph=2.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- wgcna_sft.xml
- wgcna_network.xml

Generated with Planemo.