### PR TITLE
Add MultiQC and oncoanalyser plugin

### DIFF
--- a/combinations/hash.tsv
+++ b/combinations/hash.tsv
@@ -949,3 +949,4 @@ gcta=1.94.1,tabix=1.11
 manc_cojo=1.1.0,tabix=1.11
 lastz=1.0.4,python=3.9
 aoptk=0.5.0,pyyaml=6.0.3
+multiqc=1.35,oncoanalyser::oncoanalyser-multiqc-plugin=0.1.0


### PR DESCRIPTION
Required for oncoanalyser. Packages:

- `multiqc=1.35`
- `oncoanalyser-multiqc-plugin=0.1.0`