### PR TITLE
Add container mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:749fa6221ede849dce4b3a5ecd52e6eec522fe1d.

### DIFF
--- a/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:749fa6221ede849dce4b3a5ecd52e6eec522fe1d-0.tsv
+++ b/combinations/mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:749fa6221ede849dce4b3a5ecd52e6eec522fe1d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.24,bcftools=1.24,matplotlib=3.11.0,tectonic=0.16.9,htslib=1.24	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-547c8a50abcc87dd9c56eef18e501b06ff1b77d1:749fa6221ede849dce4b3a5ecd52e6eec522fe1d

**Packages**:
- samtools=1.24
- bcftools=1.24
- matplotlib=3.11.0
- tectonic=0.16.9
- htslib=1.24
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_stats.xml

Generated with Planemo.