### PR TITLE
Add container mulled-v2-6e063e31d59a3a31ca959b19143fa481442787d5:1ab0df87e7ea3070fd6362dca6d6f47f5b2d433e.

### DIFF
--- a/combinations/mulled-v2-6e063e31d59a3a31ca959b19143fa481442787d5:1ab0df87e7ea3070fd6362dca6d6f47f5b2d433e-0.tsv
+++ b/combinations/mulled-v2-6e063e31d59a3a31ca959b19143fa481442787d5:1ab0df87e7ea3070fd6362dca6d6f47f5b2d433e-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+geopandas=0.4.1,rasterstats=0.13.1,xarray=0.11.3,netcdf4=1.5.1.2	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-6e063e31d59a3a31ca959b19143fa481442787d5:1ab0df87e7ea3070fd6362dca6d6f47f5b2d433e

**Packages**:
- geopandas=0.4.1
- rasterstats=0.13.1
- xarray=0.11.3
- netcdf4=1.5.1.2
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mean-per-zone.xml

Generated with Planemo.