### PR TITLE
Add container mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:0cc564bf209db5c80c5254b3ff6fa34df8ca1974.

### DIFF
--- a/combinations/mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:0cc564bf209db5c80c5254b3ff6fa34df8ca1974-0.tsv
+++ b/combinations/mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:0cc564bf209db5c80c5254b3ff6fa34df8ca1974-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bcftools=1.24,python=3.7,htslib=1.24	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-4046a3b419fc1d57d709b7a143645d599908d9e4:0cc564bf209db5c80c5254b3ff6fa34df8ca1974

**Packages**:
- bcftools=1.24
- python=3.7
- htslib=1.24
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bcftools_plugin_counts.xml

Generated with Planemo.