### PR TITLE
Add container mulled-v2-86745e09b984841039837b65eebdd7ff619e328b:1ca2308d8f063017daf429cc8a8a6f9b71324092.

### DIFF
--- a/combinations/mulled-v2-86745e09b984841039837b65eebdd7ff619e328b:1ca2308d8f063017daf429cc8a8a6f9b71324092-0.tsv
+++ b/combinations/mulled-v2-86745e09b984841039837b65eebdd7ff619e328b:1ca2308d8f063017daf429cc8a8a6f9b71324092-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+zip=3.0,unzip=6.0,rust-proseg=3.1.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-86745e09b984841039837b65eebdd7ff619e328b:1ca2308d8f063017daf429cc8a8a6f9b71324092

**Packages**:
- zip=3.0
- unzip=6.0
- rust-proseg=3.1.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- proseg.xml

Generated with Planemo.