### PR TITLE
Add container mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:0fe4bd8d5903f7e0f07375f7e7ee7eebc5946d05.

### DIFF
--- a/combinations/mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:0fe4bd8d5903f7e0f07375f7e7ee7eebc5946d05-0.tsv
+++ b/combinations/mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:0fe4bd8d5903f7e0f07375f7e7ee7eebc5946d05-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+perl=5.32,coreutils=9.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c5660771860859a51697ce13d5d74251dc4c8eb6:0fe4bd8d5903f7e0f07375f7e7ee7eebc5946d05

**Packages**:
- perl=5.32
- coreutils=9.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- easyjoin.xml

Generated with Planemo.