### PR TITLE
Add container mulled-v2-081fcd4146daece4ae34b858e0abfad5de1b05e2:d157652f4f2ded63f9bffd42a593a2cf5d1b24dc.

### DIFF
--- a/combinations/mulled-v2-081fcd4146daece4ae34b858e0abfad5de1b05e2:d157652f4f2ded63f9bffd42a593a2cf5d1b24dc-0.tsv
+++ b/combinations/mulled-v2-081fcd4146daece4ae34b858e0abfad5de1b05e2:d157652f4f2ded63f9bffd42a593a2cf5d1b24dc-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+r-data.table=1.12.0,r-base=3.5.1,r-speedglm=0.3_2,r-arm=1.10_1,r-ggplot2=3.0.0,r-reshape2=1.4.3	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-081fcd4146daece4ae34b858e0abfad5de1b05e2:d157652f4f2ded63f9bffd42a593a2cf5d1b24dc

**Packages**:
- r-data.table=1.12.0
- r-base=3.5.1
- r-speedglm=0.3_2
- r-arm=1.10_1
- r-ggplot2=3.0.0
- r-reshape2=1.4.3
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- mainglm.xml
- mainglm_group.xml

Generated with Planemo.