### PR TITLE
Add container mulled-v2-79b96e6c713b573ed228246bb3c27dab8270aaa0:fdeee4e1884d4ed39e49d3b4742bf3015c8f65f6.

### DIFF
--- a/combinations/mulled-v2-79b96e6c713b573ed228246bb3c27dab8270aaa0:fdeee4e1884d4ed39e49d3b4742bf3015c8f65f6-0.tsv
+++ b/combinations/mulled-v2-79b96e6c713b573ed228246bb3c27dab8270aaa0:fdeee4e1884d4ed39e49d3b4742bf3015c8f65f6-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pixy=2.2.3,htslib=1.21,numpy=1.26	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-79b96e6c713b573ed228246bb3c27dab8270aaa0:fdeee4e1884d4ed39e49d3b4742bf3015c8f65f6

**Packages**:
- pixy=2.2.3
- htslib=1.21
- numpy=1.26
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- pixy.xml

Generated with Planemo.