### PR TITLE
Add container mulled-v2-28c6b7891d61a72d7469520d11f9d0d4002fa004:f79efd1e94876d39bf23713e85b6e1a356baeddd.

### DIFF
--- a/combinations/mulled-v2-28c6b7891d61a72d7469520d11f9d0d4002fa004:f79efd1e94876d39bf23713e85b6e1a356baeddd-0.tsv
+++ b/combinations/mulled-v2-28c6b7891d61a72d7469520d11f9d0d4002fa004:f79efd1e94876d39bf23713e85b6e1a356baeddd-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+comebin=1.1.0,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-28c6b7891d61a72d7469520d11f9d0d4002fa004:f79efd1e94876d39bf23713e85b6e1a356baeddd

**Packages**:
- comebin=1.1.0
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- comebin.xml

Generated with Planemo.