### PR TITLE
Add container mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:3d346eda86e34f780e248badfdebb74ad5c5a258.

### DIFF
--- a/combinations/mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:3d346eda86e34f780e248badfdebb74ad5c5a258-0.tsv
+++ b/combinations/mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:3d346eda86e34f780e248badfdebb74ad5c5a258-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.4.1,bcftools=1.24,htslib=1.24,samtools=1.24	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-03d30cf7bcc23ba5d755e498a98359af8a2cd947:3d346eda86e34f780e248badfdebb74ad5c5a258

**Packages**:
- gawk=5.4.1
- bcftools=1.24
- htslib=1.24
- samtools=1.24
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_consensus.xml

Generated with Planemo.