### PR TITLE
Add container mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:9f0173628238dff0ca4a90c273e6453f05fa5888.

### DIFF
--- a/combinations/mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:9f0173628238dff0ca4a90c273e6453f05fa5888-0.tsv
+++ b/combinations/mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:9f0173628238dff0ca4a90c273e6453f05fa5888-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+rename=1.601,pretextsnapshot=0.0.9	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-9de4c297ab5f5a3e1b9db9e0b70a6e383f51acf0:9f0173628238dff0ca4a90c273e6453f05fa5888

**Packages**:
- rename=1.601
- pretextsnapshot=0.0.9
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pretext_snapshot.xml

Generated with Planemo.