### PR TITLE
Add container mulled-v2-842faba7afc332e008f7d8b210ce965379274249:371090825f1a2952ebfb0c8b2ea8dd7a86651fbe.

### DIFF
--- a/combinations/mulled-v2-842faba7afc332e008f7d8b210ce965379274249:371090825f1a2952ebfb0c8b2ea8dd7a86651fbe-0.tsv
+++ b/combinations/mulled-v2-842faba7afc332e008f7d8b210ce965379274249:371090825f1a2952ebfb0c8b2ea8dd7a86651fbe-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+samtools=1.24,minibwa=0.7	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-842faba7afc332e008f7d8b210ce965379274249:371090825f1a2952ebfb0c8b2ea8dd7a86651fbe

**Packages**:
- samtools=1.24
- minibwa=0.7
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- minibwa.xml

Generated with Planemo.