### PR TITLE
Add container mulled-v2-8a0a35feb40b93ca6f728c48b6d317f4a9daeee3:05d6fc4c52e63a49b8de245223454fdc604dabb5.

### DIFF
--- a/combinations/mulled-v2-8a0a35feb40b93ca6f728c48b6d317f4a9daeee3:05d6fc4c52e63a49b8de245223454fdc604dabb5-0.tsv
+++ b/combinations/mulled-v2-8a0a35feb40b93ca6f728c48b6d317f4a9daeee3:05d6fc4c52e63a49b8de245223454fdc604dabb5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scanpy=1.12.4,anndata=0.13.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-8a0a35feb40b93ca6f728c48b6d317f4a9daeee3:05d6fc4c52e63a49b8de245223454fdc604dabb5

**Packages**:
- scanpy=1.12.4
- anndata=0.13.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- anndata_inspect.xml
- anndata_export.xml
- anndata_manipulate.xml

Generated with Planemo.