### PR TITLE
Add container mulled-v2-8ea51b62372940b0540954888763c9f00634162e:7434358da2af47972837f9a7308fe4ee78563126.

### DIFF
--- a/combinations/mulled-v2-8ea51b62372940b0540954888763c9f00634162e:7434358da2af47972837f9a7308fe4ee78563126-0.tsv
+++ b/combinations/mulled-v2-8ea51b62372940b0540954888763c9f00634162e:7434358da2af47972837f9a7308fe4ee78563126-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.22,bamboozle=0.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8ea51b62372940b0540954888763c9f00634162e:7434358da2af47972837f9a7308fe4ee78563126

**Packages**:
- samtools=1.22
- bamboozle=0.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bamboozle.xml

Generated with Planemo.