### PR TITLE
Add container mulled-v2-92fff5081979b599505d907e33388db51d2ae39e:380ea91a3087b73c4ce4086365d2387f66b2bd75.

### DIFF
--- a/combinations/mulled-v2-92fff5081979b599505d907e33388db51d2ae39e:380ea91a3087b73c4ce4086365d2387f66b2bd75-0.tsv
+++ b/combinations/mulled-v2-92fff5081979b599505d907e33388db51d2ae39e:380ea91a3087b73c4ce4086365d2387f66b2bd75-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+bam-readcount=1.0.1,gawk=5.3.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-92fff5081979b599505d907e33388db51d2ae39e:380ea91a3087b73c4ce4086365d2387f66b2bd75

**Packages**:
- bam-readcount=1.0.1
- gawk=5.3.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- bam_readcount.xml

Generated with Planemo.