### PR TITLE
Add container mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:8f5c791e10a266b7c89ebd2cedf9fc984bca4d17.

### DIFF
--- a/combinations/mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:8f5c791e10a266b7c89ebd2cedf9fc984bca4d17-0.tsv
+++ b/combinations/mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:8f5c791e10a266b7c89ebd2cedf9fc984bca4d17-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcftools=1.24,htslib=1.24,samtools=1.24	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-f7a49c68bd00a9e0147f58c2f0ef0a7bd67e944b:8f5c791e10a266b7c89ebd2cedf9fc984bca4d17

**Packages**:
- bcftools=1.24
- htslib=1.24
- samtools=1.24
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_norm.xml
- bcftools_mpileup.xml
- bcftools_convert_to_vcf.xml
- bcftools_csq.xml

Generated with Planemo.