### PR TITLE
Add container mulled-v2-950195cc3effae50c06b3604fd22d9351d931201:60121815ba29977400b1abf9c07e87ee755bc71b.

### DIFF
--- a/combinations/mulled-v2-950195cc3effae50c06b3604fd22d9351d931201:60121815ba29977400b1abf9c07e87ee755bc71b-0.tsv
+++ b/combinations/mulled-v2-950195cc3effae50c06b3604fd22d9351d931201:60121815ba29977400b1abf9c07e87ee755bc71b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+meeko=0.7.1,msms=2.6.1,vina=1.2.6,numpy=1.23.5,bio-pyvol=1.7.8,biopython=1.86,enzywizard-dock=1.0.2,rdkit=2026.3.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-950195cc3effae50c06b3604fd22d9351d931201:60121815ba29977400b1abf9c07e87ee755bc71b

**Packages**:
- meeko=0.7.1
- msms=2.6.1
- vina=1.2.6
- numpy=1.23.5
- bio-pyvol=1.7.8
- biopython=1.86
- enzywizard-dock=1.0.2
- rdkit=2026.3.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- enzywizard_dock.xml

Generated with Planemo.