### PR TITLE
Add container mulled-v2-bd0df3f45ec26c5308137db81ebddedeab0fbfe0:51212f67f87afc8fe34e715356e5f226607b3550.

### DIFF
--- a/combinations/mulled-v2-bd0df3f45ec26c5308137db81ebddedeab0fbfe0:51212f67f87afc8fe34e715356e5f226607b3550-0.tsv
+++ b/combinations/mulled-v2-bd0df3f45ec26c5308137db81ebddedeab0fbfe0:51212f67f87afc8fe34e715356e5f226607b3550-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-base=3.5.1,r-mgcv=1.8_28	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-bd0df3f45ec26c5308137db81ebddedeab0fbfe0:51212f67f87afc8fe34e715356e5f226607b3550

**Packages**:
- r-base=3.5.1
- r-mgcv=1.8_28
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- flight-curve.xml

Generated with Planemo.