### PR TITLE
Add container mulled-v2-54e23f99ac9bff4ef7d7f09a8b5e0be2f57d0826:c7ae339b5b6182ecc40dcf1d30a66ba5d3399bd0.

### DIFF
--- a/combinations/mulled-v2-54e23f99ac9bff4ef7d7f09a8b5e0be2f57d0826:c7ae339b5b6182ecc40dcf1d30a66ba5d3399bd0-0.tsv
+++ b/combinations/mulled-v2-54e23f99ac9bff4ef7d7f09a8b5e0be2f57d0826:c7ae339b5b6182ecc40dcf1d30a66ba5d3399bd0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.21,wfmash=0.24.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-54e23f99ac9bff4ef7d7f09a8b5e0be2f57d0826:c7ae339b5b6182ecc40dcf1d30a66ba5d3399bd0

**Packages**:
- samtools=1.21
- wfmash=0.24.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- wfmash.xml

Generated with Planemo.