### PR TITLE
Add container mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:4282227e9e3f5f7c8a786699f3ea88640cbcbc30.

### DIFF
--- a/combinations/mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:4282227e9e3f5f7c8a786699f3ea88640cbcbc30-0.tsv
+++ b/combinations/mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:4282227e9e3f5f7c8a786699f3ea88640cbcbc30-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+curl=8.21.0,zenodo_get=1.6.1,wget=1.25.0,deacon=0.12.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:4282227e9e3f5f7c8a786699f3ea88640cbcbc30

**Packages**:
- curl=8.21.0
- zenodo_get=1.6.1
- wget=1.25.0
- deacon=0.12.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deacon_datamanager.xml

Generated with Planemo.