### PR TITLE
Add container mulled-v2-2fd06f95887857f51a6f2118ebc10728457fb6b1:c84deaacd7cc1e922358de26daf3dd2f4e2ead9f.

### DIFF
--- a/combinations/mulled-v2-2fd06f95887857f51a6f2118ebc10728457fb6b1:c84deaacd7cc1e922358de26daf3dd2f4e2ead9f-0.tsv
+++ b/combinations/mulled-v2-2fd06f95887857f51a6f2118ebc10728457fb6b1:c84deaacd7cc1e922358de26daf3dd2f4e2ead9f-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+requests=2.33.1,shapely=2.1.2,pandas=3.0.2,xarray=2026.4.0,openpyxl=3.1.5,geopandas=1.1.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2fd06f95887857f51a6f2118ebc10728457fb6b1:c84deaacd7cc1e922358de26daf3dd2f4e2ead9f

**Packages**:
- requests=2.33.1
- shapely=2.1.2
- pandas=3.0.2
- xarray=2026.4.0
- openpyxl=3.1.5
- geopandas=1.1.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- get_safran_data_geosas_api_MG.xml

Generated with Planemo.