### PR TITLE
Add container mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:db1ee9ea7888829155bbbc51b5d28b23f65abcac.

### DIFF
--- a/combinations/mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:db1ee9ea7888829155bbbc51b5d28b23f65abcac-0.tsv
+++ b/combinations/mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:db1ee9ea7888829155bbbc51b5d28b23f65abcac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.12,irma=1.3.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-23c318ae7fed5ca4cc4e59b7c0da2e2a5a34009f:db1ee9ea7888829155bbbc51b5d28b23f65abcac

**Packages**:
- python=3.12
- irma=1.3.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- irma.xml

Generated with Planemo.