### PR TITLE
Add container mulled-v2-c3b945a54cabda6696fc3e0d6c4d517e802f3bc3:60661b2a5f74963fce66d67783e310cb0a00f0f1.

### DIFF
--- a/combinations/mulled-v2-c3b945a54cabda6696fc3e0d6c4d517e802f3bc3:60661b2a5f74963fce66d67783e310cb0a00f0f1-0.tsv
+++ b/combinations/mulled-v2-c3b945a54cabda6696fc3e0d6c4d517e802f3bc3:60661b2a5f74963fce66d67783e310cb0a00f0f1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+unzip=6.0,spatialdata-io=0.7.0,anndata=0.12.10,spatialdata-plot=0.4.0,rioxarray=0.22.0,pandas=2.3.3,zip=3.0,spatialdata=0.8.0,ome-zarr=0.18.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c3b945a54cabda6696fc3e0d6c4d517e802f3bc3:60661b2a5f74963fce66d67783e310cb0a00f0f1

**Packages**:
- unzip=6.0
- spatialdata-io=0.7.0
- anndata=0.12.10
- spatialdata-plot=0.4.0
- rioxarray=0.22.0
- pandas=2.3.3
- zip=3.0
- spatialdata=0.8.0
- ome-zarr=0.18.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- spatialdata_plot.xml
- spatialdata_operation.xml
- spatialdata_io.xml

Generated with Planemo.