### PR TITLE
Add container mulled-v2-34dbc324dbdde0dd8755417ae4e459670886897e:8a5ef7f47770571b81de96f84c05a6be0ca7e5df.

### DIFF
--- a/combinations/mulled-v2-34dbc324dbdde0dd8755417ae4e459670886897e:8a5ef7f47770571b81de96f84c05a6be0ca7e5df-0.tsv
+++ b/combinations/mulled-v2-34dbc324dbdde0dd8755417ae4e459670886897e:8a5ef7f47770571b81de96f84c05a6be0ca7e5df-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+hap.py=0.3.15,rtg-tools=3.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-34dbc324dbdde0dd8755417ae4e459670886897e:8a5ef7f47770571b81de96f84c05a6be0ca7e5df

**Packages**:
- hap.py=0.3.15
- rtg-tools=3.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- hap.py.xml

Generated with Planemo.