### PR TITLE
Add container mulled-v2-2ebdbcfca1905073f23bd8a2b4f883aee054056f:4570b38c15e976cfa37ea638deadee8d63e675c5.

### DIFF
--- a/combinations/mulled-v2-2ebdbcfca1905073f23bd8a2b4f883aee054056f:4570b38c15e976cfa37ea638deadee8d63e675c5-0.tsv
+++ b/combinations/mulled-v2-2ebdbcfca1905073f23bd8a2b4f883aee054056f:4570b38c15e976cfa37ea638deadee8d63e675c5-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+python=3.11,pandas=2.3.3,matplotlib-base=3.10.5,coreutils=9.5	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-2ebdbcfca1905073f23bd8a2b4f883aee054056f:4570b38c15e976cfa37ea638deadee8d63e675c5

**Packages**:
- python=3.11
- pandas=2.3.3
- matplotlib-base=3.10.5
- coreutils=9.5
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- recap_prok_module3_interpretation.xml

Generated with Planemo.