### PR TITLE
Add container mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:240eeda5e6b07cccac1ece6742ad78c752f58e95.

### DIFF
--- a/combinations/mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:240eeda5e6b07cccac1ece6742ad78c752f58e95-0.tsv
+++ b/combinations/mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:240eeda5e6b07cccac1ece6742ad78c752f58e95-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hisat2=2.2.3,seqtk=1.5,samtools=1.24	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b570fc8a7b25c6a733660cda7e105007b53ac501:240eeda5e6b07cccac1ece6742ad78c752f58e95

**Packages**:
- hisat2=2.2.3
- seqtk=1.5
- samtools=1.24
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hisat2.xml

Generated with Planemo.