### PR TITLE
Add container mulled-v2-160b9b43cf7fabe8364c76b942224eaf1733149a:ef733639f836cae6e31b74a7e7a80e71bd41c98d.

### DIFF
--- a/combinations/mulled-v2-160b9b43cf7fabe8364c76b942224eaf1733149a:ef733639f836cae6e31b74a7e7a80e71bd41c98d-0.tsv
+++ b/combinations/mulled-v2-160b9b43cf7fabe8364c76b942224eaf1733149a:ef733639f836cae6e31b74a7e7a80e71bd41c98d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+telescope=1.0.4.1,samtools=1.9	quay.io/bioconda/base-glibc-debian-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-160b9b43cf7fabe8364c76b942224eaf1733149a:ef733639f836cae6e31b74a7e7a80e71bd41c98d

**Packages**:
- telescope=1.0.4.1
- samtools=1.9
Base Image:quay.io/bioconda/base-glibc-debian-bash:latest

**For** :
- telescope_assign.xml

Generated with Planemo.