### PR TITLE
Add container mulled-v2-a591abb8ff08e0a823fcd5fc89b8db18ecd0f91d:4dbe5c9ba8cbfab88b5a02f4bc2c8c136a5e48b8.

### DIFF
--- a/combinations/mulled-v2-a591abb8ff08e0a823fcd5fc89b8db18ecd0f91d:4dbe5c9ba8cbfab88b5a02f4bc2c8c136a5e48b8-0.tsv
+++ b/combinations/mulled-v2-a591abb8ff08e0a823fcd5fc89b8db18ecd0f91d:4dbe5c9ba8cbfab88b5a02f4bc2c8c136a5e48b8-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+pyyaml=6.0.3,datavzrd=2.72.0,zip=3.0,python=3.13	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-a591abb8ff08e0a823fcd5fc89b8db18ecd0f91d:4dbe5c9ba8cbfab88b5a02f4bc2c8c136a5e48b8

**Packages**:
- pyyaml=6.0.3
- datavzrd=2.72.0
- zip=3.0
- python=3.13
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- datavzrd_render.xml

Generated with Planemo.