### PR TITLE
Add container mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:7ed8ab5f35de7619ed167bd58e1404e24277f69d.

### DIFF
--- a/combinations/mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:7ed8ab5f35de7619ed167bd58e1404e24277f69d-0.tsv
+++ b/combinations/mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:7ed8ab5f35de7619ed167bd58e1404e24277f69d-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+gawk=5.4.1,coreutils=9.11	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-52f5bd98cdc03cd276481898c88aba56f11228d3:7ed8ab5f35de7619ed167bd58e1404e24277f69d

**Packages**:
- gawk=5.4.1
- coreutils=9.11
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- compare.xml

Generated with Planemo.