### PR TITLE
Add container pycytominer:1.6.1.

### DIFF
--- a/combinations/pycytominer:1.6.1-0.tsv
+++ b/combinations/pycytominer:1.6.1-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pycytominer=1.6.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: pycytominer:1.6.1

**Packages**:
- pycytominer=1.6.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pycytominer_aggregate.xml
- pycytominer_normalize.xml
- pycytominer_consensus.xml
- pycytominer_feature.xml
- pycytominer_annotate.xml

Generated with Planemo.