### PR TITLE
Add container mulled-v2-0951be1d305c88de2aeca0843f04cc3da59abdff:d540316a321f8bb63b04e592d45022cab9ee89d0.

### DIFF
--- a/combinations/mulled-v2-0951be1d305c88de2aeca0843f04cc3da59abdff:d540316a321f8bb63b04e592d45022cab9ee89d0-0.tsv
+++ b/combinations/mulled-v2-0951be1d305c88de2aeca0843f04cc3da59abdff:d540316a321f8bb63b04e592d45022cab9ee89d0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+chewbbaca=3.3.10,plotly=5.8.0,fasttree=2.1.11,zip=3.0,unzip=6.0,blast=2.15.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-0951be1d305c88de2aeca0843f04cc3da59abdff:d540316a321f8bb63b04e592d45022cab9ee89d0

**Packages**:
- chewbbaca=3.3.10
- plotly=5.8.0
- fasttree=2.1.11
- zip=3.0
- unzip=6.0
- blast=2.15.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- PrepExternalSchema.xml
- ExtractCgMLST.xml
- AlleleCall.xml
- JoinProfiles.xml
- NSStats.xml
- CreateSchema.xml
- AlleleCallEvaluator.xml
- DownloadSchema.xml

Generated with Planemo.