### PR TITLE
Add container mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:13857222cc9f709e355c2459b402438af6ff1e7a.

### DIFF
--- a/combinations/mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:13857222cc9f709e355c2459b402438af6ff1e7a-0.tsv
+++ b/combinations/mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:13857222cc9f709e355c2459b402438af6ff1e7a-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.24,rasusa=5.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-63db865de20231a1a8041a0097020a7aa4d6fd4f:13857222cc9f709e355c2459b402438af6ff1e7a

**Packages**:
- samtools=1.24
- rasusa=5.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rasusa.xml

Generated with Planemo.