### PR TITLE
Add container mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:042473ad6c5ea254d978bb5f7f12f3a9e4b238ef.

### DIFF
--- a/combinations/mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:042473ad6c5ea254d978bb5f7f12f3a9e4b238ef-0.tsv
+++ b/combinations/mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:042473ad6c5ea254d978bb5f7f12f3a9e4b238ef-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+zenodo_get=1.6.1,deacon=0.17.0,curl=8.21.0,wget=1.25.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-420ebfeee4756ebac3587fd5892d8680469047a7:042473ad6c5ea254d978bb5f7f12f3a9e4b238ef

**Packages**:
- zenodo_get=1.6.1
- deacon=0.17.0
- curl=8.21.0
- wget=1.25.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- deacon_datamanager.xml

Generated with Planemo.