### PR TITLE
Add container mulled-v2-79d8d868ff472ddb3533e1bec1c689acdc186ed8:cd00e08cfca257acb77783162bb0275968b07f4b.

### DIFF
--- a/combinations/mulled-v2-79d8d868ff472ddb3533e1bec1c689acdc186ed8:cd00e08cfca257acb77783162bb0275968b07f4b-0.tsv
+++ b/combinations/mulled-v2-79d8d868ff472ddb3533e1bec1c689acdc186ed8:cd00e08cfca257acb77783162bb0275968b07f4b-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+spacy=3.8.14,nltk=3.10.1,nltk_data=2026.07.01,spacy-model-en_core_web_sm=3.8.0,langchain-text-splitters=1.1.2,python-gil=3.12.13,tiktoken=0.13.0	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-79d8d868ff472ddb3533e1bec1c689acdc186ed8:cd00e08cfca257acb77783162bb0275968b07f4b

**Packages**:
- spacy=3.8.14
- nltk=3.10.1
- nltk_data=2026.07.01
- spacy-model-en_core_web_sm=3.8.0
- langchain-text-splitters=1.1.2
- python-gil=3.12.13
- tiktoken=0.13.0
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- langchain_text_splitters.xml

Generated with Planemo.