### PR TITLE
Add container mulled-v2-581b430b914748efa65c6df67e41b582cd057ca9:b7dc21332bfe68466bce5e6b9f7ba40d52b8dab5.

### DIFF
--- a/combinations/mulled-v2-581b430b914748efa65c6df67e41b582cd057ca9:b7dc21332bfe68466bce5e6b9f7ba40d52b8dab5-0.tsv
+++ b/combinations/mulled-v2-581b430b914748efa65c6df67e41b582cd057ca9:b7dc21332bfe68466bce5e6b9f7ba40d52b8dab5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+enzywizard-pocket=1.0.2,pymol-open-source=3.1.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-581b430b914748efa65c6df67e41b582cd057ca9:b7dc21332bfe68466bce5e6b9f7ba40d52b8dab5

**Packages**:
- enzywizard-pocket=1.0.2
- pymol-open-source=3.1.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- enzywizard_pocket.xml

Generated with Planemo.