### PR TITLE
Add container mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:aec10e45bf005caed6486407631409353340e627.

### DIFF
--- a/combinations/mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:aec10e45bf005caed6486407631409353340e627-0.tsv
+++ b/combinations/mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:aec10e45bf005caed6486407631409353340e627-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcftools=1.24,htslib=1.24,matplotlib=3.11.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3f0b2099bce3ecb75064dfe6cdabcd4018727aa8:aec10e45bf005caed6486407631409353340e627

**Packages**:
- bcftools=1.24
- htslib=1.24
- matplotlib=3.11.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_cnv.xml

Generated with Planemo.