### PR TITLE
Add container mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:47a09d31b20940827b4c2d23e72b6ddfdc693ce7.

### DIFF
--- a/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:47a09d31b20940827b4c2d23e72b6ddfdc693ce7-0.tsv
+++ b/combinations/mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:47a09d31b20940827b4c2d23e72b6ddfdc693ce7-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.24,cutesv=2.1.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-31457b56c9a9c57b2aa348290faca1623bd406a7:47a09d31b20940827b4c2d23e72b6ddfdc693ce7

**Packages**:
- samtools=1.24
- cutesv=2.1.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- cutesv.xml

Generated with Planemo.