### PR TITLE
Add container mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:2fbd5183d56e74d889e50c82c59b46990c1793eb.

### DIFF
--- a/combinations/mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:2fbd5183d56e74d889e50c82c59b46990c1793eb-0.tsv
+++ b/combinations/mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:2fbd5183d56e74d889e50c82c59b46990c1793eb-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-arrow=24.0.0,r-recetox-waveica=0.2.1,r-dplyr=1.2.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a82601b1de287e2d9eef04c9c9049bc1c79728c3:2fbd5183d56e74d889e50c82c59b46990c1793eb

**Packages**:
- r-arrow=24.0.0
- r-recetox-waveica=0.2.1
- r-dplyr=1.2.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- waveica.xml

Generated with Planemo.