### PR TITLE
Add container mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:219fe5f93c1077f1ee737e6b2f52e77ac0be83ab.

### DIFF
--- a/combinations/mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:219fe5f93c1077f1ee737e6b2f52e77ac0be83ab-0.tsv
+++ b/combinations/mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:219fe5f93c1077f1ee737e6b2f52e77ac0be83ab-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-dispersionindicators=0.1.6,r-ggplot2=3.5.2,r-optparse=1.7.5,r-base=4.5.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-92d47985975132a021120baf1ef5e46d5fa80e5a:219fe5f93c1077f1ee737e6b2f52e77ac0be83ab

**Packages**:
- r-dispersionindicators=0.1.6
- r-ggplot2=3.5.2
- r-optparse=1.7.5
- r-base=4.5.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- batch_dispersion.xml

Generated with Planemo.