### PR TITLE
Add container mulled-v2-d4e417f2056ce7a93b7a212fd9fc073add2e69aa:0327cda6663acc53533ac70d1b8864cebc08e7ac.

### DIFF
--- a/combinations/mulled-v2-d4e417f2056ce7a93b7a212fd9fc073add2e69aa:0327cda6663acc53533ac70d1b8864cebc08e7ac-0.tsv
+++ b/combinations/mulled-v2-d4e417f2056ce7a93b7a212fd9fc073add2e69aa:0327cda6663acc53533ac70d1b8864cebc08e7ac-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pandas=2.3.3,anndata=0.12.10,loompy=3.0.8,scanpy=1.12.4	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-d4e417f2056ce7a93b7a212fd9fc073add2e69aa:0327cda6663acc53533ac70d1b8864cebc08e7ac

**Packages**:
- pandas=2.3.3
- anndata=0.12.10
- loompy=3.0.8
- scanpy=1.12.4
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- import.xml
- export.xml
- inspect.xml
- modify_loom.xml
- manipulate.xml

Generated with Planemo.