### PR TITLE
Add container kraken-ocr:7.0.2.

### DIFF
--- a/combinations/kraken-ocr:7.0.2-0.tsv
+++ b/combinations/kraken-ocr:7.0.2-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+kraken-ocr=7.0.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: kraken-ocr:7.0.2

**Packages**:
- kraken-ocr=7.0.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- kraken_binarize.xml
- kraken_segment.xml
- kraken_ocr.xml

Generated with Planemo.