### PR TITLE
Add container mulled-v2-793d6c481b6d9374e2d9a7d337eefae1a667456d:b097f9918e1e51ba12e9cad40a507a77b878b399.

### DIFF
--- a/combinations/mulled-v2-793d6c481b6d9374e2d9a7d337eefae1a667456d:b097f9918e1e51ba12e9cad40a507a77b878b399-0.tsv
+++ b/combinations/mulled-v2-793d6c481b6d9374e2d9a7d337eefae1a667456d:b097f9918e1e51ba12e9cad40a507a77b878b399-0.tsv
@@ -1,0 +1,2 @@
+#targets	base_image	image_build
+coreutils=9.5,gawk=5.3.0,bedtools=2.31.1	quay.io/bioconda/base-glibc-busybox-bash:latest	0


### PR DESCRIPTION
**Hash**: mulled-v2-793d6c481b6d9374e2d9a7d337eefae1a667456d:b097f9918e1e51ba12e9cad40a507a77b878b399

**Packages**:
- coreutils=9.5
- gawk=5.3.0
- bedtools=2.31.1
Base Image:quay.io/bioconda/base-glibc-busybox-bash:latest

**For** :
- recap_prok_module3.xml

Generated with Planemo.