### PR TITLE
Add container mulled-v2-3b62966bb5abb1228683819650478f85a768a305:f6fc7840b507d9c503a0c2a11dc4299e2101cace.

### DIFF
--- a/combinations/mulled-v2-3b62966bb5abb1228683819650478f85a768a305:f6fc7840b507d9c503a0c2a11dc4299e2101cace-0.tsv
+++ b/combinations/mulled-v2-3b62966bb5abb1228683819650478f85a768a305:f6fc7840b507d9c503a0c2a11dc4299e2101cace-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+sed=4.9,coreutils=9.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-3b62966bb5abb1228683819650478f85a768a305:f6fc7840b507d9c503a0c2a11dc4299e2101cace

**Packages**:
- sed=4.9
- coreutils=9.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- unsorted_uniq.xml
- sort.xml
- sorted_uniq.xml

Generated with Planemo.