### PR TITLE
Add container mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:56502a6719853872a705f337a9081d7b894fbb95.

### DIFF
--- a/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:56502a6719853872a705f337a9081d7b894fbb95-0.tsv
+++ b/combinations/mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:56502a6719853872a705f337a9081d7b894fbb95-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+ca-certificates=2026.7.22,ncbi-datasets-cli=18.33.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b8c00919e78e310f5965a5971fdc4280dbc6cc1c:56502a6719853872a705f337a9081d7b894fbb95

**Packages**:
- ca-certificates=2026.7.22
- ncbi-datasets-cli=18.33.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datasets_genome.xml
- datasets_gene.xml

Generated with Planemo.