### PR TITLE
Add container mulled-v2-20f3882ed8f553f4888eb16ec5de721e4009a15c:c88489970f5d378cd81b5ff27cd8562903df7078.

### DIFF
--- a/combinations/mulled-v2-20f3882ed8f553f4888eb16ec5de721e4009a15c:c88489970f5d378cd81b5ff27cd8562903df7078-0.tsv
+++ b/combinations/mulled-v2-20f3882ed8f553f4888eb16ec5de721e4009a15c:c88489970f5d378cd81b5ff27cd8562903df7078-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+mirtrace=1.0.1,gzip=1.14	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-20f3882ed8f553f4888eb16ec5de721e4009a15c:c88489970f5d378cd81b5ff27cd8562903df7078

**Packages**:
- mirtrace=1.0.1
- gzip=1.14
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mirtrace_trace.xml
- mirtrace_qc.xml

Generated with Planemo.