### PR TITLE
Add container mulled-v2-d453af009d630c8ce42dd1f83b519f6ed061f0f5:205b0717a82bdfb8c48da56f9970a62d49d862e4.

### DIFF
--- a/combinations/mulled-v2-d453af009d630c8ce42dd1f83b519f6ed061f0f5:205b0717a82bdfb8c48da56f9970a62d49d862e4-0.tsv
+++ b/combinations/mulled-v2-d453af009d630c8ce42dd1f83b519f6ed061f0f5:205b0717a82bdfb8c48da56f9970a62d49d862e4-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+anndata=0.10.8,rectanglepy=1.5.0,spatialdata=0.4.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d453af009d630c8ce42dd1f83b519f6ed061f0f5:205b0717a82bdfb8c48da56f9970a62d49d862e4

**Packages**:
- anndata=0.10.8
- rectanglepy=1.5.0
- spatialdata=0.4.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- rectanglepy.xml

Generated with Planemo.