### PR TITLE
Add container mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:dd635895dac38142e8046e7e612ab3df9ddbfff0.

### DIFF
--- a/combinations/mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:dd635895dac38142e8046e7e612ab3df9ddbfff0-0.tsv
+++ b/combinations/mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:dd635895dac38142e8046e7e612ab3df9ddbfff0-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.4.1,vardict-java=1.8.4,samtools=1.24,python=3.10.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-c145d1fa9aee2dbbbd6e1840c07ac5de6dcbf946:dd635895dac38142e8046e7e612ab3df9ddbfff0

**Packages**:
- gawk=5.4.1
- vardict-java=1.8.4
- samtools=1.24
- python=3.10.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- vardict.xml

Generated with Planemo.