### PR TITLE
Add container mulled-v2-fe1d8a960beffef079d78f52188e3f8a36380301:b100ed3650a732b03c3410820aa6ebeba7aca287.

### DIFF
--- a/combinations/mulled-v2-fe1d8a960beffef079d78f52188e3f8a36380301:b100ed3650a732b03c3410820aa6ebeba7aca287-0.tsv
+++ b/combinations/mulled-v2-fe1d8a960beffef079d78f52188e3f8a36380301:b100ed3650a732b03c3410820aa6ebeba7aca287-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+apptainer=1.4.1,openjdk=23.0.2,nextflow=26.04.2,samtools=1.21	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-fe1d8a960beffef079d78f52188e3f8a36380301:b100ed3650a732b03c3410820aa6ebeba7aca287

**Packages**:
- apptainer=1.4.1
- openjdk=23.0.2
- nextflow=26.04.2
- samtools=1.21
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- drmab.xml

Generated with Planemo.