### PR TITLE
Add container mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:c05d428486946ba4884a7d5e3ba69cc2ae2c6883.

### DIFF
--- a/combinations/mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:c05d428486946ba4884a7d5e3ba69cc2ae2c6883-0.tsv
+++ b/combinations/mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:c05d428486946ba4884a7d5e3ba69cc2ae2c6883-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+scanpy=1.12.4,anndata=0.12.10,loompy=3.0.8	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-b3544c97ae88d85d8b9acc7193ca8242afb1d703:c05d428486946ba4884a7d5e3ba69cc2ae2c6883

**Packages**:
- scanpy=1.12.4
- anndata=0.12.10
- loompy=3.0.8
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- modify_loom.xml

Generated with Planemo.