### PR TITLE
Add container mulled-v2-1e98e23989d3208b8a8e2a62e9664da1121b2353:9fe9dc6328adc36ed9e3a0e58b5f8f6a1ca5aa52.

### DIFF
--- a/combinations/mulled-v2-1e98e23989d3208b8a8e2a62e9664da1121b2353:9fe9dc6328adc36ed9e3a0e58b5f8f6a1ca5aa52-0.tsv
+++ b/combinations/mulled-v2-1e98e23989d3208b8a8e2a62e9664da1121b2353:9fe9dc6328adc36ed9e3a0e58b5f8f6a1ca5aa52-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+tnt=1.5,goalign=0.3.9,gotree=0.5.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-1e98e23989d3208b8a8e2a62e9664da1121b2353:9fe9dc6328adc36ed9e3a0e58b5f8f6a1ca5aa52

**Packages**:
- tnt=1.5
- goalign=0.3.9
- gotree=0.5.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- tnt.xml

Generated with Planemo.